### PR TITLE
Remove side stepper and clean up layout

### DIFF
--- a/emt/static/emt/css/submit_event_report.css
+++ b/emt/static/emt/css/submit_event_report.css
@@ -7,6 +7,10 @@
   --muted: #64748b;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   background: var(--bg);
   font-family: 'Inter', 'Poppins', sans-serif;
@@ -76,43 +80,6 @@ body {
   border-bottom: none;
 }
 
-.stepper {
-  margin-top: 24px;
-}
-
-.stepper ol {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  border-left: 2px solid var(--border);
-}
-
-.stepper li {
-  position: relative;
-  padding: 12px 0 12px 24px;
-  color: var(--muted);
-  font-weight: 500;
-}
-
-.stepper li:before {
-  content: '';
-  position: absolute;
-  left: -9px;
-  top: 14px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--border);
-}
-
-.stepper li.active {
-  color: var(--primary);
-  font-weight: 600;
-}
-
-.stepper li.active:before {
-  background: var(--primary);
-}
 
 .form-card {
   background: var(--surface);

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -22,13 +22,7 @@
         <tr><th>Target Audience</th><td>{{ proposal.target_audience }}</td></tr>
       </table>
     </div>
-    <nav class="stepper">
-      <ol>
-        <li class="active">Report Details</li>
-        <li>Attachments</li>
-        <li>Review &amp; Submit</li>
-      </ol>
-    </nav>
+    {# Stepper removed - single page layout #}
   </aside>
 
   <section class="form-wrapper">
@@ -69,8 +63,11 @@
           </div>
         </div>
 
-        <div class="save-btn">
-          <button type="submit">Save &amp; Generate</button>
+        <div class="section">
+          <h3 class="section-title">Review &amp; Submit</h3>
+          <div class="save-btn">
+            <button type="submit">Save &amp; Generate</button>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- remove the non-functional stepper navigation
- show a final **Review & Submit** section instead
- delete stepper styles and enable smooth scrolling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688af56acac4832c8f895dab92228d0f