### PR TITLE
Fix faculty search to include capitalized roles

### DIFF
--- a/emt/tests.py
+++ b/emt/tests.py
@@ -39,3 +39,40 @@ class FacultyAPITests(TestCase):
         ids = {item["id"] for item in data}
         self.assertIn(self.user1.id, ids)
         self.assertIn(self.user2.id, ids)
+
+    def test_api_faculty_includes_profile_role(self):
+        user3 = User.objects.create(
+            username="f3",
+            first_name="Gamma",
+            email="gamma@example.com",
+        )
+        user3.profile.role = "faculty"
+        user3.profile.save()
+
+        resp = self.client.get(reverse("emt:api_faculty"), {"q": "Gamma"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(user3.id, ids)
+
+    def test_api_faculty_matches_capitalized_roles(self):
+        user4 = User.objects.create(
+            username="f4",
+            first_name="Delta",
+            email="delta@example.com",
+        )
+        cap_role = OrganizationRole.objects.create(
+            organization=self.org,
+            name="Faculty",
+        )
+        RoleAssignment.objects.create(
+            user=user4,
+            role=cap_role,
+            organization=self.org,
+        )
+
+        resp = self.client.get(reverse("emt:api_faculty"), {"q": "Delta"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(user4.id, ids)

--- a/emt/views.py
+++ b/emt/views.py
@@ -40,7 +40,12 @@ ACADEMIC_COORDINATOR_ROLE = "academic_coordinator"
 FACULTY_LIKE_ROLES = [
     ApprovalStep.Role.FACULTY.value,
     ApprovalStep.Role.FACULTY_INCHARGE.value,
+    "Faculty",
+    "Faculty In-Charge",
 ]
+
+# Fallback profile roles for faculty search when no role assignments exist
+PROFILE_FACULTY_ROLES = ["faculty"]
 from django.contrib import messages
 from django.utils import timezone
 from django.db import models
@@ -528,7 +533,10 @@ def api_faculty(request):
     q = request.GET.get("q", "").strip()
     users = (
         User.objects
-            .filter(role_assignments__role__name__in=FACULTY_LIKE_ROLES)
+            .filter(
+                Q(role_assignments__role__name__in=FACULTY_LIKE_ROLES) |
+                Q(profile__role__in=PROFILE_FACULTY_ROLES)
+            )
             .filter(
                 Q(first_name__icontains=q) |
                 Q(last_name__icontains=q) |


### PR DESCRIPTION
## Summary
- ensure faculty API also matches `Faculty` and `Faculty In-Charge` names
- add regression test covering capitalized role names

## Testing
- `python manage.py test emt.tests.FacultyAPITests --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_688a4a930110832ca97512e9fe16f2d4