### PR TITLE
Add role-based login redirect to avoid admin loop

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -1,4 +1,6 @@
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.account.adapter import DefaultAccountAdapter
+from django.urls import reverse
 from django.utils.text import slugify
 from django.contrib.auth.models import User
 from core.models import Profile
@@ -46,3 +48,13 @@ class SchoolSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def login(self, request, sociallogin):
         return super().login(request, sociallogin)
+
+
+class RoleBasedAccountAdapter(DefaultAccountAdapter):
+    """Redirect users based on their role after login."""
+
+    def get_login_redirect_url(self, request):
+        user = request.user
+        if user.is_superuser:
+            return reverse('admin_dashboard')
+        return reverse('dashboard')

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -109,7 +109,7 @@ SITE_ID = 1 # Must match ID in django_site table
 
 
 LOGIN_URL = '/accounts/login/'
-LOGIN_REDIRECT_URL = 'admin_dashboard'  # This should be a URL name, not a path
+LOGIN_REDIRECT_URL = 'dashboard'  # Default redirect after login
 LOGOUT_REDIRECT_URL = '/accounts/login/'
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -122,6 +122,8 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/login/'
 ACCOUNT_LOGOUT_ON_GET = True
+
+ACCOUNT_ADAPTER = 'core.adapters.RoleBasedAccountAdapter'
 
 SOCIALACCOUNT_AUTO_SIGNUP = True
 SOCIALACCOUNT_LOGIN_ON_GET = True


### PR DESCRIPTION
## Summary
- Redirect users after login based on role with custom allauth adapter
- Change default login redirect to the general dashboard

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688ef5206fb4832c8ce431f032ab4d7a