### PR TITLE
Improve org role filtering and user role UI

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -196,11 +196,23 @@ def delete_org_role(request, role_id):
 
 @user_passes_test(lambda u: u.is_superuser)
 def view_org_roles(request):
+    """Display roles, optionally filtered by organization type."""
     roles = (
         OrganizationRole.objects.select_related("organization", "organization__org_type")
         .order_by("organization__org_type__name", "organization__name", "name")
     )
-    return render(request, "core/admin_view_roles.html", {"roles": roles})
+
+    org_type_id = request.GET.get("org_type_id")
+    org_type = None
+    if org_type_id:
+        org_type = get_object_or_404(OrganizationType, id=org_type_id)
+        roles = roles.filter(organization__org_type=org_type)
+
+    context = {
+        "roles": roles,
+        "org_type": org_type,
+    }
+    return render(request, "core/admin_view_roles.html", context)
 
 
 @user_passes_test(lambda u: u.is_superuser)
@@ -267,10 +279,21 @@ def admin_user_edit(request, user_id):
     else:
         formset = RoleFormSet(instance=user)
 
-    org_roles = {
-        org.id: [r.name for r in org.roles.all()]
-        for org in Organization.objects.filter(is_active=True)
-    }
+    orgs = (
+        Organization.objects.filter(is_active=True)
+        .select_related("org_type")
+        .prefetch_related("roles")
+    )
+
+    org_roles = {org.id: [r.name for r in org.roles.all()] for org in orgs}
+
+    orgs_by_type = {}
+    roles_by_type = {}
+    for org in orgs:
+        ot_id = org.org_type_id
+        orgs_by_type.setdefault(ot_id, []).append({"id": org.id, "name": org.name})
+        roles_by_type.setdefault(ot_id, set()).update(r.name for r in org.roles.all())
+    roles_by_type = {k: sorted(v) for k, v in roles_by_type.items()}
 
     return render(
         request,
@@ -282,6 +305,8 @@ def admin_user_edit(request, user_id):
             "organization_types": OrganizationType.objects.filter(),
             "org_roles_json": json.dumps(org_roles),
             "role_choices_json": json.dumps(RoleAssignment.ROLE_CHOICES),
+            "orgs_by_type_json": json.dumps(orgs_by_type),
+            "roles_by_type_json": json.dumps(roles_by_type),
         },
     )
 

