### PR TITLE
Enhance notification handling

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,5 +1,7 @@
 from django.utils import timezone
 from django.utils.timesince import timesince
+from django.db.models import Q
+from datetime import timedelta
 from emt.models import EventProposal
 
 
@@ -8,10 +10,15 @@ def notifications(request):
     if not request.user.is_authenticated:
         return {}
 
+    two_days_ago = timezone.now() - timedelta(days=2)
     proposals = (
         EventProposal.objects
         .filter(submitted_by=request.user)
-        .order_by('-updated_at')[:5]
+        .filter(
+            ~Q(status=EventProposal.Status.FINALIZED) |
+            Q(updated_at__gte=two_days_ago)
+        )
+        .order_by('-updated_at')[:10]
     )
 
     notif_list = []

--- a/emt/static/emt/css/iqac_suite_dashboard.css
+++ b/emt/static/emt/css/iqac_suite_dashboard.css
@@ -224,6 +224,7 @@
   padding: 1.15rem 1rem;
   border: 1.5px solid #e3eaf2;
   flex: 1;
+  max-height: 400px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- keep event proposal notifications until finalized
- remove finalized notifications after 2 days
- limit IQAC dashboard notification panel height so it scrolls

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688af7f4e108832cad744dd6d5d1583d