### PR TITLE
Fix role dropdown display in admin user edit

### DIFF
--- a/templates/core/admin_user_edit.html
+++ b/templates/core/admin_user_edit.html
@@ -116,8 +116,8 @@
 
 <script>
   // Pass your org/role mapping to JS
-  const ORGS = {{ organizations_json|safe }};
-  const ROLES = {{ roles_json|safe }};
+  const ORGS = JSON.parse('{{ organizations_json|escapejs }}');
+  const ROLES = JSON.parse('{{ roles_json|escapejs }}');
 
   // Function to update organizations based on selected category
   function updateOrganizations(card) {


### PR DESCRIPTION
## Summary
- fix JS that loads orgs and roles in admin user edit page
- ensure role/organization JSON is parsed correctly

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688843e6ead0832cbe7a3f08c8af4966