### PR TITLE
Add typeahead for approval flow

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -860,6 +860,7 @@ def search_users(request):
     q = request.GET.get("q", "")
     role = request.GET.get("role", "")
     org_id = request.GET.get("org_id", "")
+    org_type_id = request.GET.get("org_type_id", "")
 
     users = User.objects.all()
 
@@ -878,6 +879,8 @@ def search_users(request):
     # --- Filter by organization/department ---
     if org_id:
         users = users.filter(role_assignments__organization_id=org_id)
+    elif org_type_id:
+        users = users.filter(role_assignments__organization__org_type_id=org_type_id)
 
     users = users.distinct()[:10]
     data = [{"id": u.id, "name": u.get_full_name(), "email": u.email} for u in users]
@@ -889,8 +892,11 @@ def organization_users(request, org_id):
     """Return users for a given organization, optional search by name or role."""
     q = request.GET.get("q", "")
     role = request.GET.get("role", "")
+    org_type_id = request.GET.get("org_type_id", "")
 
     assignments = RoleAssignment.objects.filter(organization_id=org_id)
+    if not assignments.exists() and org_type_id:
+        assignments = RoleAssignment.objects.filter(organization__org_type_id=org_type_id)
     if role:
         assignments = assignments.filter(role__iexact=role)
     if q:

--- a/templates/core/admin_approval_flow_manage.html
+++ b/templates/core/admin_approval_flow_manage.html
@@ -5,6 +5,7 @@
 
 {% block head_extra %}
   <link rel="stylesheet" href="{% static 'core/css/admin_approval_flow.css' %}">
+  <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet"/>
 {% endblock %}
 
 {% block page_title %}Admin Approval Flow{% endblock %}
@@ -89,7 +90,9 @@
 {% block scripts %}
   <script>
     window.SELECTED_ORG_ID = {{ selected_org_id|default:'null' }};
+    window.SELECTED_ORG_TYPE_ID = {{ selected_org.org_type_id|default:'null' }};
     window.SELECTED_ORG_NAME = "{{ selected_org.name }}";
   </script>
+  <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>
   <script src="{% static 'core/js/admin_approval_flow.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add TomSelect to Admin Approval Flow Management page
- implement user typeahead for each approval step
- extend user search APIs to filter by organization type

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68884f852110832c91d0103a00fa8657