### PR TITLE
Fix file input template error

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -218,6 +218,10 @@ class EventReportAttachmentForm(forms.ModelForm):
     class Meta:
         model = EventReportAttachment
         fields = ['file', 'caption']
+        widgets = {
+            'file': forms.ClearableFileInput(attrs={'class': 'file-input', 'style': 'display:none;'}),
+            'caption': forms.TextInput(attrs={'style': 'display:none;'}),
+        }
 
 
 class CDLSupportForm(forms.ModelForm):

--- a/emt/static/emt/css/submit_event_report.css
+++ b/emt/static/emt/css/submit_event_report.css
@@ -228,6 +228,11 @@ body {
   cursor: pointer;
 }
 
+/* Hide formset delete checkboxes */
+input[name$="-DELETE"] {
+  display: none;
+}
+
 .add-attachment-btn {
   margin-top: 12px;
   padding: 8px 16px;

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -63,10 +63,10 @@
                     <span class="attach-remove" style="display:none;">&times;</span>
                   {% endif %}
                 </div>
-                {{ f.file.as_widget(attrs={'class':'file-input','style':'display:none;'}) }}
-                {{ f.caption.as_widget(attrs={'style':'display:none;'}) }}
+                {{ f.file }}
+                {{ f.caption }}
                 {% if f.instance.pk %}
-                  {{ f.DELETE.as_widget(attrs={'style':'display:none;'}) }}
+                  {{ f.DELETE }}
                 {% endif %}
               </div>
             {% endfor %}
@@ -80,8 +80,8 @@
                 <span class="attach-add">+</span>
                 <span class="attach-remove" style="display:none;">&times;</span>
               </div>
-              {{ formset.empty_form.file.as_widget(attrs={'class':'file-input','style':'display:none;'}) }}
-              {{ formset.empty_form.caption.as_widget(attrs={'style':'display:none;'}) }}
+              {{ formset.empty_form.file }}
+              {{ formset.empty_form.caption }}
             </div>
           </template>
         </div>


### PR DESCRIPTION
## Summary
- hide formset delete checkbox with CSS
- simplify attachment template fields
- add hidden widgets for attachment form inputs

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b924c12b4832c816eaf17f6f512bb