### PR TITLE
Fix admin approval flow JS scope

### DIFF
--- a/static/core/js/admin_approval_flow.js
+++ b/static/core/js/admin_approval_flow.js
@@ -367,20 +367,18 @@ window.showToast = showToast;
   window.openBulkApprovalModal = openBulkApprovalModal;
   window.openSystemSettingsModal = openSystemSettingsModal;
   window.generateReport = generateReport;
-})();
-let draggedUser = null;
-function openApprovalFlowEditor() {
-    document.getElementById('approvalFlowEditorModal').classList.add('show');
-    document.body.style.overflow = 'hidden';
+
+  // ———————————————————————————————————————————————
+  // Approval flow editor
+  // ———————————————————————————————————————————————
+  let draggedUser = null;
+
+  function openApprovalFlowEditor() {
+    openModal('approvalFlowEditorModal');
     loadApprovalFlow();
     loadOrgUsers();
     loadRoles();
-}
-
-function closeModal(modalId) {
-    document.getElementById(modalId).classList.remove('show');
-    document.body.style.overflow = 'auto';
-}
+  }
 window.loadApprovalFlow = async function() {
   const orgId = window.SELECTED_ORG_ID;
   approvalSteps = [];
@@ -686,3 +684,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 });
+
+  // Expose approval flow helpers
+  window.openApprovalFlowEditor = openApprovalFlowEditor;
+  window.closeModal = closeModal;
+})();


### PR DESCRIPTION
## Summary
- keep the modal helper functions inside the main IIFE
- register `openApprovalFlowEditor` and `closeModal` on `window`
- close the IIFE after exposing helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688894dd5db8832c85d04c0293f8d939