### PR TITLE
Fix admin role management view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -152,7 +152,24 @@ def admin_role_management(request):
         .order_by("name")
         .prefetch_related("organizations__roles")
     )
-    return render(request, "core/admin_role_management.html", {"org_types": org_types})
+
+    organizations = (
+        Organization.objects.filter(is_active=True)
+        .select_related("org_type")
+        .order_by("org_type__name", "name")
+    )
+
+    roles = (
+        OrganizationRole.objects.select_related("organization__org_type")
+        .order_by("organization__org_type__name", "organization__name", "name")
+    )
+
+    context = {
+        "org_types": org_types,
+        "organizations": organizations,
+        "roles": roles,
+    }
+    return render(request, "core/admin_role_management.html", context)
 
 
 
@@ -160,10 +177,19 @@ def admin_role_management(request):
 @require_POST
 def add_org_role(request):
     org_id = request.POST.get("org_id")
+    org_type_id = request.POST.get("org_type_id")
     name = request.POST.get("name", "").strip()
-    if org_id and name:
+
+    if not name:
+        return redirect("admin_role_management")
+
+    if org_id:
         org = get_object_or_404(Organization, id=org_id)
         OrganizationRole.objects.get_or_create(organization=org, name=name)
+    elif org_type_id:
+        orgs = Organization.objects.filter(org_type_id=org_type_id, is_active=True)
+        for org in orgs:
+            OrganizationRole.objects.get_or_create(organization=org, name=name)
     return redirect("admin_role_management")
 
 

--- a/static/core/css/admin_role_management.css
+++ b/static/core/css/admin_role_management.css
@@ -112,7 +112,8 @@
 .dataTables_paginate a:hover {
   background: #2274cb;
   color: #fff;
-=======
+}
+
 :root {
   --rm-padding: 2rem;
 }

--- a/templates/core/admin_role_management.html
+++ b/templates/core/admin_role_management.html
@@ -3,6 +3,7 @@
 
 {% block head_extra %}
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.dataTables.min.css">
   <link rel="stylesheet" href="{% static 'core/css/admin_role_management.css' %}">
 {% endblock %}
 
@@ -14,7 +15,7 @@
   <form id="addRoleForm" class="add-role-global" method="post" action="{% url 'add_org_role' %}">
     {% csrf_token %}
     <div class="field-group">
-      <select id="orgTypeSelect" class="form-select" required>
+      <select id="orgTypeSelect" name="org_type_id" class="form-select" required>
         <option value="">Select Category</option>
         {% for t in org_types %}
         <option value="{{ t.id }}">{{ t.name }}</option>
@@ -22,12 +23,13 @@
       </select>
     </div>
     <div class="field-group">
-      <select name="org_id" id="orgSelect" class="form-select" required>
-        <option value="">Select Organization</option>
+      <select name="org_id" id="orgSelect" class="form-select">
+        <option value="">Select Organization (optional)</option>
         {% for org in organizations %}
         <option value="{{ org.id }}" data-org-type="{{ org.org_type.id }}">{{ org.name }} ({{ org.org_type.name }})</option>
         {% endfor %}
       </select>
+      <small class="form-text text-muted">Leave blank to add role to all organizations in the selected category.</small>
     </div>
     <div class="field-group">
       <input type="text" name="name" placeholder="Role name" required>
@@ -100,5 +102,11 @@
 {% block scripts %}
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
   <script src="{% static 'core/js/admin_role_management.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- pass roles & organizations to admin role management template
- allow assigning roles to entire organization categories
- show DataTables buttons and optional org field
- clean up role management CSS

## Testing
- `pytest -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6882fa2925f4832c850aef0a4b3ab0ed