### PR TITLE
Add event approval flow admin filters

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from .models import OrganizationType, Organization
+from django.contrib.auth.models import User
+from .models import OrganizationType, Organization, ApprovalFlowTemplate
 
 
 class OrganizationModelTests(TestCase):
@@ -10,3 +11,18 @@ class OrganizationModelTests(TestCase):
 
         self.assertEqual(Organization.objects.count(), 1)
         self.assertEqual(org.org_type.name, "Department")
+
+
+class ApprovalFlowViewTests(TestCase):
+    def test_delete_approval_flow(self):
+        ot = OrganizationType.objects.create(name="Dept")
+        org = Organization.objects.create(name="Math", org_type=ot)
+        step = ApprovalFlowTemplate.objects.create(
+            organization=org, step_order=1, role_required="faculty"
+        )
+
+        admin = User.objects.create_superuser("admin", "a@x.com", "pass")
+        self.client.force_login(admin)
+        resp = self.client.post(f"/core-admin/approval-flow/{org.id}/delete/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(ApprovalFlowTemplate.objects.count(), 0)

--- a/core/urls.py
+++ b/core/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     # Event Approval Workflow
     path('core-admin/approval-flow/<int:org_id>/get/', views.get_approval_flow, name='get_approval_flow'),
     path('core-admin/approval-flow/<int:org_id>/save/', views.save_approval_flow, name='save_approval_flow'),
+    path('core-admin/approval-flow/<int:org_id>/delete/', views.delete_approval_flow, name='delete_approval_flow'),
     path('api/approval-flow/<int:org_id>/', views.api_approval_flow_steps, name='api_approval_flow_steps'),
     path('core-admin/api/search-users/', views.search_users, name='search_users'),
 

--- a/static/core/js/admin_approval_flow.js
+++ b/static/core/js/admin_approval_flow.js
@@ -466,7 +466,7 @@ window.removeStep = function(idx) {
   approvalSteps.splice(idx, 1);
   renderApprovalSteps();
 };
-window.saveApprovalFlow = function() {
+  window.saveApprovalFlow = function() {
   const orgId = document.getElementById('approvalFlowOrgSelect').value;
 
   // Map your frontend data to the backend format!
@@ -475,7 +475,7 @@ window.saveApprovalFlow = function() {
     user_id: s.user ? s.user.id : null
   }));
 
-  fetch(`/core-admin/approval-flow/${orgId}/save/`, {
+    fetch(`/core-admin/approval-flow/${orgId}/save/`, {
     method: "POST",
     headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF_TOKEN },
     body: JSON.stringify({ steps: payloadSteps })
@@ -491,6 +491,39 @@ window.saveApprovalFlow = function() {
     }
   }).catch(e => {
     alert("Error: " + e);
+  });
+};
+
+window.deleteApprovalFlow = function() {
+  const orgId = document.getElementById('approvalFlowOrgSelect').value;
+  if (!orgId) return;
+  if (!confirm('Delete entire approval flow for this organization?')) return;
+  fetch(`/core-admin/approval-flow/${orgId}/delete/`, {
+    method: 'POST',
+    headers: { 'X-CSRFToken': CSRF_TOKEN }
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.success) {
+      approvalSteps = [];
+      renderApprovalSteps();
+      showToast('Approval flow deleted', 'success');
+    } else {
+      showToast('Failed to delete flow', 'error');
+    }
+  })
+  .catch(() => showToast('Error deleting flow', 'error'));
+};
+
+window.filterOrgOptions = function() {
+  const type = document.getElementById('orgTypeFilter').value;
+  const search = document.getElementById('orgSearchInput').value.toLowerCase();
+  const select = document.getElementById('approvalFlowOrgSelect');
+  Array.from(select.options).forEach(opt => {
+    if (!opt.value) return;
+    const matchesType = !type || opt.dataset.orgType === type;
+    const matchesSearch = !search || opt.textContent.toLowerCase().includes(search);
+    opt.style.display = matchesType && matchesSearch ? '' : 'none';
   });
 };
 

--- a/templates/core/admin_approval_flow.html
+++ b/templates/core/admin_approval_flow.html
@@ -44,13 +44,22 @@
       <button class="modal-close" onclick="closeModal('approvalFlowEditorModal')">&times;</button>
     </div>
     <div class="modal-body">
-      <!-- Organization select -->
       <div class="form-group">
-        <label for="approvalFlowOrgSelect">Organization</label>
-        <select id="approvalFlowOrgSelect" class="form-select" onchange="loadApprovalFlow()">
+        <label for="orgTypeFilter">Category</label>
+        <select id="orgTypeFilter" class="form-select" onchange="filterOrgOptions()">
+          <option value="">All Categories</option>
+          {% for ot in org_types %}
+          <option value="{{ ot.id }}">{{ ot.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="orgSearchInput">Organization</label>
+        <input type="text" id="orgSearchInput" class="form-control" placeholder="Search..." oninput="filterOrgOptions()">
+        <select id="approvalFlowOrgSelect" class="form-select" onchange="loadApprovalFlow()" size="8" style="margin-top:0.5rem;">
           <option value="">– Select organization –</option>
           {% for org in organizations %}
-            <option value="{{ org.id }}">{{ org.name }} ({{ org.org_type.name }})</option>
+            <option value="{{ org.id }}" data-org-type="{{ org.org_type.id }}">{{ org.name }} ({{ org.org_type.name }})</option>
           {% endfor %}
         </select>
       </div>
@@ -64,6 +73,7 @@
       <p class="form-tip">Tip: Use roles like <code>faculty</code>, <code>dept_iqac</code>, <code>hod</code>, etc.</p>
     </div>
     <div class="modal-footer">
+      <button class="btn btn-danger" onclick="deleteApprovalFlow()">Delete Flow</button>
       <button class="btn btn-secondary" onclick="closeModal('approvalFlowEditorModal')">Cancel</button>
       <button class="btn btn-primary" onclick="saveApprovalFlow()">Save</button>
     </div>


### PR DESCRIPTION
## Summary
- pass organization types to approval flow template
- allow deleting approval flows
- filter organizations by category and name
- update JS with delete and filter helpers
- test approval flow deletion

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68824c0e9eb4832ca13c1c83d5662787