### PR TITLE
feat: allow script injection in base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -539,9 +539,9 @@
         if (notificationDropdown && !e.target.closest('.notification-section')) {
           notificationDropdown.classList.remove('active');
         }
-      });
     });
+  });
   </script>
-
-</body>
-</html>
+  {% block scripts %}{% endblock %}
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add a `{% block scripts %}` in `base.html` so child templates can include extra JS
- confirm submit proposal page loads jQuery, TomSelect and proposal dashboard scripts

## Testing
- `python manage.py test`
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE','iqac_project.settings')
django.setup()
from django.contrib.auth.models import User
from django.test import Client
u,_=User.objects.get_or_create(username='tester',defaults={'email':'tester@example.com'})
client=Client(); client.force_login(u)
resp=client.get('/suite/submit/',HTTP_HOST='localhost')
print('status',resp.status_code)
html=resp.content.decode()
print('jquery snippet present', 'jquery.min.js' in html)
print('tom-select snippet present', 'tom-select.complete.min.js' in html)
print('proposal_dashboard snippet present', 'proposal_dashboard.js' in html)
PY`

------
https://chatgpt.com/codex/tasks/task_e_688f09481534832cbbd85101fd3ad788