### PR TITLE
feat: configure Gemini API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ DEBUG=True
 SECRET_KEY=your-secret-key
 DATABASE_URL=sqlite:///db.sqlite3
 ALLOWED_HOSTS=127.0.0.1,localhost
+# Either set `GEMINI_API_KEY` or `GOOGLE_API_KEY` for Gemini access
 GEMINI_API_KEY=your-gemini-api-key
 ```
 

--- a/emt/utils.py
+++ b/emt/utils.py
@@ -74,9 +74,9 @@ def generate_report_with_ai(event_report):
     Returns:
         The generated report text as a string, or an error message if something goes wrong.
     """
-    api_key = os.getenv("GEMINI_API_KEY")
+    api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
     if not api_key:
-        return "Error: GEMINI_API_KEY is not set in the .env file."
+        return "Error: GEMINI_API_KEY or GOOGLE_API_KEY is not set in the .env file."
 
     api_url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={api_key}"
 

--- a/emt/views.py
+++ b/emt/views.py
@@ -65,8 +65,11 @@ from operator import attrgetter
 # ──────────────────────────────
 # CDL DASHBOARD
 # ──────────────────────────────
-# Configure Gemini API key from environment variable
-genai.configure(api_key=os.environ.get("GEMINI_API_KEY"))
+# Configure Gemini API key from environment variable(s)
+# Prefer `GEMINI_API_KEY`; fall back to `GOOGLE_API_KEY`
+api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+if api_key:
+    genai.configure(api_key=api_key)
 
 @login_required
 def submit_request_view(request):

--- a/test.py
+++ b/test.py
@@ -2,7 +2,9 @@ import google.generativeai as genai
 import os
 
 if __name__ == "__main__":
-    # Configure Gemini API key from environment variable
-    genai.configure(api_key=os.environ.get("GEMINI_API_KEY"))
+    # Configure Gemini API key from environment variables
+    api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+    if api_key:
+        genai.configure(api_key=api_key)
     for model in genai.list_models():
         print(model)


### PR DESCRIPTION
## Summary
- allow Gemini client to load API key from `GEMINI_API_KEY` or `GOOGLE_API_KEY`
- document Gemini API key environment variable

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688d83fc5a60832c8736c6614359bd7b