### PR TITLE
Add editing options for rejected proposals

### DIFF
--- a/emt/models.py
+++ b/emt/models.py
@@ -75,6 +75,16 @@ class EventProposal(models.Model):
     def __str__(self):
         return self.event_title or f"Proposal #{self.id}"
 
+    @property
+    def return_comment(self):
+        """Return the comment from the latest rejected approval step, if any."""
+        step = (
+            self.approval_steps.filter(status=ApprovalStep.Status.REJECTED)
+            .order_by("-step_order")
+            .first()
+        )
+        return getattr(step, "comment", "")
+
 # ────────────────────────────────────────────────────────────────
 #  One-to-one / related tables
 # ────────────────────────────────────────────────────────────────

--- a/emt/static/emt/css/iqac_suite_dashboard.css
+++ b/emt/static/emt/css/iqac_suite_dashboard.css
@@ -319,6 +319,20 @@
   color: #1e40af;
   text-decoration: underline;
 }
+.notif-edit-btn {
+  display: inline-block;
+  margin-top: 8px;
+  margin-right: 10px;
+  font-size: 0.96rem;
+  color: #d97706;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.18s;
+}
+.notif-edit-btn:hover {
+  color: #b45309;
+  text-decoration: underline;
+}
 
 .notif-empty {
   text-align: center;

--- a/emt/static/emt/css/proposal_status_detail.css
+++ b/emt/static/emt/css/proposal_status_detail.css
@@ -347,6 +347,25 @@ a:hover { color: var(--christ-blue-secondary); }
   transform: translateY(-1px);
 }
 
+.edit-btn {
+  grid-column: 1 / -1;
+  display: inline-block;
+  background: #fb923c;
+  color: var(--white);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-lg);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-align: center;
+  transition: background var(--trans-fast), transform var(--trans-fast);
+  margin-top: 1rem;
+  margin-right: 0.5rem;
+}
+.edit-btn:hover {
+  background: #f97316;
+  transform: translateY(-1px);
+}
+
 
 /* ========================================================================
    9) RESPONSIVE TWEAKS

--- a/emt/templates/emt/iqac_suite_dashboard.html
+++ b/emt/templates/emt/iqac_suite_dashboard.html
@@ -171,7 +171,10 @@
                 </span>
               </div>
               <!-- END CHART -->
-               <a href="{% url 'emt:proposal_status_detail' proposal.id %}" class="notif-view-btn">View More Details →</a>
+              {% if proposal.status == 'rejected' %}
+                <a href="{% url 'emt:submit_proposal_with_pk' proposal.id %}" class="notif-edit-btn">Edit Proposal →</a>
+              {% endif %}
+              <a href="{% url 'emt:proposal_status_detail' proposal.id %}" class="notif-view-btn">View More Details →</a>
             </li>
             {% endfor %}
           </ul>

--- a/emt/templates/emt/proposal_status_detail.html
+++ b/emt/templates/emt/proposal_status_detail.html
@@ -126,7 +126,10 @@
       </div>
     </div>
 
-    {# — Full-width Back Button — #}
+    {# — Action Buttons — #}
+    {% if proposal.status == 'rejected' %}
+      <a href="{% url 'emt:submit_proposal_with_pk' proposal.id %}" class="edit-btn">Edit Proposal →</a>
+    {% endif %}
     <a href="{% url 'emt:iqac_suite_dashboard' %}" class="back-btn">
       ← Back to Dashboard
     </a>

--- a/emt/views.py
+++ b/emt/views.py
@@ -786,6 +786,7 @@ def suite_dashboard(request):
             status='finalized',
             updated_at__lt=now() - timedelta(days=2)
         )
+        .prefetch_related('approval_steps')
         .order_by('-updated_at')
     )
 


### PR DESCRIPTION
## Summary
- show an **Edit Proposal** link in notification items when a proposal is rejected
- show the same edit link on the proposal detail page
- style the new notification and detail buttons
- expose rejection comments via `EventProposal.return_comment`
- prefetch approval steps for dashboard performance

## Testing
- `python -m pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b8c45ae24832cb4e88ab7233f62fb