### PR TITLE
Skip duplicate faculty approvals

### DIFF
--- a/emt/utils.py
+++ b/emt/utils.py
@@ -22,7 +22,10 @@ def build_approval_chain(proposal):
     steps = []
     idx = 1
 
-    if config and config.require_faculty_incharge_first:
+    # Track if we've already added faculty in-charge approvals
+    fic_first = config and config.require_faculty_incharge_first
+
+    if fic_first:
         for fic in proposal.faculty_incharges.all():
             steps.append(
                 ApprovalStep(
@@ -36,10 +39,15 @@ def build_approval_chain(proposal):
             idx += 1
 
     for tmpl in flow:
+        # Skip duplicate faculty in-charge steps if they're already added above
+        if fic_first and tmpl.role_required == ApprovalStep.Role.FACULTY_INCHARGE:
+            continue
+
         assigned_to = tmpl.user or User.objects.filter(
             role_assignments__role__name=tmpl.role_required,
             role_assignments__organization=proposal.organization,
         ).first()
+
         steps.append(
             ApprovalStep(
                 proposal=proposal,


### PR DESCRIPTION
## Summary
- prevent adding a second faculty-in-charge step when FIC-first is enabled
- run test suite

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b8ca4467c832cbde2c991fde046ac