### PR TITLE
Implement approval flow management pages

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -62,6 +62,7 @@ urlpatterns = [
 
     # Approval Flow Setup UI
     path('core-admin/approval-flow/', views.admin_approval_flow, name='admin_approval_flow'),
+    path('core-admin/approval-flow/<int:org_id>/', views.admin_approval_flow_manage, name='admin_approval_flow_manage'),
 
     # Academic Year Select/Add (AJAX)
     path('core-admin/set-academic-year/', views.set_academic_year, name='set_academic_year'),

--- a/static/core/js/admin_approval_flow.js
+++ b/static/core/js/admin_approval_flow.js
@@ -552,3 +552,14 @@ window.filterOrgOptions = function() {
   });
 };
 
+document.addEventListener('DOMContentLoaded', () => {
+  if (window.SELECTED_ORG_ID) {
+    openApprovalFlowEditor();
+    const select = document.getElementById('approvalFlowOrgSelect');
+    if (select) {
+      select.value = String(window.SELECTED_ORG_ID);
+      loadApprovalFlow();
+    }
+  }
+});
+

--- a/templates/core/admin_approval_flow_list.html
+++ b/templates/core/admin_approval_flow_list.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load dict_filters %}
+
+{% block title %}Approval Flow Management – CHRIST University{% endblock %}
+
+{% block head_extra %}
+  <link rel="stylesheet" href="{% static 'core/css/admin_master_data.css' %}">
+{% endblock %}
+
+{% block page_title %}Approval Flow Management{% endblock %}
+{% block current_page %}Approval Flow Management{% endblock %}
+
+{% block breadcrumb %}
+  <a href="{% url 'dashboard' %}">Home</a>
+  <i class="fa-solid fa-chevron-right"></i>
+  <a href="{% url 'core_admin_dashboard' %}">Admin Dashboard</a>
+  <i class="fa-solid fa-chevron-right"></i>
+  <span>Approval Flow Management</span>
+{% endblock %}
+
+{% block content %}
+<div class="main-container">
+  <div class="page-header">
+    <h1>Proposal Approval Flows</h1>
+    <p>Select an organization to view or edit its approval hierarchy.</p>
+  </div>
+
+  <div class="widget-grid">
+    {% for org_type in org_types %}
+      <div class="data-widget">
+        <div class="widget-header">
+          <div class="widget-title">{{ org_type.name }}{% if not org_type.name|lower == 'cell' %}s{% endif %}</div>
+        </div>
+        <div class="widget-content">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for org in orgs_by_type|get_item:org_type.name %}
+                <tr>
+                  <td>{{ org.name }}</td>
+                  <td class="actions">
+                    <a class="btn btn-primary btn-sm" href="{% url 'admin_approval_flow_manage' org.id %}">View</a>
+                  </td>
+                </tr>
+              {% empty %}
+                <tr><td colspan="2" class="text-center">No organizations.</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/templates/core/admin_approval_flow_manage.html
+++ b/templates/core/admin_approval_flow_manage.html
@@ -23,17 +23,13 @@
 
   <!-- Page Header -->
   <div class="page-header">
-    <h1><i class="fa-solid fa-route"></i> Admin Approval Flow Management</h1>
-    <p>Define and maintain the hierarchical approval chain for each organization.</p>
+    <h1>
+      <i class="fa-solid fa-route"></i> Approval Flow – {{ selected_org.name }}
+    </h1>
+    <p>Drag to reorder the steps or assign users.</p>
+    <p><a class="btn btn-secondary btn-sm" href="{% url 'admin_approval_flow' %}">Back to list</a></p>
   </div>
 
-  <!-- Manage Flow Button -->
-  <div class="manage-flow-action">
-    <button class="btn btn-primary" onclick="openApprovalFlowEditor()">
-      <i class="fa-solid fa-diagram-project"></i> Manage Approval Flow
-    </button>
-    <span class="hint">Pick an organization to configure its approval steps</span>
-  </div>
 </div>
 
 <!-- Approval Flow Editor Modal -->
@@ -88,5 +84,8 @@
 {% endblock %}
 
 {% block scripts %}
+  <script>
+    window.SELECTED_ORG_ID = {{ selected_org_id|default:'null' }};
+  </script>
   <script src="{% static 'core/js/admin_approval_flow.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add listing page for approval flows by organization
- allow editing approval flow per organization
- open approval flow editor automatically when managing a specific org

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6883190ccfc0832cb63b1fb098539ebf