### PR TITLE
Protect admin dashboard with superuser check

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -161,10 +161,8 @@ def proposal_status(request, pk):
 # ─────────────────────────────────────────────────────────────
 #  Admin Dashboard and User Management
 # ─────────────────────────────────────────────────────────────
+@user_passes_test(lambda u: u.is_superuser)
 def admin_dashboard(request):
-    if not request.user.is_superuser:
-        return redirect("dashboard")
-
     org_stats = (
         RoleAssignment.objects
         .filter(user__is_active=True, organization__isnull=False)


### PR DESCRIPTION
## Summary
- Restrict `/core-admin/dashboard` to superusers using `user_passes_test`
- Remove unconditional redirect that sent non-superusers back to the main dashboard

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688ef2ce3a5c832c90b1ddc4fe2192ae