### PR TITLE
Fix CDL dashboard links

### DIFF
--- a/emt/templates/emt/cdl_dashboard.html
+++ b/emt/templates/emt/cdl_dashboard.html
@@ -14,13 +14,13 @@
         <div class="cdl-card">
             <h3>Submit Media Request</h3>
             <p>Request posters, videos, reels, or photo coverage for your event.</p>
-            <a href="#" class="cdl-btn">Submit Request</a>
+            <a href="{% url 'emt:cdl_submit' %}" class="cdl-btn">Submit Request</a>
         </div>
         <!-- Card 2 -->
         <div class="cdl-card">
             <h3>My Requests</h3>
             <p>Track the status of your submitted media content requests.</p>
-            <a href="#" class="cdl-btn">View Requests</a>
+            <a href="{% url 'emt:cdl_my_requests' %}" class="cdl-btn">View Requests</a>
         </div>
     </div>
 

--- a/emt/templates/emt/cdl_my_requests.html
+++ b/emt/templates/emt/cdl_my_requests.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-<link rel="stylesheet" href="{% static 'cdl/css/my_requests.css' %}">
+<link rel="stylesheet" href="{% static 'emt/css/my_requests.css' %}">
 
 <div class="my-requests-container">
   <h2 class="my-requests-heading">My Media Requests</h2>

--- a/emt/templates/emt/cdl_submit_request.html
+++ b/emt/templates/emt/cdl_submit_request.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-<link rel="stylesheet" href="{% static 'cdl/css/submit_request.css' %}">
+<link rel="stylesheet" href="{% static 'emt/css/submit_request.css' %}">
 
 <div class="submit-container">
   <h2 class="submit-heading">Submit Media Request</h2>

--- a/emt/views.py
+++ b/emt/views.py
@@ -67,8 +67,6 @@ from operator import attrgetter
 # ──────────────────────────────
 # Configure Gemini API key from environment variable
 genai.configure(api_key=os.environ.get("GEMINI_API_KEY"))
-def cdl_dashboard(request):
-    return render(request, 'emt/cdl_dashboard.html')
 
 @login_required
 def submit_request_view(request):

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,7 +78,7 @@
         <a href="/transcript/" class="nav-link {% if 'transcript' in request.resolver_match.url_name %}active{% endif %}">
           <i class="fa-solid fa-graduation-cap"></i> Transcript
         </a>
-        <a href="/core-admin/cdl/" class="nav-link {% if 'cdl' in request.resolver_match.url_name %}active{% endif %}">
+        <a href="{% url 'cdl_dashboard' %}" class="nav-link {% if 'cdl' in request.resolver_match.url_name %}active{% endif %}">
           <i class="fa-solid fa-photo-video"></i> CDL
         </a>
       </nav>
@@ -109,7 +109,7 @@
       </a>
       {% endif %}
       {% if request.session.role in 'cdl_admin,super_admin' or user.is_superuser %}
-      <a href="/core-admin/cdl/" class="nav-link {% if 'cdl' in request.resolver_match.url_name %}active{% endif %}">
+      <a href="{% url 'cdl_dashboard' %}" class="nav-link {% if 'cdl' in request.resolver_match.url_name %}active{% endif %}">
         <i class="fa-solid fa-photo-video"></i> CDL
       </a>
       {% endif %}
@@ -209,7 +209,7 @@
 
         <!-- CDL Card -->
         {% if request.session.role in 'cdl_admin,super_admin' or user.is_superuser %}
-        <a href="/core-admin/cdl/" class="app-card app-card-orange">
+        <a href="{% url 'cdl_dashboard' %}" class="app-card app-card-orange">
           <div class="app-icon">
             <i class="fa-solid fa-camera"></i>
           </div>


### PR DESCRIPTION
## Summary
- wire up CDL dashboard card links
- correct CSS paths for CDL templates
- remove duplicate dashboard view and use named URL in navigation

## Testing
- `pytest -q`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_688a55f4d18c832c966d3d39033ae697