### PR TITLE
Fix autosave not running on first proposal page

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -157,4 +157,10 @@
       });
     });
   </script>
+  <script>
+    window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
+    window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
+    window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+  </script>
+  <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add client-side autosave variables and script to `submit_proposal.html`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b936421dc832cb4ea65a120b076d9