### PR TITLE
Require comment to reject proposal

### DIFF
--- a/emt/static/emt/js/review_approval_step.js
+++ b/emt/static/emt/js/review_approval_step.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('.review-form-ultra');
+  if (!form) return;
+  const commentField = form.querySelector('textarea[name="comment"]');
+  const rejectBtn = form.querySelector('button[name="action"][value="reject"]');
+  if (rejectBtn) {
+    rejectBtn.addEventListener('click', (e) => {
+      if (!commentField.value.trim()) {
+        e.preventDefault();
+        alert('Please add a comment before rejecting the proposal.');
+      }
+    });
+  }
+});

--- a/emt/templates/emt/review_approval_step.html
+++ b/emt/templates/emt/review_approval_step.html
@@ -193,7 +193,7 @@
         <form method="post" class="review-form-ultra">
           {% csrf_token %}
           <div class="form-group">
-            <label>Comment / Remarks:</label>
+            <label>Comment / Remarks: <small class="text-muted">(required when rejecting)</small></label>
             <textarea name="comment" class="form-control"></textarea>
           </div>
           {% if step.role_required in GATEKEEPER_ROLES %}
@@ -223,8 +223,9 @@
           This step is <strong>{{ step.get_status_display }}</strong>.
         </div>
       {% endif %}
-    </div>
+</div>
 
   </main>
 </div>
+<script src="{% static 'emt/js/review_approval_step.js' %}"></script>
 {% endblock %}

--- a/emt/views.py
+++ b/emt/views.py
@@ -702,18 +702,23 @@ def review_approval_step(request, step_id):
                 proposal.status = 'finalized'
             proposal.save()
             messages.success(request, 'Proposal approved.')
+            return redirect('emt:my_approvals')
 
         elif action == 'reject':
-            step.status = 'rejected'
-            step.comment = comment
-            step.approved_by = request.user
-            step.approved_at = timezone.now()
-            proposal.status = 'rejected'
-            proposal.save()
-            step.save()
-            messages.error(request, 'Proposal rejected.')
-
-        return redirect('emt:my_approvals')
+            if not comment.strip():
+                messages.error(request, 'Comment is required to reject the proposal.')
+            else:
+                step.status = 'rejected'
+                step.comment = comment
+                step.approved_by = request.user
+                step.approved_at = timezone.now()
+                proposal.status = 'rejected'
+                proposal.save()
+                step.save()
+                messages.error(request, 'Proposal rejected.')
+                return redirect('emt:my_approvals')
+        else:
+            return redirect('emt:my_approvals')
 
     return render(request, 'emt/review_approval_step.html', {
         'step': step,


### PR DESCRIPTION
## Summary
- require a comment before rejecting a proposal during review
- validate comment in the backend
- enforce comment via new JS helper
- note the requirement in the review form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b87cf3340832c9ea3546edc66db73