### PR TITLE
Improve admin proposal page design

### DIFF
--- a/static/core/css/admin_event_proposals.css
+++ b/static/core/css/admin_event_proposals.css
@@ -4,10 +4,16 @@ body {
 .admin-proposals-container {
     background: #fff;
     border-radius: 24px;
-    max-width: 1100px;
-    margin: 60px auto 0;
-    padding: 40px 40px 32px 40px;
-    box-shadow: 0 4px 36px rgba(34,116,203,0.13);
+    width: calc(100% - 40px);
+    margin: 40px auto;
+    padding: 40px;
+    box-shadow: 0 8px 40px rgba(34,116,203,0.10);
+    animation: fadeInContainer .5s ease-out;
+}
+
+@keyframes fadeInContainer {
+    from { opacity: 0; transform: scale(0.98); }
+    to { opacity: 1; transform: none; }
 }
 .proposals-title {
     font-size: 2.1rem;
@@ -66,6 +72,16 @@ body {
     box-shadow: 0 2px 14px 0 rgba(34,116,203,0.07);
     background: #f8fbfd;
     overflow: hidden;
+    transform-origin: top;
+}
+
+.proposals-table.fade-in {
+    animation: fadeInUp .6s ease-out;
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(15px); }
+    to { opacity: 1; transform: none; }
 }
 .proposals-table th {
     background: #2274cb;
@@ -83,6 +99,10 @@ body {
 }
 .proposals-table tr:nth-child(even) td {
     background: #e6f2fc;
+}
+.proposals-table tbody tr:hover td {
+    background: #d7e9fb;
+    transition: background .2s;
 }
 .proposal-title-link {
     color: #18528a;
@@ -161,7 +181,7 @@ body {
     margin-top: 7px;
 }
 @media (max-width: 650px) {
-    .admin-proposals-container { padding: 10px 2vw; max-width: 99vw; }
+    .admin-proposals-container { padding: 10px 2vw; width: 100%; }
     .modal-content { padding: 13px 8px 8px 8px; }
     .proposals-title { font-size: 1.4rem; }
     .proposals-filter-form {

--- a/static/core/js/admin_event_proposals.js
+++ b/static/core/js/admin_event_proposals.js
@@ -44,3 +44,10 @@ function handleAction(proposalId, action) {
         }
     });
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    const table = document.querySelector('.proposals-table');
+    if (table) {
+        table.classList.add('fade-in');
+    }
+});


### PR DESCRIPTION
## Summary
- restyle admin event proposals page with modern appearance
- animate table fade in via JavaScript

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68889dae11b0832c92f53ed255e117fe