### PR TITLE
Fix CSRF token in approval flow modal

### DIFF
--- a/templates/core/admin_approval_flow_manage.html
+++ b/templates/core/admin_approval_flow_manage.html
@@ -89,6 +89,7 @@
 
 {% block scripts %}
   <script>
+    window.CSRF_TOKEN = "{{ csrf_token }}";
     window.SELECTED_ORG_ID = {{ selected_org_id|default:'null' }};
     window.SELECTED_ORG_TYPE_ID = {{ selected_org.org_type_id|default:'null' }};
     window.SELECTED_ORG_NAME = "{{ selected_org.name }}";


### PR DESCRIPTION
## Summary
- inject `window.CSRF_TOKEN` into `admin_approval_flow_manage.html`
- ensure fetch requests in `admin_approval_flow.js` send the CSRF header

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688883060944832c9c64d88398e352e6