### PR TITLE
Add JSON and text files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Thumbs.db
 sqlite_backup.json
 clean_backup.json
 full_data.json
+# Data files
+*.json
+emt.txt


### PR DESCRIPTION
## Summary
- prevent `.json` and `emt.txt` files from being tracked

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68899bbd7f6c832ca980ad43d66c35b4