### PR TITLE
Add role-based dashboard and sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -144,15 +144,18 @@
         </div>
       </div>
 
-      <!-- Graduate Transcript - Standalone -->
+      <!-- Graduate Transcript - Standalone (Superuser only) -->
+      {% if user.is_superuser %}
       <div class="nav-item">
         <a href="/transcript/" class="nav-link {% if request.resolver_match.namespace == 'transcript' or 'transcript' in request.resolver_match.url_name or '/transcript/' in request.path %}active{% endif %}">
           <i class="fas fa-graduation-cap nav-icon"></i>
           <span class="nav-text">Graduate Transcript</span>
         </a>
       </div>
+      {% endif %}
 
-      <!-- CDL - Expandable -->
+      <!-- CDL - Expandable (Faculty and Superuser) -->
+      {% if user.is_superuser or request.user.groups.filter(name='Faculty').exists %}
       <div class="nav-section {% if 'cdl' in request.resolver_match.url_name or '/cdl/' in request.path %}expanded{% endif %}">
         <div class="nav-section-header">
           <i class="fas fa-photo-video nav-icon"></i>
@@ -168,6 +171,7 @@
           </a>
         </div>
       </div>
+      {% endif %}
 
       <!-- User Management - Expandable (Admin Only) -->
       {% if user.is_superuser or request.session.role == 'admin' %}

--- a/templates/core/dashboard.html
+++ b/templates/core/dashboard.html
@@ -9,24 +9,10 @@
 {% endblock %}
 
 {% block content %}
-<div class="dash-wrap">
-
-  <!-- HERO -->
-  <section class="dash-hero">
-    <h2 class="dash-sub">Welcome&nbsp;to</h2>
-    <h1 class="dash-head">
-      IQAC Suite <span class="dash-and">&amp;</span> Transcript Automater
-    </h1>
-    <p class="dash-greet">
-      Welcome ({{ request.user.profile.get_role_display }})&nbsp;<strong>{{ request.user.get_full_name|default:request.user.username|upper }}</strong>!&nbsp;
-      Pick an application to get started:
-    </p>
-  </section>
-
-  <!-- APP CARDS - Material List Tiles Style (All Blue Theme) -->
+<div class="dashboard-container">
   <section class="dash-apps">
-    <!-- Card 1: IQAC Suite - Blue Theme -->
-    <a href="{% url 'emt:iqac_suite_dashboard' %}" class="material-list-tile blue-theme">
+    <!-- Always visible cards -->
+    <a href="{% url 'emt:iqac_suite_dashboard' %}" class="material-list-tile blue-theme card">
       <div class="material-list-leading">
         <div class="material-list-icon">
           <i class="fa-solid fa-file-lines"></i>
@@ -41,24 +27,38 @@
       </div>
     </a>
 
-    <!-- Card 2: Graduate Transcript - Blue Theme -->
-    <a href="{% url 'transcript:home' %}" class="material-list-tile blue-theme">
+    <a href="{% url 'admin_event_proposals' %}" class="material-list-tile blue-theme card">
       <div class="material-list-leading">
         <div class="material-list-icon">
-          <i class="fa-solid fa-graduation-cap"></i>
+          <i class="fa-solid fa-list"></i>
         </div>
       </div>
       <div class="material-list-content">
-        <div class="material-list-primary">Graduate Transcript</div>
-        <div class="material-list-secondary">Generate character strength transcript reports. For students.</div>
+        <div class="material-list-primary">Event Proposals</div>
+        <div class="material-list-secondary">View and manage your event proposals.</div>
       </div>
       <div class="material-list-trailing">
         <i class="fa-solid fa-arrow-right material-list-arrow"></i>
       </div>
     </a>
 
-    <!-- Card 3: CDL - Blue Theme -->
-    <a href="{% url 'cdl_dashboard' %}" class="material-list-tile blue-theme">
+    <a href="{% url 'admin_reports' %}" class="material-list-tile blue-theme card">
+      <div class="material-list-leading">
+        <div class="material-list-icon">
+          <i class="fa-solid fa-file-alt"></i>
+        </div>
+      </div>
+      <div class="material-list-content">
+        <div class="material-list-primary">Reports</div>
+        <div class="material-list-secondary">Browse generated event reports.</div>
+      </div>
+      <div class="material-list-trailing">
+        <i class="fa-solid fa-arrow-right material-list-arrow"></i>
+      </div>
+    </a>
+
+    {% if user.is_superuser or request.user.groups.filter(name='Faculty').exists %}
+    <a href="{% url 'cdl_dashboard' %}" class="material-list-tile blue-theme card">
       <div class="material-list-leading">
         <div class="material-list-icon">
           <i class="fa-solid fa-camera"></i>
@@ -66,13 +66,30 @@
       </div>
       <div class="material-list-content">
         <div class="material-list-primary">CDL</div>
-        <div class="material-list-secondary">Request media content creation and approval. For marketing and communications.</div>
+        <div class="material-list-secondary">Request media content creation and approval.</div>
       </div>
       <div class="material-list-trailing">
         <i class="fa-solid fa-arrow-right material-list-arrow"></i>
       </div>
     </a>
-  </section>
+    {% endif %}
 
+    {% if user.is_superuser %}
+    <a href="{% url 'transcript:home' %}" class="material-list-tile blue-theme card">
+      <div class="material-list-leading">
+        <div class="material-list-icon">
+          <i class="fa-solid fa-graduation-cap"></i>
+        </div>
+      </div>
+      <div class="material-list-content">
+        <div class="material-list-primary">Graduate Transcript</div>
+        <div class="material-list-secondary">Generate character strength transcript reports.</div>
+      </div>
+      <div class="material-list-trailing">
+        <i class="fa-solid fa-arrow-right material-list-arrow"></i>
+      </div>
+    </a>
+    {% endif %}
+  </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show Graduate Transcript and CDL navigation based on user role
- render dashboard cards per Student, Faculty, or Superuser

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f2c84f068832c9816689f9fe928c2