### PR TITLE
Return role objects in API

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -73,7 +73,8 @@ class RoleManagementTests(TestCase):
         user = User.objects.create(username="u1")
         ot = OrganizationType.objects.create(name="Dept")
         org = Organization.objects.create(name="Math", org_type=ot)
-        RoleAssignment.objects.create(user=user, role="hod", organization=org)
+        role_obj = OrganizationRole.objects.create(organization=org, name="hod")
+        RoleAssignment.objects.create(user=user, role=role_obj, organization=org)
 
         RoleFormSet = inlineformset_factory(
             User,
@@ -91,9 +92,9 @@ class RoleManagementTests(TestCase):
             "role_assignments-MIN_NUM_FORMS": "0",
             "role_assignments-MAX_NUM_FORMS": "1000",
             "role_assignments-0-id": str(RoleAssignment.objects.first().id),
-            "role_assignments-0-role": "hod",
+            "role_assignments-0-role": str(role_obj.id),
             "role_assignments-0-organization": str(org.id),
-            "role_assignments-1-role": "hod",
+            "role_assignments-1-role": str(role_obj.id),
             "role_assignments-1-organization": str(org.id),
         }
         formset = RoleFormSet(data, instance=user)

--- a/static/core/js/admin_user_edit.js
+++ b/static/core/js/admin_user_edit.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const data = await fetchJson(url);
       const roles = data.roles || [];
       roleSel.innerHTML = '<option value="">---------</option>' +
-        roles.map(r => `<option value="${r}">${r}</option>`).join('');
+        roles.map(r => `<option value="${r.id}">${r.name}</option>`).join('');
       if (current && roleSel.querySelector(`option[value="${current}"]`)) {
         roleSel.value = current;
       }
@@ -63,7 +63,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function toggleOrg() {
-      const r = (roleSel.value || '').toLowerCase();
+      const opt = roleSel.options[roleSel.selectedIndex];
+      const r = opt ? opt.textContent.toLowerCase() : '';
       if (ORG_OPTIONAL_ROLES.includes(r)) {
         orgGroup.style.display = 'none';
         orgSel.value = '';


### PR DESCRIPTION
## Summary
- include role `id` and `name` in organization role APIs
- adapt JS to use role ids and read option text when toggling organizations
- update tests for new role object usage

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68883f94b490832cb2d55f9fb2e7f917