### PR TITLE
Fix CSRF for approval flow

### DIFF
--- a/static/core/js/admin_approval_flow.js
+++ b/static/core/js/admin_approval_flow.js
@@ -581,6 +581,7 @@ window.removeStep = function(idx) {
   fetch(`/core-admin/approval-flow/${orgId}/save/`, {
     method: "POST",
     headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF_TOKEN },
+    credentials: 'same-origin',
     body: JSON.stringify({ steps: payloadSteps })
   })
   .then(r => r.json())
@@ -603,7 +604,8 @@ window.deleteApprovalFlow = function() {
   if (!confirm('Delete entire approval flow for this organization?')) return;
   fetch(`/core-admin/approval-flow/${orgId}/delete/`, {
     method: 'POST',
-    headers: { 'X-CSRFToken': CSRF_TOKEN }
+    headers: { 'X-CSRFToken': CSRF_TOKEN },
+    credentials: 'same-origin'
   })
   .then(r => r.json())
   .then(data => {


### PR DESCRIPTION
## Summary
- ensure session cookies are sent when saving or deleting approval flows

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688885431778832c90e1010666783e11