### PR TITLE
Fix missing organization when submitting reports

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -4,7 +4,8 @@ document.addEventListener('DOMContentLoaded', function(){
   });
 
   const posField = document.getElementById('id_pos_pso_mapping');
-  if(posField){
+  const modal = document.getElementById('outcomeModal');
+  if(posField && modal && modal.dataset.url){
     posField.addEventListener('click', openOutcomeModal);
     posField.readOnly = true;
     posField.style.cursor = 'pointer';
@@ -15,6 +16,10 @@ function openOutcomeModal(){
   const modal = document.getElementById('outcomeModal');
   const container = document.getElementById('outcomeOptions');
   const url = modal.dataset.url;
+  if(!url){
+    alert('No organization set for this proposal.');
+    return;
+  }
   modal.classList.add('show');
   container.textContent = 'Loading...';
   fetch(url)

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -74,16 +74,37 @@
   </section>
 </div>
 
-<div id="outcomeModal" class="outcome-modal" data-url="{% url 'emt:api_outcomes' proposal.organization.id %}">
-  <div class="modal-content">
-    <h3>Select Outcomes</h3>
-    <div id="outcomeOptions">Loading...</div>
-    <div class="modal-actions">
-      <button type="button" id="outcomeCancel" class="btn-cancel">Cancel</button>
-      <button type="button" id="outcomeSave" class="btn-save">Add</button>
+{% if proposal.organization %}
+  {% comment %}
+    When the proposal is associated with an organization, allow the outcomes
+    modal to load Program Outcomes/Program Specific Outcomes via AJAX.
+  {% endcomment %}
+  <div id="outcomeModal" class="outcome-modal"
+       data-url="{% url 'emt:api_outcomes' proposal.organization.id %}">
+    <div class="modal-content">
+      <h3>Select Outcomes</h3>
+      <div id="outcomeOptions">Loading...</div>
+      <div class="modal-actions">
+        <button type="button" id="outcomeCancel" class="btn-cancel">Cancel</button>
+        <button type="button" id="outcomeSave" class="btn-save">Add</button>
+      </div>
     </div>
   </div>
-</div>
+{% else %}
+  {# If no organization is set for the proposal, keep the modal in the DOM but
+     do not provide an API URL. The JS will detect this and skip showing the
+     modal. #}
+  <div id="outcomeModal" class="outcome-modal" data-url="">
+    <div class="modal-content">
+      <h3>Select Outcomes</h3>
+      <div id="outcomeOptions">No organization selected.</div>
+      <div class="modal-actions">
+        <button type="button" id="outcomeCancel" class="btn-cancel">Cancel</button>
+        <button type="button" id="outcomeSave" class="btn-save">Add</button>
+      </div>
+    </div>
+  </div>
+{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- avoid URL reversing errors when a proposal has no organization
- skip outcome modal interaction when organization is missing

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b8bee5d08832cb3a7d62fc9b02b4f