### PR TITLE
Show role-specific dashboards for students and faculty

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -113,5 +113,4 @@ urlpatterns = [
     # ────────────────────────────────────────────────
     # Optional: User Dashboard (if not admin)
     # ────────────────────────────────────────────────
-    # path('dashboard/', views.user_dashboard, name='user_dashboard'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -92,22 +92,13 @@ def custom_logout(request):
 # ─────────────────────────────────────────────────────────────
 @login_required
 def dashboard(request):
-    proposals = (
-        EventProposal.objects
-        .filter(submitted_by=request.user)
-        .exclude(status="completed")
-        .order_by("-created_at")
-    )
-    other_notifications = [
-        {"type": "info",     "msg": "System update scheduled for tonight at 10 PM.", "time": "2 hours ago"},
-        {"type": "reminder", "msg": "Submit your event report before 26 June.",      "time": "1 day ago"},
-        {"type": "alert",    "msg": "One of your proposals was returned.",           "time": "5 mins ago"},
-    ]
-    return render(
-        request,
-        "core/dashboard.html",
-        {"proposals": proposals, "notifications": other_notifications},
-    )
+    """Render the appropriate dashboard based on the user's role."""
+    role = request.session.get("role")
+    if role and role.lower() == "student":
+        template = "core/student_dashboard.html"
+    else:
+        template = "core/faculty_dashboard.html"
+    return render(request, template)
 
 @login_required
 def propose_event(request):
@@ -1336,10 +1327,6 @@ def api_faculty_overview(request):
     ]
     return JsonResponse(stats, safe=False)
 
-@login_required
-def user_dashboard(request):
-    # Do NOT render the admin dashboard here!
-    return render(request, 'core/user_dashboard.html')
 
 # --------------------- Global Search API Endpoint ----------------------
 

--- a/templates/core/dashboard.html
+++ b/templates/core/dashboard.html
@@ -18,61 +18,11 @@
       IQAC Suite <span class="dash-and">&amp;</span> Transcript Automater
     </h1>
     <p class="dash-greet">
-      Welcome ({{ request.user.profile.get_role_display }})&nbsp;<strong>{{ request.user.get_full_name|default:request.user.username|upper }}</strong>!&nbsp;
-      Pick an application to get started:
+      Welcome ({{ request.user.profile.get_role_display }})&nbsp;<strong>{{ request.user.get_full_name|default:request.user.username|upper }}</strong>!
     </p>
   </section>
 
-  <!-- APP CARDS - Material List Tiles Style (All Blue Theme) -->
-  <section class="dash-apps">
-    <!-- Card 1: IQAC Suite - Blue Theme -->
-    <a href="{% url 'emt:iqac_suite_dashboard' %}" class="material-list-tile blue-theme">
-      <div class="material-list-leading">
-        <div class="material-list-icon">
-          <i class="fa-solid fa-file-lines"></i>
-        </div>
-      </div>
-      <div class="material-list-content">
-        <div class="material-list-primary">IQAC Suite</div>
-        <div class="material-list-secondary">Submit event proposals, track approvals, and generate reports.</div>
-      </div>
-      <div class="material-list-trailing">
-        <i class="fa-solid fa-arrow-right material-list-arrow"></i>
-      </div>
-    </a>
-
-    <!-- Card 2: Graduate Transcript - Blue Theme -->
-    <a href="{% url 'transcript:home' %}" class="material-list-tile blue-theme">
-      <div class="material-list-leading">
-        <div class="material-list-icon">
-          <i class="fa-solid fa-graduation-cap"></i>
-        </div>
-      </div>
-      <div class="material-list-content">
-        <div class="material-list-primary">Graduate Transcript</div>
-        <div class="material-list-secondary">Generate character strength transcript reports. For students.</div>
-      </div>
-      <div class="material-list-trailing">
-        <i class="fa-solid fa-arrow-right material-list-arrow"></i>
-      </div>
-    </a>
-
-    <!-- Card 3: CDL - Blue Theme -->
-    <a href="{% url 'cdl_dashboard' %}" class="material-list-tile blue-theme">
-      <div class="material-list-leading">
-        <div class="material-list-icon">
-          <i class="fa-solid fa-camera"></i>
-        </div>
-      </div>
-      <div class="material-list-content">
-        <div class="material-list-primary">CDL</div>
-        <div class="material-list-secondary">Request media content creation and approval. For marketing and communications.</div>
-      </div>
-      <div class="material-list-trailing">
-        <i class="fa-solid fa-arrow-right material-list-arrow"></i>
-      </div>
-    </a>
-  </section>
+  <!-- Application cards removed to show direct user dashboard -->
 
 </div>
 {% endblock %}

