### PR TITLE
Add event approval flow admin filters

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from .models import OrganizationType, Organization
+from django.contrib.auth.models import User
+from .models import OrganizationType, Organization, ApprovalFlowTemplate
 
 
 class OrganizationModelTests(TestCase):
@@ -10,3 +11,18 @@ class OrganizationModelTests(TestCase):
 
         self.assertEqual(Organization.objects.count(), 1)
         self.assertEqual(org.org_type.name, "Department")
+
+
+class ApprovalFlowViewTests(TestCase):
+    def test_delete_approval_flow(self):
+        ot = OrganizationType.objects.create(name="Dept")
+        org = Organization.objects.create(name="Math", org_type=ot)
+        step = ApprovalFlowTemplate.objects.create(
+            organization=org, step_order=1, role_required="faculty"
+        )
+
+        admin = User.objects.create_superuser("admin", "a@x.com", "pass")
+        self.client.force_login(admin)
+        resp = self.client.post(f"/core-admin/approval-flow/{org.id}/delete/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(ApprovalFlowTemplate.objects.count(), 0)

--- a/core/urls.py
+++ b/core/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     # Event Approval Workflow
     path('core-admin/approval-flow/<int:org_id>/get/', views.get_approval_flow, name='get_approval_flow'),
     path('core-admin/approval-flow/<int:org_id>/save/', views.save_approval_flow, name='save_approval_flow'),
+    path('core-admin/approval-flow/<int:org_id>/delete/', views.delete_approval_flow, name='delete_approval_flow'),
     path('api/approval-flow/<int:org_id>/', views.api_approval_flow_steps, name='api_approval_flow_steps'),
     path('core-admin/api/search-users/', views.search_users, name='search_users'),
 

--- a/static/core/css/admin_approval_flow.css
+++ b/static/core/css/admin_approval_flow.css
@@ -261,23 +261,43 @@ body {
     font-size: 1.75rem;
   }
 }
-.approval-flow-steps-list {
-  margin: 1rem 0 0 0; padding: 0;
+.steps-container {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
-.approval-flow-steps-list li {
+
+.step-block {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: .5rem;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: #f9fafb;
+  border: 1px solid #d1d5db;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
 }
-.approval-step-badge {
+
+.step-block.dragging {
+  opacity: 0.6;
+}
+
+.drag-handle {
+  cursor: move;
+  color: #64748b;
+}
+
+.step-number {
   font-weight: bold;
   background: #3b82f6;
   color: #fff;
   padding: 0.25rem 0.75rem;
   border-radius: 8px;
 }
-.approval-role-input {
+
+.role-input {
   border: none;
   background: #f3f4f6;
   font-size: 1rem;
@@ -285,10 +305,44 @@ body {
   border-radius: 6px;
   width: 180px;
 }
-.approval-user-hint {
-  color: #64748b;
-  font-size: 0.9em;
+
+.user-search-input {
+  position: relative;
+  border: none;
+  background: #f3f4f6;
+  font-size: 1rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  width: 200px;
 }
+
+.user-search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  max-height: 150px;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.user-search-option {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.user-search-option:hover {
+  background: #e5e7eb;
+}
+
+.user-search-option.disabled {
+  color: #9ca3af;
+  cursor: default;
+}
+
 .empty-msg, .error-msg {
   padding: 1rem 0;
   color: #aaa;

--- a/templates/core/admin_approval_flow.html
+++ b/templates/core/admin_approval_flow.html
@@ -44,13 +44,22 @@
       <button class="modal-close" onclick="closeModal('approvalFlowEditorModal')">&times;</button>
     </div>
     <div class="modal-body">
-      <!-- Organization select -->
       <div class="form-group">
-        <label for="approvalFlowOrgSelect">Organization</label>
-        <select id="approvalFlowOrgSelect" class="form-select" onchange="loadApprovalFlow()">
+        <label for="orgTypeFilter">Category</label>
+        <select id="orgTypeFilter" class="form-select" onchange="filterOrgOptions()">
+          <option value="">All Categories</option>
+          {% for ot in org_types %}
+          <option value="{{ ot.id }}">{{ ot.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="orgSearchInput">Organization</label>
+        <input type="text" id="orgSearchInput" class="form-control" placeholder="Search..." oninput="filterOrgOptions()">
+        <select id="approvalFlowOrgSelect" class="form-select" onchange="loadApprovalFlow()" size="8" style="margin-top:0.5rem;">
           <option value="">– Select organization –</option>
           {% for org in organizations %}
-            <option value="{{ org.id }}">{{ org.name }} ({{ org.org_type.name }})</option>
+            <option value="{{ org.id }}" data-org-type="{{ org.org_type.id }}">{{ org.name }} ({{ org.org_type.name }})</option>
           {% endfor %}
         </select>
       </div>
@@ -64,6 +73,7 @@
       <p class="form-tip">Tip: Use roles like <code>faculty</code>, <code>dept_iqac</code>, <code>hod</code>, etc.</p>
     </div>
     <div class="modal-footer">
+      <button class="btn btn-danger" onclick="deleteApprovalFlow()">Delete Flow</button>
       <button class="btn btn-secondary" onclick="closeModal('approvalFlowEditorModal')">Cancel</button>
       <button class="btn btn-primary" onclick="saveApprovalFlow()">Save</button>
     </div>


### PR DESCRIPTION
## Summary
- pass organization types to approval flow template
- allow deleting approval flows
- filter organizations by category and name
- update JS with delete and filter helpers
- test approval flow deletion
- improve approval flow editor UI with draggable blocks

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68824c0e9eb4832ca13c1c83d5662787