### PR TITLE
Fix CDL links in admin dashboard sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -160,10 +160,10 @@
           <i class="fas fa-chevron-right expand-icon {% if 'cdl' in request.resolver_match.url_name or '/cdl/' in request.path %}rotated{% endif %}"></i>
         </div>
         <div class="nav-submenu {% if 'cdl' in request.resolver_match.url_name or '/cdl/' in request.path %}open{% endif %}">
-          <a href="/cdl/" class="nav-sublink {% if request.resolver_match.url_name == 'cdl_dashboard' %}active{% endif %}">
+          <a href="{% url 'cdl_dashboard' %}" class="nav-sublink {% if request.resolver_match.url_name == 'cdl_dashboard' %}active{% endif %}">
             <i class="fas fa-clock"></i> Pre-Event
           </a>
-          <a href="/cdl/" class="nav-sublink">
+          <a href="{% url 'cdl_dashboard' %}" class="nav-sublink">
             <i class="fas fa-check-circle"></i> Post-Event
           </a>
         </div>


### PR DESCRIPTION
## Summary
- fix CDL links in admin dashboard sidebar

## Testing
- `python manage.py test` *(fails: Cannot resolve keyword 'role_assignments_rolename_iexact' into field)*

------
https://chatgpt.com/codex/tasks/task_e_688d8f39dd48832c901119f98a5aa081