### PR TITLE
Fix faculty search to use profile role

### DIFF
--- a/emt/tests.py
+++ b/emt/tests.py
@@ -39,3 +39,18 @@ class FacultyAPITests(TestCase):
         ids = {item["id"] for item in data}
         self.assertIn(self.user1.id, ids)
         self.assertIn(self.user2.id, ids)
+
+    def test_api_faculty_includes_profile_role(self):
+        user3 = User.objects.create(
+            username="f3",
+            first_name="Gamma",
+            email="gamma@example.com",
+        )
+        user3.profile.role = "faculty"
+        user3.profile.save()
+
+        resp = self.client.get(reverse("emt:api_faculty"), {"q": "Gamma"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(user3.id, ids)

--- a/emt/views.py
+++ b/emt/views.py
@@ -41,6 +41,9 @@ FACULTY_LIKE_ROLES = [
     ApprovalStep.Role.FACULTY.value,
     ApprovalStep.Role.FACULTY_INCHARGE.value,
 ]
+
+# Fallback profile roles for faculty search when no role assignments exist
+PROFILE_FACULTY_ROLES = ["faculty"]
 from django.contrib import messages
 from django.utils import timezone
 from django.db import models
@@ -528,7 +531,10 @@ def api_faculty(request):
     q = request.GET.get("q", "").strip()
     users = (
         User.objects
-            .filter(role_assignments__role__name__in=FACULTY_LIKE_ROLES)
+            .filter(
+                Q(role_assignments__role__name__in=FACULTY_LIKE_ROLES) |
+                Q(profile__role__in=PROFILE_FACULTY_ROLES)
+            )
             .filter(
                 Q(first_name__icontains=q) |
                 Q(last_name__icontains=q) |


### PR DESCRIPTION
## Summary
- include fallback profile roles when searching for faculty
- test that the API returns users by profile role

## Testing
- `python manage.py test emt.tests.FacultyAPITests --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_688a4a930110832ca97512e9fe16f2d4