### PR TITLE
Assign role based on email domain

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -21,8 +21,12 @@ class SchoolSocialAccountAdapter(DefaultSocialAccountAdapter):
             except User.DoesNotExist:
                 pass  # No user found, so this will be a new user
 
-        # If new signup, set up default role and profile
-        role = 'student'  # You can add logic for different roles if needed
+        # If new signup, set up role and profile based on email domain.
+        # Any address ending with ``christuniversity.in`` is treated as a
+        # student; everything else defaults to a faculty account.
+        domain = email.split("@")[-1].lower() if email else ""
+        role = "student" if domain.endswith("christuniversity.in") else "faculty"
+
         user = sociallogin.user
         user.save()
         profile, _ = Profile.objects.get_or_create(user=user)

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,8 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.contrib.auth.models import User
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.forms import inlineformset_factory
+from types import SimpleNamespace
 import json
 from .models import (
     OrganizationType,
@@ -8,8 +10,10 @@ from .models import (
     ApprovalFlowTemplate,
     OrganizationRole,
     RoleAssignment,
+    Profile,
 )
 from .views import RoleAssignmentForm, RoleAssignmentFormSet
+from .adapters import SchoolSocialAccountAdapter
 
 
 class OrganizationModelTests(TestCase):
@@ -210,3 +214,38 @@ class ApprovalFlowTemplateDisplayTests(TestCase):
         data = resp.json()
         self.assertTrue(data["success"])
         self.assertEqual(data["steps"][0]["role_display"], "Faculty")
+
+
+class SocialLoginRoleAssignmentTests(TestCase):
+    """Verify role assignment based on email domain during social login."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.adapter = SchoolSocialAccountAdapter()
+
+    def _build_request(self):
+        request = self.factory.get("/")
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        return request
+
+    def _sociallogin(self, email):
+        username = email.split("@")[0]
+        return SimpleNamespace(user=User(username=username, email=email))
+
+    def test_student_email_assigns_student_role(self):
+        request = self._build_request()
+        email = "alen.shibu@bscdsh.christuniversity.in"
+        sociallogin = self._sociallogin(email)
+        self.adapter.pre_social_login(request, sociallogin)
+        profile = Profile.objects.get(user=sociallogin.user)
+        self.assertEqual(profile.role, "student")
+
+    def test_non_christ_email_assigns_faculty_role(self):
+        request = self._build_request()
+        email = "jane.doe@example.com"
+        sociallogin = self._sociallogin(email)
+        self.adapter.pre_social_login(request, sociallogin)
+        profile = Profile.objects.get(user=sociallogin.user)
+        self.assertEqual(profile.role, "faculty")


### PR DESCRIPTION
## Summary
- Assign new social login users to `student` role when their email ends with `christuniversity.in`, otherwise set role to `faculty`
- Added tests verifying role assignment for Christ University and non-Christ emails

## Testing
- `python manage.py test core.tests.SocialLoginRoleAssignmentTests -v 2`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688ef95f6fe4832cae2c9f674d406f06