### PR TITLE
Add button types in approval flow modal

### DIFF
--- a/templates/core/admin_approval_flow_manage.html
+++ b/templates/core/admin_approval_flow_manage.html
@@ -73,9 +73,9 @@
       <datalist id="roleSuggestions"></datalist>
     </div>
     <div class="modal-footer">
-      <button class="btn btn-danger" onclick="deleteApprovalFlow()">Delete Flow</button>
-      <button class="btn btn-secondary" onclick="closeModal('approvalFlowEditorModal')">Cancel</button>
-      <button class="btn btn-primary" onclick="saveApprovalFlow()">Save</button>
+      <button type="button" class="btn btn-danger" onclick="deleteApprovalFlow()">Delete Flow</button>
+      <button type="button" class="btn btn-secondary" onclick="closeModal('approvalFlowEditorModal')">Cancel</button>
+      <button type="button" class="btn btn-primary" onclick="saveApprovalFlow()">Save</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- specify type attribute for buttons in the admin approval flow modal

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68888c469bc0832c869f675ecc369460