### PR TITLE
Fix autosave persistence after server save

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -5,11 +5,14 @@ let timeoutId = null;
 const fields = Array.from(document.querySelectorAll('input[name], textarea[name], select[name]'));
 
 // Unique key for this page's local storage
-const pageKey = `proposal_draft_${window.location.pathname}_${proposalId || 'new'}`;
+const pageKey = `proposal_draft_${window.location.pathname}_new`;
 
 // Load any saved draft from localStorage
 try {
     const savedData = JSON.parse(localStorage.getItem(pageKey) || '{}');
+    if (savedData._proposal_id && !proposalId) {
+        proposalId = savedData._proposal_id;
+    }
     fields.forEach(f => {
         if (savedData.hasOwnProperty(f.name) && !f.value) {
             if (f.type === 'checkbox' || f.type === 'radio') {
@@ -42,6 +45,9 @@ function saveLocal() {
             }
         }
     });
+    if (proposalId) {
+        data._proposal_id = proposalId;
+    }
     localStorage.setItem(pageKey, JSON.stringify(data));
 }
 
@@ -74,7 +80,7 @@ function autosaveDraft() {
     .then(data => {
         if (data.success && data.proposal_id) {
             proposalId = data.proposal_id;
-            clearLocal(); // server saved, clear local draft
+            saveLocal(); // persist id with draft
         }
     })
     .catch(() => { /* Optionally show: "Draft Not Saved" */ });

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -157,4 +157,10 @@
       });
     });
   </script>
+  <script>
+    window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
+    window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
+    window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+  </script>
+  <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- store proposal ID in local draft
- keep draft in local storage even after saving to server

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688b936421dc832cb4ea65a120b076d9