--- a/templates/core/faculty_dashboard.html
+++ b/templates/core/faculty_dashboard.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Dashboard - CHRIST University</title>
+    <link rel="stylesheet" href="{% static 'core/css/user_dashboard.css' %}">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <!-- Header -->
+    <header class="header">
+        <div class="header-content">
+            <div class="logo">
+                <div class="logo-icon">C</div>
+                <span class="logo-text">CHRIST University</span>
+            </div>
+            <div class="header-right">
+                <div class="notification-btn" id="notificationBtn">
+                    <i class="fas fa-bell"></i>
+                    <span class="notification-badge" id="notificationCount">0</span>
+                </div>
+                <div class="profile-avatar" id="profileAvatar">U</div>
+            </div>
+        </div>
+    </header>
+
+    <!-- Welcome Banner -->
+    <div class="welcome-banner">
+        <div class="banner-content">
+            <h1 id="welcomeTitle">Welcome!</h1>
+            <p id="welcomeSubtitle"></p>
+        </div>
+    </div>
+
+    <!-- Navigation Tabs -->
+    <nav class="nav-tabs">
+        <div class="nav-content">
+            <button class="nav-tab active" data-tab="overview">
+                <i class="fas fa-chart-line"></i>
+                <span>Overview</span>
+            </button>
+            <button class="nav-tab" data-tab="events">
+                <i class="fas fa-calendar"></i>
+                <span>My Events</span>
+            </button>
+            <button class="nav-tab" data-tab="students">
+                <i class="fas fa-users"></i>
+                <span>My Students</span>
+            </button>
+            <button class="nav-tab" data-tab="profile">
+                <i class="fas fa-user"></i>
+                <span>My Profile</span>
+            </button>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Overview Tab -->
+        <div id="overview" class="tab-content active">
+            <div class="stats-grid" id="statsGrid"></div>
+            <div class="mentees-section" id="menteesSection"></div>
+        </div>
+
+        <!-- Events Tab -->
+        <div id="events" class="tab-content">
+            <div class="filters-section" id="eventsFilters"></div>
+            <div class="events-section" id="facultyEventsSection"></div>
+        </div>
+
+        <!-- Students Tab -->
+        <div id="students" class="tab-content">
+            <div class="search-section" id="studentsSearch"></div>
+            <div class="students-section" id="studentsList"></div>
+        </div>
+
+        <!-- Profile Tab -->
+        <div id="profile" class="tab-content">
+            <div class="profile-section" id="profileHeader"></div>
+            <div class="classes-section" id="classesSection"></div>
+            <div class="profile-grid" id="facultyProfileGrid"></div>
+        </div>
+    </main>
+
+    <!-- Floating Action Button -->
+    <div class="fab">
+        <button class="fab-btn" id="fabBtn">
+            <i class="fas fa-plus"></i>
+        </button>
+    </div>
+
+    <!-- Notification Modal -->
+    <div class="notification-modal" id="notificationModal">
+        <div class="notification-content">
+            <div class="notification-header">
+                <h3>📢 Notifications</h3>
+                <button class="close-btn" id="closeNotificationBtn">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="notification-list" id="notificationList"></div>
+        </div>
+    </div>
+
+    <script src="{% static 'core/js/user_dashboard.js' %}"></script>
+</body>
+</html>

