### PR TITLE
Call build_approval_chain after final proposal submission

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -184,6 +184,7 @@ def submit_proposal(request, pk=None):
             proposal.submitted_at = timezone.now()
             proposal.save()
             form.save_m2m()
+            build_approval_chain(proposal)
             messages.success(
                 request,
                 f"Proposal '{proposal.event_title}' submitted.",


### PR DESCRIPTION
## Summary
- Build approval workflow when a proposal is finally submitted by calling `build_approval_chain`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f448d7344832c98415d524590bc0f