### PR TITLE
Restrict Event Proposals menu to admin

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -199,13 +199,15 @@
       </div>
       {% endif %}
 
-      <!-- Event Proposals - Standalone -->
+      {% if user.is_superuser or request.session.role == 'admin' %}
+      <!-- Event Proposals - Standalone (Admin Only) -->
       <div class="nav-item">
         <a href="/core-admin/event-proposals/" class="nav-link {% if request.resolver_match.url_name == 'admin_event_proposals' %}active{% endif %}">
           <i class="fas fa-list nav-icon"></i>
           <span class="nav-text">Event Proposals</span>
         </a>
       </div>
+      {% endif %}
 
       <!-- Reports - Standalone (Admin Only) -->
       {% if user.is_superuser or request.session.role == 'admin' %}


### PR DESCRIPTION
## Summary
- hide Event Proposals sidebar link for non-admin roles

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f42d6d568832ca8f36338bfd5e4e1