### PR TITLE
Expand faculty API search

### DIFF
--- a/emt/tests.py
+++ b/emt/tests.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from emt.models import ApprovalStep
+from core.models import OrganizationType, Organization, OrganizationRole, RoleAssignment
+
+class FacultyAPITests(TestCase):
+    def setUp(self):
+        self.ot = OrganizationType.objects.create(name="Dept")
+        self.org = Organization.objects.create(name="Science", org_type=self.ot)
+        self.faculty_role = OrganizationRole.objects.create(
+            organization=self.org, name=ApprovalStep.Role.FACULTY.value
+        )
+        self.faculty_incharge_role = OrganizationRole.objects.create(
+            organization=self.org, name=ApprovalStep.Role.FACULTY_INCHARGE.value
+        )
+        self.user1 = User.objects.create(
+            username="f1", first_name="Alpha", email="alpha@example.com"
+        )
+        self.user2 = User.objects.create(
+            username="f2", first_name="Beta", email="beta@example.com"
+        )
+        RoleAssignment.objects.create(
+            user=self.user1, role=self.faculty_role, organization=self.org
+        )
+        RoleAssignment.objects.create(
+            user=self.user2, role=self.faculty_incharge_role, organization=self.org
+        )
+        self.admin = User.objects.create_superuser(
+            "admin", "admin@example.com", "pass"
+        )
+        self.client.force_login(self.admin)
+
+    def test_api_faculty_returns_faculty_like_roles(self):
+        resp = self.client.get(reverse("emt:api_faculty"), {"q": ""})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(self.user1.id, ids)
+        self.assertIn(self.user2.id, ids)


### PR DESCRIPTION
## Summary
- make `api_faculty` search across faculty-like roles
- test that `api_faculty` returns both faculty and faculty in‑charge users

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6889bc886658832cb4b6718d624819b5