### PR TITLE
Add UI for AI report page

### DIFF
--- a/emt/static/emt/css/ai_generate_report.css
+++ b/emt/static/emt/css/ai_generate_report.css
@@ -1,0 +1,165 @@
+/* Styles for AI Generate Report page */
+body {
+  background: linear-gradient(110deg, #e8f1fa 70%, #e2e2ef 100%);
+}
+
+.ultra-proposal-root {
+  display: flex;
+  gap: 46px;
+  max-width: 1200px;
+  margin: 40px auto;
+  min-height: 80vh;
+}
+
+.ultra-side-info {
+  flex: 0 0 360px;
+  min-width: 300px;
+  max-width: 400px;
+  position: sticky;
+  top: 90px;
+  align-self: flex-start;
+  height: fit-content;
+  z-index: 2;
+}
+
+.info-card {
+  padding: 28px;
+  border-radius: 20px;
+  background: rgba(245,249,255,0.83);
+  border: 1.5px solid #e7ebf4;
+  box-shadow: 0 4px 32px rgba(42,67,155,0.11);
+  backdrop-filter: blur(9px);
+}
+
+.info-card h2 {
+  margin: 0 0 16px 0;
+  font-size: 1.15rem;
+  color: #253c72;
+  letter-spacing: 0.4px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.info-card table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 1.06rem;
+}
+
+.info-card th,
+.info-card td {
+  text-align: left;
+  padding: 7.5px 7px 7.5px 0;
+  border-bottom: 1px solid #e3eaf7;
+  font-weight: 500;
+}
+
+.info-card th {
+  width: 44%;
+  color: #26407c;
+  font-weight: 700;
+}
+
+.info-card tr:last-child td,
+.info-card tr:last-child th {
+  border-bottom: none;
+}
+
+.info-card td {
+  color: #1f2540;
+}
+
+.ultra-main-content {
+  flex: 1 1 0%;
+  min-width: 420px;
+  max-width: 960px;
+}
+
+.ultra-header {
+  margin-bottom: 18px;
+  border-bottom: 2.5px solid #e6ecf6;
+  padding-bottom: 14px;
+}
+
+.ultra-header h1 {
+  font-size: 2rem;
+  font-weight: 900;
+  color: #23457a;
+  margin: 0;
+  text-shadow: 0 2px 16px #c5deff, 0 0px 2px #74b4ff;
+  letter-spacing: 1px;
+}
+
+.ultra-header .meta {
+  font-size: 1rem;
+  color: #5370b6;
+  display: block;
+  margin-top: 2px;
+}
+
+.section-glass {
+  margin-bottom: 22px;
+  background: rgba(255,255,255,0.9);
+  border-radius: 18px;
+  border: 1.4px solid #e3eaf7;
+  box-shadow: 0 4px 28px rgba(36,70,120,0.08);
+  padding: 24px;
+}
+
+.section-glass h3 {
+  font-size: 1.14rem;
+  font-weight: 700;
+  color: #253c72;
+  margin: 0 0 12px 0;
+}
+
+.report-data-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px 32px;
+  margin-top: 16px;
+}
+
+.report-data-grid div {
+  font-size: 1rem;
+  color: #253660;
+}
+
+.placeholder {
+  color: #aaa;
+  font-style: italic;
+}
+
+.btn-ultra {
+  display: inline-block;
+  min-width: 140px;
+  padding: 13px 0;
+  font-size: 1.1rem;
+  font-weight: 800;
+  border-radius: 10px;
+  border: none;
+  box-shadow: 0 1px 6px rgba(0,30,60,0.09);
+  letter-spacing: 0.7px;
+  transition: transform 0.14s, box-shadow 0.12s;
+}
+
+.btn-success-ultra {
+  background: linear-gradient(90deg,#11d173 65%, #2ea84e 100%);
+  color: #fff;
+}
+
+.btn-ultra:hover {
+  transform: scale(1.05) translateY(-2px);
+  box-shadow: 0 4px 16px rgba(60,120,250,0.08);
+}
+
+@media (max-width: 1050px) {
+  .ultra-proposal-root { flex-direction: column; gap: 26px; }
+  .ultra-side-info { position: static; margin-bottom: 28px; }
+}
+
+@media (max-width: 900px) {
+  .ultra-main-content, .ultra-side-info { max-width: 100%; min-width: 0; }
+  .report-data-grid { grid-template-columns: 1fr; }
+}

--- a/emt/templates/emt/ai_generate_report.html
+++ b/emt/templates/emt/ai_generate_report.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'emt/css/submit_event_report.css' %}">
+<link rel="stylesheet" href="{% static 'emt/css/ai_generate_report.css' %}">
 
 <div class="ultra-proposal-root">
 
@@ -43,20 +43,6 @@
         <div><b>IQAC Feedback:</b> {{ report.iqac_feedback|default:"<span class='placeholder'>(not provided)</span>"|safe }}</div>
         <div><b>Beneficiaries:</b> {{ report.beneficiaries_details|default:"<span class='placeholder'>(not provided)</span>"|safe }}</div>
       </div>
-      <style>
-        .report-data-grid {
-          display: grid;
-          grid-template-columns: 1fr 1fr;
-          gap: 20px 32px;
-          margin-top: 18px;
-          margin-bottom: 6px;
-        }
-        .report-data-grid div { font-size: 1.07rem; color: #253660; }
-        .placeholder { color: #aaa; font-style: italic; }
-        @media (max-width: 900px) {
-          .report-data-grid { grid-template-columns: 1fr; }
-        }
-      </style>
     </div>
 
     <!-- AI Generate Button & Preview -->


### PR DESCRIPTION
## Summary
- add dedicated `ai_generate_report.css` for new event report page design
- update HTML template to link new stylesheet and remove inline styles

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_688b8958d21c832cae93927faf1239ec