--- a/static/core/js/admin_user_edit.js
+++ b/static/core/js/admin_user_edit.js
@@ -13,16 +13,35 @@ document.addEventListener('DOMContentLoaded', () => {
   const ORG_OPTIONAL_ROLES = ['dean','academic_coordinator','director','cdl','uni_iqac','admin'];
 
   function bindCard(card) {
+    const typeSel = card.querySelector('.org-type-select');
     const roleSel = card.querySelector("select[name$='-role']");
     const orgSel = card.querySelector("select[name$='-organization']");
-    const orgGroup = card.querySelectorAll('.field-group')[1];
+    const orgGroup = card.querySelectorAll('.field-group')[2];
     const delBox = card.querySelector("input[name$='-DELETE']");
     const remBtn = card.querySelector('.remove-role-btn');
 
-    function populateOptions() {
+    function populateOrganizations() {
+      const typeId = typeSel.value;
+      const orgs = ORGS_BY_TYPE[typeId] || [];
+      const current = orgSel.value;
+      orgSel.innerHTML = '<option value="">---------</option>' +
+        orgs.map(o => `<option value="${o.id}">${o.name}</option>`).join('');
+      if (current && orgSel.querySelector(`option[value="${current}"]`)) {
+        orgSel.value = current;
+      }
+    }
+
+    function populateRoleOptions() {
       const current = roleSel.value;
       const opts = [...BASE_ROLES];
-      const extras = ORG_ROLES[orgSel.value] || [];
+      let extras = [];
+      const typeId = typeSel.value;
+      const orgId = orgSel.value;
+      if (orgId && ORG_ROLES[orgId]) {
+        extras = ORG_ROLES[orgId];
+      } else if (typeId && ROLES_BY_TYPE[typeId]) {
+        extras = ROLES_BY_TYPE[typeId];
+      }
       extras.forEach(r => opts.push([r, r]));
       roleSel.innerHTML = opts.map(o => `<option value="${o[0]}">${o[1]}</option>`).join('');
       if (current) roleSel.value = current;
@@ -39,12 +58,21 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
-    orgSel.addEventListener('change', () => {
-      populateOptions();
+    typeSel.addEventListener('change', () => {
+      populateOrganizations();
+      populateRoleOptions();
       toggleOrg();
     });
+
+    orgSel.addEventListener('change', () => {
+      populateRoleOptions();
+      toggleOrg();
+    });
+
     roleSel.addEventListener('change', toggleOrg);
-    populateOptions();
+
+    populateOrganizations();
+    populateRoleOptions();
     toggleOrg();
 
     remBtn?.addEventListener('click', () => {

--- a/templates/core/admin_role_management.html
+++ b/templates/core/admin_role_management.html
@@ -34,7 +34,7 @@
             <input type="hidden" name="org_type_id" value="{{ type.id }}">
             <input type="text" name="name" placeholder="Role name" required class="form-control form-control-sm">
             <button type="submit" class="btn btn-primary btn-sm">Add</button>
-            <a href="{% url 'view_org_roles' %}" class="btn btn-secondary btn-sm ms-2">View Roles</a>
+            <a href="{% url 'view_org_roles' %}?org_type_id={{ type.id }}" class="btn btn-secondary btn-sm ms-2">View Roles</a>
           </form>
         </td>
       </tr>

--- a/templates/core/admin_user_edit.html
+++ b/templates/core/admin_user_edit.html
@@ -44,11 +44,20 @@
           {{ form.id }}{{ form.DELETE }}
 
           <div class="field-group">
-            {{ form.role }}
+            <select class="org-type-select">
+              <option value="">Select Category</option>
+              {% for ot in organization_types %}
+              <option value="{{ ot.id }}" {% if form.instance.organization and form.instance.organization.org_type.id == ot.id %}selected{% endif %}>{{ ot.name }}</option>
+              {% endfor %}
+            </select>
           </div>
 
           <div class="field-group">
             {{ form.organization }}
+          </div>
+
+          <div class="field-group">
+            {{ form.role }}
           </div>
 
           <button type="button" class="remove-role-btn">×</button>
@@ -74,11 +83,20 @@
     {{ formset.empty_form.id }}{{ formset.empty_form.DELETE }}
 
     <div class="field-group">
-      {{ formset.empty_form.role }}
+      <select class="org-type-select">
+        <option value="">Select Category</option>
+        {% for ot in organization_types %}
+        <option value="{{ ot.id }}">{{ ot.name }}</option>
+        {% endfor %}
+      </select>
     </div>
 
     <div class="field-group">
       {{ formset.empty_form.organization }}
+    </div>
+
+    <div class="field-group">
+      {{ formset.empty_form.role }}
     </div>
 
     <button type="button" class="remove-role-btn">×</button>
@@ -87,6 +105,8 @@
 <script>
   const ORG_ROLES = {{ org_roles_json|safe }};
   const BASE_ROLES = {{ role_choices_json|safe }};
+  const ORGS_BY_TYPE = {{ orgs_by_type_json|safe }};
+  const ROLES_BY_TYPE = {{ roles_by_type_json|safe }};
 </script>
 <script src="{% static 'core/js/admin_user_edit.js' %}"></script>
 {% endblock %}

--- a/templates/core/admin_view_roles.html
+++ b/templates/core/admin_view_roles.html
@@ -4,13 +4,13 @@
 {% block content %}
 <link rel="stylesheet" href="{% static 'core/css/admin_user_management.css' %}">
 <div class="user-mgmt-container">
-    <h1 class="mgmt-title">Organization Roles</h1>
+    <h1 class="mgmt-title">{{ org_type.name if org_type else "Organization Roles" }}</h1>
     <div class="table-responsive">
         <table id="rolesTable" class="admin-users-table display nowrap" style="width:100%">
             <thead>
                 <tr>
                     <th>#</th>
-                    <th>Organization Type</th>
+                    {% if not org_type %}<th>Organization Type</th>{% endif %}
                     <th>Organization</th>
                     <th>Role Name</th>
                     <th>Status</th>
@@ -21,7 +21,7 @@
             {% for role in roles %}
                 <tr>
                     <td>{{ forloop.counter }}</td>
-                    <td>{{ role.organization.org_type.name }}</td>
+                    {% if not org_type %}<td>{{ role.organization.org_type.name }}</td>{% endif %}
                     <td>{{ role.organization.name }}</td>
                     <td>
                         <form method="post" action="{% url 'update_org_role' role.id %}" class="d-flex">


### PR DESCRIPTION
## Summary
- filter organization roles by category when viewing roles
- link from role management page passes the selected category
- show category-specific heading and table in role list
- allow admins to pick organization category when editing user roles
- dynamically update organizations and roles by selected category

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68832be22990832cac824922223f9053