### PR TITLE
Fix role assignment by email domain

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -24,11 +24,16 @@ def create_or_update_user_profile(sender, instance, created, **kwargs):
 def assign_role_on_login(sender, user, request, **kwargs):
     """Assign either the faculty or student role based on the email address."""
     email = (user.email or "").lower()
-    role = "faculty"
-    if any(keyword in email for keyword in ["student", "stud."]):
-        role = "student"
+    # Determine role purely based on email domain.
+    # Any address ending with ``christuniversity.in`` is a student account;
+    # everything else defaults to faculty.
+    domain = email.split("@")[-1]
+    role = "student" if domain.endswith("christuniversity.in") else "faculty"
 
     profile, _ = Profile.objects.get_or_create(user=user)
     if profile.role != role:
         profile.role = role
         profile.save()
+    # Store the role in the session for downstream views if available.
+    if request is not None:
+        request.session['role'] = role

--- a/core/tests.py
+++ b/core/tests.py
@@ -28,7 +28,7 @@ class OrganizationModelTests(TestCase):
 class UserRoleAssignmentTests(TestCase):
     def test_student_role_assigned_by_email(self):
         user = User.objects.create_user(
-            username="stud", email="stud1@student.example.com", password="pass"
+            username="stud", email="stud1@dept.christuniversity.in", password="pass"
         )
         self.client.login(username="stud", password="pass")
         user.refresh_from_db()
@@ -45,7 +45,7 @@ class UserRoleAssignmentTests(TestCase):
     def test_api_auth_me_returns_profile_role(self):
         user = User.objects.create_user(
             username="stud2",
-            email="stud2@student.example.com",
+            email="stud2@dept.christuniversity.in",
             password="pass",
             first_name="Stu",
             last_name="Dent",


### PR DESCRIPTION
## Summary
- Ensure user role is determined by email domain on login
- Update tests to cover christuniversity.in domain logic

## Testing
- `python manage.py test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688efd7d8884832c8ecffd0a9feb9391