### PR TITLE
Fix role form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,7 @@
 from django import forms
-from .models import RoleAssignment, OrganizationRole
+from django.db.models import Q
+
+from .models import RoleAssignment, OrganizationRole, Organization
 
 class RoleAssignmentForm(forms.ModelForm):
     class Meta:
@@ -8,5 +10,21 @@ class RoleAssignmentForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Show only active roles; you can filter by organization if needed
-        self.fields["role"].queryset = OrganizationRole.objects.filter(is_active=True)
+
+        # Include active organizations plus the currently assigned one (if any)
+        org_filter = Q(is_active=True)
+        if self.instance.pk and self.instance.organization_id:
+            org_filter |= Q(pk=self.instance.organization_id)
+        self.fields["organization"].queryset = (
+            Organization.objects.filter(org_filter).order_by("name")
+        )
+
+        # Include active roles plus the currently assigned role (even if inactive)
+        role_filter = Q(is_active=True)
+        if self.instance.pk and self.instance.role_id:
+            role_filter |= Q(pk=self.instance.role_id)
+        self.fields["role"].queryset = (
+            OrganizationRole.objects.filter(role_filter)
+            .select_related("organization")
+            .order_by("name")
+        )

--- a/templates/core/admin_user_edit.html
+++ b/templates/core/admin_user_edit.html
@@ -42,6 +42,7 @@
         {% for form in formset.forms %}
         <div class="role-card" data-form-index="{{ forloop.counter0 }}">
           {{ form.id }}{{ form.DELETE }}
+          {{ form.non_field_errors }}
 
           <!-- Category -->
           <div class="field-group">
@@ -60,11 +61,13 @@
           <!-- Organization -->
           <div class="field-group">
             {{ form.organization }}
+            {{ form.organization.errors }}
           </div>
 
           <!-- Role -->
           <div class="field-group">
             {{ form.role }}
+            {{ form.role.errors }}
           </div>
 
           <button type="button" class="remove-role-btn">×</button>
@@ -73,6 +76,7 @@
       </div>
 
       {{ formset.management_form }}
+      {{ formset.non_form_errors }}
 
       <button type="button" id="add-role-btn" class="btn-add-role">+ Add Role</button>
     </div>


### PR DESCRIPTION
## Summary
- update RoleAssignmentForm to use ForeignKey queryset
- load role and organization data in user edit
- show form errors in the role form template

## Testing
- `python manage.py test core` *(fails: RoleAssignment.role requires a OrganizationRole instance)*

------
https://chatgpt.com/codex/tasks/task_e_6883583ef310832ca3a0e2421855b866