### PR TITLE
Fix review page details

### DIFF
--- a/emt/utils.py
+++ b/emt/utils.py
@@ -93,7 +93,7 @@ def generate_report_with_ai(event_report):
     {event_report.summary}
 
     **2. Objectives & Outcomes:**
-    - **Stated Objectives:** {proposal.eventobjectives.content if hasattr(proposal, 'eventobjectives') else 'Not provided.'}
+    - **Stated Objectives:** {proposal.objectives.content if hasattr(proposal, 'objectives') else 'Not provided.'}
     - **Achieved Outcomes:** {event_report.outcomes}
 
     **3. Participation & Engagement:**

--- a/emt/views.py
+++ b/emt/views.py
@@ -567,10 +567,11 @@ def review_approval_step(request, step_id):
     step = get_object_or_404(ApprovalStep, id=step_id, assigned_to=request.user)
     proposal = step.proposal
 
-    need_analysis = getattr(proposal, "eventneedanalysis", None)
-    objectives = getattr(proposal, "eventobjectives", None)
-    outcomes = getattr(proposal, "eventexpectedoutcomes", None)
-    flow = getattr(proposal, "tentativeflow", None)
+    # Fetch related proposal details using the proper `related_name`
+    need_analysis = getattr(proposal, "need_analysis", None)
+    objectives = getattr(proposal, "objectives", None)
+    outcomes = getattr(proposal, "expected_outcomes", None)
+    flow = getattr(proposal, "tentative_flow", None)
     speakers = SpeakerProfile.objects.filter(proposal=proposal)
     expenses = ExpenseDetail.objects.filter(proposal=proposal)
 


### PR DESCRIPTION
## Summary
- ensure review page fetches need analysis, objectives and outcomes via correct related names
- update AI report generation to access objectives via new related name

## Testing
- `python manage.py check`
- `python manage.py test transcript.tests.StrengthCalculationTests.test_calculate_strength_data_returns_scores`


------
https://chatgpt.com/codex/tasks/task_e_688a53aef900832c84aca425e57439c7