### PR TITLE
Fix edit persistence and clean dashboard notifications

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -64,6 +64,8 @@ class EventProposalForm(forms.ModelForm):
                 org_type = None
         elif self.instance and getattr(self.instance, "organization", None):
             org_type = self.instance.organization.org_type
+            # Pre-populate organization type when editing existing proposals
+            self.fields["organization_type"].initial = org_type
 
         if org_type:
             self.fields['organization'].queryset = Organization.objects.filter(org_type=org_type, is_active=True)

--- a/emt/templates/emt/iqac_suite_dashboard.html
+++ b/emt/templates/emt/iqac_suite_dashboard.html
@@ -126,9 +126,6 @@
                 <span class="notif-age-pill">{{ proposal.updated_at|timesince }} ago</span>
               </div>
 
-              {% if proposal.status == 'rejected' and proposal.return_comment %}
-                <div class="notif-feedback"><b>Rejection Reason:</b> {{ proposal.return_comment }}</div>
-              {% endif %}
 
               <!-- MODERN PROGRESS CHART -->
               <div class="workflow-progress">
@@ -171,9 +168,6 @@
                 </span>
               </div>
               <!-- END CHART -->
-              {% if proposal.status == 'rejected' %}
-                <a href="{% url 'emt:submit_proposal_with_pk' proposal.id %}" class="notif-edit-btn">Edit Proposal →</a>
-              {% endif %}
               <a href="{% url 'emt:proposal_status_detail' proposal.id %}" class="notif-view-btn">View More Details →</a>
             </li>
             {% endfor %}

--- a/emt/views.py
+++ b/emt/views.py
@@ -150,9 +150,11 @@ def submit_proposal(request, pk=None):
         # Always get the selected academic year from session (ensured above)
         selected_academic_year = request.session.get('selected_academic_year')
         form = EventProposalForm(instance=proposal, selected_academic_year=selected_academic_year)
-        # Populate all faculty as available choices for JS search/select on GET
+        # Populate all faculty as available choices for JS search/select on GET.
+        # Include already assigned faculty so their selections remain visible.
+        fac_ids = list(proposal.faculty_incharges.all().values_list('id', flat=True)) if proposal else []
         form.fields['faculty_incharges'].queryset = User.objects.filter(
-            role_assignments__role__name=FACULTY_ROLE
+            Q(role_assignments__role__name=FACULTY_ROLE) | Q(id__in=fac_ids)
         ).distinct()
 
     # Utility to get the display name from ID


### PR DESCRIPTION
## Summary
- keep org type preselected when editing proposals
- ensure faculty in charge selections remain visible on edit
- simplify IQAC dashboard notifications

## Testing
- `python manage.py test --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_688b8febf260832c8636158c91100bda