--- a/templates/core/student_dashboard.html
+++ b/templates/core/student_dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>User Dashboard - CHRIST University</title>
-    <link rel="stylesheet" href="{% static 'core/user_dashboard.css' %}">
+    <link rel="stylesheet" href="{% static 'core/css/user_dashboard.css' %}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
@@ -44,11 +44,7 @@
                 <i class="fas fa-calendar"></i>
                 <span>My Events</span>
             </button>
-            <button class="nav-tab faculty-only" data-tab="students">
-                <i class="fas fa-users"></i>
-                <span>My Students</span>
-            </button>
-            <button class="nav-tab student-only" data-tab="achievements">
+            <button class="nav-tab" data-tab="achievements">
                 <i class="fas fa-trophy"></i>
                 <span>Achievements</span>
             </button>
@@ -64,26 +60,18 @@
         <!-- Overview Tab -->
         <div id="overview" class="tab-content active">
             <div class="stats-grid" id="statsGrid"></div>
-            <div class="mentees-section faculty-only" id="menteesSection"></div>
-            <div class="attributes-section student-only" id="attributesSection"></div>
-            <div class="remarks-section student-only" id="remarksSection"></div>
+            <div class="attributes-section" id="attributesSection"></div>
+            <div class="remarks-section" id="remarksSection"></div>
         </div>
 
         <!-- Events Tab -->
         <div id="events" class="tab-content">
             <div class="filters-section" id="eventsFilters"></div>
-            <div class="events-section faculty-only" id="facultyEventsSection"></div>
-            <div class="events-section student-only" id="studentEventsSection"></div>
+            <div class="events-section" id="studentEventsSection"></div>
         </div>
 
-        <!-- Students Tab (Faculty only) -->
-        <div id="students" class="tab-content faculty-only">
-            <div class="search-section" id="studentsSearch"></div>
-            <div class="students-section" id="studentsList"></div>
-        </div>
-
-        <!-- Achievements Tab (Student only) -->
-        <div id="achievements" class="tab-content student-only">
+        <!-- Achievements Tab -->
+        <div id="achievements" class="tab-content">
             <div class="achievement-stats" id="achievementStats"></div>
             <div class="filters-section" id="achievementsFilters"></div>
             <div class="achievements-section" id="achievementsList"></div>
@@ -93,13 +81,11 @@
         <!-- Profile Tab -->
         <div id="profile" class="tab-content">
             <div class="profile-section" id="profileHeader"></div>
-            <div class="classes-section faculty-only" id="classesSection"></div>
-            <div class="contributions-section student-only" id="contributionsSection"></div>
-            <div class="clubs-section student-only" id="clubsSection"></div>
-            <div class="timeline-section student-only" id="timelineSection"></div>
-            <div class="academic-section student-only" id="academicSection"></div>
-            <div class="mentor-section student-only" id="mentorSection"></div>
-            <div class="profile-grid faculty-only" id="facultyProfileGrid"></div>
+            <div class="contributions-section" id="contributionsSection"></div>
+            <div class="clubs-section" id="clubsSection"></div>
+            <div class="timeline-section" id="timelineSection"></div>
+            <div class="academic-section" id="academicSection"></div>
+            <div class="mentor-section" id="mentorSection"></div>
         </div>
     </main>
 
@@ -123,6 +109,6 @@
         </div>
     </div>
 
-    <script src="{% static 'core/user_dashboard.js' %}"></script>
+    <script src="{% static 'core/js/user_dashboard.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace generic dashboard view with role-aware version that renders student or faculty dashboard
- Add separate `student_dashboard.html` and `faculty_dashboard.html` templates
- Remove old application selection cards from dashboard

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f20249554832cbd3e90bea57cbc12