### PR TITLE
Fix view roles listing

### DIFF
--- a/static/core/css/admin_view_roles.css
+++ b/static/core/css/admin_view_roles.css
@@ -15,6 +15,12 @@
   gap: 1rem;
 }
 
+.role-card .org-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--christ-blue-dark);
+}
+
 .role-card form {
   display: flex;
   gap: 0.5rem;

--- a/templates/core/admin_view_roles.html
+++ b/templates/core/admin_view_roles.html
@@ -16,6 +16,7 @@
         <div class="roles-container">
             {% for role in roles %}
             <div class="role-card">
+                <div class="org-name">{{ role.organization.name }}</div>
                 <form method="post" action="{% url 'update_org_role' role.id %}?org_type_id={{ org_type.id }}">
                     {% csrf_token %}
                     <input type="text" name="name" value="{{ role.name }}" class="form-control form-control-sm" />


### PR DESCRIPTION
## Summary
- display organization name next to each role when viewing roles filtered by type
- add styling for the organization name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883472c42bc832cb0fd9d366ccb913b