### PR TITLE
Implement dynamic notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - CDL (Content Development Lab) request module
 - Graduate Attribute Script
 - Notification panel with visual indicators
+- Dynamic notifications about event proposals
 - Dashboard with statistics and filters
 - Fully responsive and mobile-optimized
 

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,30 @@
+from django.utils import timezone
+from django.utils.timesince import timesince
+from emt.models import EventProposal
+
+
+def notifications(request):
+    """Return proposal-related notifications for the logged-in user."""
+    if not request.user.is_authenticated:
+        return {}
+
+    proposals = (
+        EventProposal.objects
+        .filter(submitted_by=request.user)
+        .order_by('-updated_at')[:5]
+    )
+
+    notif_list = []
+    for p in proposals:
+        # Determine notification type based on status
+        if p.status == EventProposal.Status.REJECTED:
+            n_type = 'alert'
+        elif p.status in [EventProposal.Status.SUBMITTED, EventProposal.Status.UNDER_REVIEW]:
+            n_type = 'reminder'
+        else:
+            n_type = 'info'
+        message = f"{p.event_title or 'Event Proposal'} - {p.get_status_display()}"
+        time_label = timesince(p.updated_at, timezone.now()) + ' ago'
+        notif_list.append({'type': n_type, 'msg': message, 'time': time_label})
+
+    return {'notifications': notif_list}

--- a/core/urls.py
+++ b/core/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('user-roles/', views.admin_role_management, name='admin_role_management'),
     path('user-roles/<int:organization_id>/', views.admin_role_management, name='admin_role_management_org'),
     path('user-roles/<int:organization_id>/add/', views.add_org_role, name='add_org_role'),
+    path('user-roles/add/', views.add_role, name='add_role'),
     path('user-roles/role/<int:role_id>/update/', views.update_org_role, name='update_org_role'),
     path('user-roles/role/<int:role_id>/toggle/', views.toggle_org_role, name='toggle_org_role'),
     path('user-roles/role/<int:role_id>/delete/', views.delete_org_role, name='delete_org_role'),

--- a/core/views.py
+++ b/core/views.py
@@ -283,6 +283,34 @@ def add_org_role(request, organization_id):
 
 @user_passes_test(lambda u: u.is_superuser)
 @require_POST
+def add_role(request):
+    """Add a role by organization or organization type (used by tests)."""
+    name = request.POST.get("name", "").strip()
+    org_id = request.POST.get("org_id")
+    org_type_id = request.POST.get("org_type_id")
+
+    if not name:
+        return HttpResponseRedirect(reverse("admin_role_management"))
+
+    if org_id:
+        orgs = Organization.objects.filter(id=org_id, is_active=True)
+        redirect_url = reverse("admin_role_management_org", args=[org_id])
+    elif org_type_id:
+        orgs = Organization.objects.filter(org_type_id=org_type_id, is_active=True)
+        redirect_url = reverse("admin_role_management") + f"?org_type_id={org_type_id}"
+    else:
+        orgs = []
+        redirect_url = reverse("admin_role_management")
+
+    for org in orgs:
+        if not OrganizationRole.objects.filter(organization=org, name__iexact=name).exists():
+            OrganizationRole.objects.create(organization=org, name=name, is_active=True)
+
+    return HttpResponseRedirect(redirect_url)
+
+
+@user_passes_test(lambda u: u.is_superuser)
+@require_POST
 def update_org_role(request, role_id):
     """Update this role for ALL organizations of the same type"""
     role = get_object_or_404(OrganizationRole, id=role_id)
@@ -1080,7 +1108,7 @@ def search_users(request):
 
     # --- Filter by role ---
     if role:
-        users = users.filter(role_assignments__role__iexact=role)
+        users = users.filter(role_assignments__role__name__iexact=role)
 
     # --- Filter by organization/department ---
     if org_id:

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -77,6 +77,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.csrf',
                 'django.contrib.messages.context_processors.messages',
+                'core.context_processors.notifications',
             ],
         },
     },


### PR DESCRIPTION
## Summary
- add global context processor for proposal notifications
- wire context processor into settings
- fix admin search_users role lookup
- expose `add_role` URL for tests
- document dynamic notifications in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688a55df2b38832caa7dd861d8aa41f8