### PR TITLE
Add slug field for org roles

### DIFF
--- a/core/migrations/0018_add_slug_to_organizationrole.py
+++ b/core/migrations/0018_add_slug_to_organizationrole.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+from django.utils.text import slugify
+
+
+def populate_slugs(apps, schema_editor):
+    OrganizationRole = apps.get_model('core', 'OrganizationRole')
+    for role in OrganizationRole.objects.all():
+        base = slugify(role.name)
+        slug = base
+        counter = 2
+        existing = set(
+            OrganizationRole.objects.filter(organization_id=role.organization_id).exclude(pk=role.pk).values_list('slug', flat=True)
+        )
+        while slug in existing or slug == "":
+            slug = f"{base}-{counter}"
+            counter += 1
+        role.slug = slug
+        role.save(update_fields=['slug'])
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0017_merge_20250730_0935'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='organizationrole',
+            name='slug',
+            field=models.SlugField(blank=True, editable=False, max_length=100),
+        ),
+        migrations.RunPython(populate_slugs, migrations.RunPython.noop),
+        migrations.AlterUniqueTogether(
+            name='organizationrole',
+            unique_together={('organization', 'name'), ('organization', 'slug')},
+        ),
+    ]

--- a/core/tests.py
+++ b/core/tests.py
@@ -171,7 +171,7 @@ class SearchUsersTests(TestCase):
 
     def test_search_users_by_role(self):
         resp = self.client.get("/core-admin/api/search-users/", {
-            "role": "Faculty",
+            "role": "faculty",
             "org_id": self.org.id,
         })
         self.assertEqual(resp.status_code, 200)

--- a/emt/views.py
+++ b/emt/views.py
@@ -120,10 +120,10 @@ def submit_proposal(request, pk=None):
         faculty_ids = post_data.getlist("faculty_incharges")
         if faculty_ids:
             form.fields['faculty_incharges'].queryset = User.objects.filter(
-                Q(role_assignments__role='faculty') | Q(id__in=faculty_ids)
+                Q(role_assignments__role__slug='faculty') | Q(id__in=faculty_ids)
             ).distinct()
         else:
-            form.fields['faculty_incharges'].queryset = User.objects.filter(role_assignments__role='faculty').distinct()
+            form.fields['faculty_incharges'].queryset = User.objects.filter(role_assignments__role__slug='faculty').distinct()
         # --------------------------------------------------
 
     else:
@@ -131,7 +131,7 @@ def submit_proposal(request, pk=None):
         selected_academic_year = request.session.get('selected_academic_year')
         form = EventProposalForm(instance=proposal, selected_academic_year=selected_academic_year)
         # Populate all faculty as available choices for JS search/select on GET
-        form.fields['faculty_incharges'].queryset = User.objects.filter(role_assignments__role__name='faculty').distinct()
+        form.fields['faculty_incharges'].queryset = User.objects.filter(role_assignments__role__slug='faculty').distinct()
 
     # Utility to get the display name from ID
     def get_name(model, value):
@@ -484,7 +484,7 @@ def api_organizations(request):
 def api_faculty(request):
     q = request.GET.get("q", "").strip()
     users = (User.objects
-                  .filter(role_assignments__role="faculty")
+                  .filter(role_assignments__role__slug="faculty")
                   .filter(
                       Q(first_name__icontains=q) |
                       Q(last_name__icontains=q) |
@@ -553,7 +553,7 @@ def review_approval_step(request, step_id):
 
             if step.role_required in GATEKEEPER_ROLES:
                 if needs_academic_coord_approval and not approval_exists('academic_coordinator'):
-                    acad_coord = User.objects.filter(role_assignments__role='academic_coordinator').first()
+                    acad_coord = User.objects.filter(role_assignments__role__slug='academic_coordinator').first()
                     if acad_coord:
                         additional_steps.append(
                             ApprovalStep(
@@ -567,7 +567,7 @@ def review_approval_step(request, step_id):
                         next_step_order += 1
 
                 if needs_dean_approval and not approval_exists('dean'):
-                    dean = User.objects.filter(role_assignments__role='dean').first()
+                    dean = User.objects.filter(role_assignments__role__slug='dean').first()
                     if dean:
                         additional_steps.append(
                             ApprovalStep(
@@ -582,7 +582,7 @@ def review_approval_step(request, step_id):
 
             if step.role_required == "academic_coordinator":
                 if needs_dean_approval and not approval_exists('dean'):
-                    dean = User.objects.filter(role_assignments__role='dean').first()
+                    dean = User.objects.filter(role_assignments__role__slug='dean').first()
                     if dean:
                         additional_steps.append(
                             ApprovalStep(


### PR DESCRIPTION
## Summary
- add `slug` to `OrganizationRole` model
- populate slugs with migration
- query roles by `slug` instead of `name`
- update admin role creation
- adjust tests for slugs

## Testing
- `python manage.py makemigrations`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6889b4fe2a70832c8098f42d683e727f