### PR TITLE
Improve dynamic role selection

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -82,6 +82,9 @@ urlpatterns = [
     path('api/approval-flow/<int:org_id>/', views.api_approval_flow_steps, name='api_approval_flow_steps'),
     path('core-admin/api/search-users/', views.search_users, name='search_users'),
     path('core-admin/api/org-users/<int:org_id>/', views.organization_users, name='organization_users'),
+    path('core-admin/api/org-type/<int:org_type_id>/organizations/', views.api_org_type_organizations, name='api_org_type_organizations'),
+    path('core-admin/api/org-type/<int:org_type_id>/roles/', views.api_org_type_roles, name='api_org_type_roles'),
+    path('core-admin/api/organization/<int:org_id>/roles/', views.api_organization_roles, name='api_organization_roles'),
 
     # ---- OPTIONAL: Direct organization add endpoint ----
     # path('core-admin/master-data/add/organization/', views.admin_master_data_add, {"model_name": "organization"}, name='admin_settings_add_organization'),

--- a/templates/core/admin_user_edit.html
+++ b/templates/core/admin_user_edit.html
@@ -102,11 +102,5 @@
     <button type="button" class="remove-role-btn">×</button>
   </div>
 </template>
-<script>
-  const ORG_ROLES = {{ org_roles_json|safe }};
-  const BASE_ROLES = {{ role_choices_json|safe }};
-  const ORGS_BY_TYPE = {{ orgs_by_type_json|safe }};
-  const ROLES_BY_TYPE = {{ roles_by_type_json|safe }};
-</script>
 <script src="{% static 'core/js/admin_user_edit.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add API endpoints for org-type and organization roles
- fetch roles dynamically in admin user edit JS
- simplify admin user edit template

## Testing
- `python manage.py test --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_688349e7aa94832cb60670db2e593555