### PR TITLE
Fix admin URL prefix duplication

### DIFF
--- a/iqac_project/urls.py
+++ b/iqac_project/urls.py
@@ -10,8 +10,6 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),  # login/logout
     path('suite/', include(('emt.urls', 'emt'), namespace='emt')),  # emt app
     path('transcript/', include('transcript.urls')),  # transcript module
-    path('core-admin/', include('core.urls')),  # optional alternate route
-    path('emt/', include('emt.urls')),
 ]
 
 # ✅ This line enables media file serving (for student photos) in development:


### PR DESCRIPTION
## Summary
- remove duplicate `core-admin/` URL include
- drop unused `emt/` route to prevent namespace warnings

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68899d4923e0832c9b02131978a54e11