### PR TITLE
feat: add user dashboard routing

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -15,7 +15,8 @@ urlpatterns = [
     # ────────────────────────────────────────────────
     # General Dashboard and Proposal Views
     # ────────────────────────────────────────────────
-    path('', views.dashboard, name='dashboard'),
+    # Landing page now shows the unified user dashboard for students and faculty
+    path('', views.user_dashboard, name='dashboard'),
     path('cdl/', views.cdl_dashboard, name='cdl_dashboard'),
     path('propose-event/', views.propose_event, name='propose_event'),
     path('proposal-status/<int:pk>/', views.proposal_status, name='proposal_status'),
@@ -101,6 +102,8 @@ urlpatterns = [
     # APIs
     # ────────────────────────────────────────────────
     path('core-admin/api/auth/me', views.api_auth_me, name='api_auth_me'),
+    # Public API endpoint used by the user dashboard to fetch profile info
+    path('api/auth/me', views.api_auth_me, name='user_api_auth_me'),
     path('core-admin/api/faculty/overview', views.api_faculty_overview, name='api_faculty_overview'),
     path('core-admin/api/approval-flow/<int:org_id>/', views.api_approval_flow_steps, name='api_approval_flow_steps'),
     path('core-admin/api/search-users/', views.search_users, name='search_users'),

--- a/core/views.py
+++ b/core/views.py
@@ -1338,7 +1338,14 @@ def api_faculty_overview(request):
 
 @login_required
 def user_dashboard(request):
-    # Do NOT render the admin dashboard here!
+    """Render the dashboard for non-admin users.
+
+    Superusers already have a dedicated admin dashboard; if one logs in
+    and somehow hits this view, redirect them to the admin dashboard to
+    avoid showing the regular user interface.
+    """
+    if request.user.is_superuser:
+        return redirect('admin_dashboard')
     return render(request, 'core/user_dashboard.html')
 
 # --------------------- Global Search API Endpoint ----------------------

--- a/static/core/js/user_dashboard.js
+++ b/static/core/js/user_dashboard.js
@@ -115,6 +115,10 @@ function renderAchievementStats(stats) { /* ... */ }
 function renderAchievementsList(achievements) { /* ... */ }
 function renderPeerAchievements(peers) { /* ... */ }
 
-document.querySelector('.graph-icon').addEventListener('click', function() {
-    window.location.href = '/dashboard/';
-});
+// Optional link back to landing page if a graph icon exists
+const graphIcon = document.querySelector('.graph-icon');
+if (graphIcon) {
+    graphIcon.addEventListener('click', function() {
+        window.location.href = '/';
+    });
+}


### PR DESCRIPTION
## Summary
- show unified student/faculty dashboard after login instead of welcome screen
- expose `/api/auth/me` for dashboard profile fetch
- redirect superusers to admin dashboard and tidy user dashboard JS navigation

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f1a920148832c822df29160f87860