### PR TITLE
Fix JS injection

### DIFF
--- a/static/core/js/admin_approval_flow.js
+++ b/static/core/js/admin_approval_flow.js
@@ -581,6 +581,7 @@ window.removeStep = function(idx) {
   fetch(`/core-admin/approval-flow/${orgId}/save/`, {
     method: "POST",
     headers: { 'Content-Type': 'application/json', 'X-CSRFToken': CSRF_TOKEN },
+    credentials: 'same-origin',
     body: JSON.stringify({ steps: payloadSteps })
   })
   .then(r => r.json())
@@ -603,7 +604,8 @@ window.deleteApprovalFlow = function() {
   if (!confirm('Delete entire approval flow for this organization?')) return;
   fetch(`/core-admin/approval-flow/${orgId}/delete/`, {
     method: 'POST',
-    headers: { 'X-CSRFToken': CSRF_TOKEN }
+    headers: { 'X-CSRFToken': CSRF_TOKEN },
+    credentials: 'same-origin'
   })
   .then(r => r.json())
   .then(data => {

--- a/templates/core/admin_approval_flow_manage.html
+++ b/templates/core/admin_approval_flow_manage.html
@@ -89,10 +89,10 @@
 
 {% block scripts %}
   <script>
-    window.CSRF_TOKEN = "{{ csrf_token }}";
+    window.CSRF_TOKEN = "{{ csrf_token|escapejs }}";
     window.SELECTED_ORG_ID = {{ selected_org_id|default:'null' }};
     window.SELECTED_ORG_TYPE_ID = {{ selected_org.org_type_id|default:'null' }};
-    window.SELECTED_ORG_NAME = "{{ selected_org.name }}";
+    window.SELECTED_ORG_NAME = "{{ selected_org.name|escapejs }}";
   </script>
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>
   <script src="{% static 'core/js/admin_approval_flow.js' %}"></script>


### PR DESCRIPTION
## Summary
- escape JS variables in approval flow template

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688885431778832c90e1010666783e11