### PR TITLE
Add attachment preview UI

### DIFF
--- a/emt/static/emt/css/submit_event_report.css
+++ b/emt/static/emt/css/submit_event_report.css
@@ -179,15 +179,63 @@ body {
 .attachment-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 12px;
 }
 
 .attachment-block {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  padding: 16px;
+  position: relative;
+  width: 110px;
+  height: 110px;
+}
+
+.attach-upload {
+  width: 100%;
+  height: 100%;
+  border: 2px dashed var(--border);
   border-radius: 8px;
-  flex: 1 1 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.attach-upload img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.attach-add {
+  font-size: 2rem;
+  color: var(--border);
+}
+
+.attach-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.add-attachment-btn {
+  margin-top: 12px;
+  padding: 8px 16px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
 }
 
 .save-btn {

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -10,6 +10,8 @@ document.addEventListener('DOMContentLoaded', function(){
     posField.readOnly = true;
     posField.style.cursor = 'pointer';
   }
+
+  initAttachments();
 });
 
 function openOutcomeModal(){
@@ -60,3 +62,48 @@ document.getElementById('outcomeSave').onclick = function(){
   field.value = existing + selected.join('\n');
   modal.classList.remove('show');
 };
+
+function initAttachments(){
+  const list = document.getElementById('attachment-list');
+  const addBtn = document.getElementById('add-attachment-btn');
+  const template = document.getElementById('attachment-template');
+  const totalInput = document.querySelector('input[name$="-TOTAL_FORMS"]');
+  if(!list || !addBtn || !template || !totalInput) return;
+
+  function bind(block){
+    const upload = block.querySelector('.attach-upload');
+    const fileInput = block.querySelector('.file-input');
+    const removeBtn = block.querySelector('.attach-remove');
+    upload.addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', () => {
+      if(fileInput.files && fileInput.files[0]){
+        const url = URL.createObjectURL(fileInput.files[0]);
+        upload.innerHTML = `<img src="${url}">`;
+        upload.appendChild(removeBtn);
+        removeBtn.style.display = 'flex';
+      }
+    });
+    removeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      fileInput.value = '';
+      upload.innerHTML = '<span class="attach-add">+</span>';
+      removeBtn.style.display = 'none';
+      const del = block.querySelector('input[name$="-DELETE"]');
+      if(del) del.checked = true;
+    });
+  }
+
+  list.querySelectorAll('.attachment-block').forEach(bind);
+
+  addBtn.addEventListener('click', () => {
+    const idx = +totalInput.value;
+    const html = template.innerHTML.replace(/__prefix__/g, idx);
+    const temp = document.createElement('div');
+    temp.innerHTML = html.trim();
+    const block = temp.firstElementChild;
+    list.appendChild(block);
+    totalInput.value = idx + 1;
+    bind(block);
+    block.querySelector('.file-input').click();
+  });
+}

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -50,17 +50,40 @@
         <div class="section">
           <h3 class="section-title">Upload Attachments</h3>
           {{ formset.management_form }}
-          <div class="attachment-row">
+          <div id="attachment-list" class="attachment-row">
             {% for f in formset %}
-              <div class="attachment-block">
-                {{ f.file.label_tag }} {{ f.file }}
-                {{ f.caption.label_tag }} {{ f.caption }}
+              <div class="attachment-block" data-form-index="{{ forloop.counter0 }}" {% if f.instance.pk %}data-existing="1"{% endif %}>
+                {{ f.id }}
+                <div class="attach-upload">
+                  {% if f.instance.pk %}
+                    <img src="{{ f.instance.file.url }}" alt="attachment">
+                    <span class="attach-remove">&times;</span>
+                  {% else %}
+                    <span class="attach-add">+</span>
+                    <span class="attach-remove" style="display:none;">&times;</span>
+                  {% endif %}
+                </div>
+                {{ f.file.as_widget(attrs={'class':'file-input','style':'display:none;'}) }}
+                {{ f.caption.as_widget(attrs={'style':'display:none;'}) }}
                 {% if f.instance.pk %}
-                  <label>Delete:</label> {{ f.DELETE }}
+                  {{ f.DELETE.as_widget(attrs={'style':'display:none;'}) }}
                 {% endif %}
               </div>
             {% endfor %}
           </div>
+          <button type="button" id="add-attachment-btn" class="add-attachment-btn">Add Attachment</button>
+
+          <template id="attachment-template">
+            <div class="attachment-block" data-form-index="__prefix__">
+              {{ formset.empty_form.id }}
+              <div class="attach-upload">
+                <span class="attach-add">+</span>
+                <span class="attach-remove" style="display:none;">&times;</span>
+              </div>
+              {{ formset.empty_form.file.as_widget(attrs={'class':'file-input','style':'display:none;'}) }}
+              {{ formset.empty_form.caption.as_widget(attrs={'style':'display:none;'}) }}
+            </div>
+          </template>
         </div>
 
         <div class="section">


### PR DESCRIPTION
## Summary
- add dynamic attachment block and template for uploads
- style attachment preview squares with remove button
- implement JS logic to handle previews and new blocks

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b8e967bc4832c8334df4aaa44c904