### PR TITLE
Fix missing proposal details on review page

### DIFF
--- a/emt/templates/emt/review_approval_step.html
+++ b/emt/templates/emt/review_approval_step.html
@@ -46,22 +46,38 @@
 
     <div class="fadein-card section-glass">
       <h3>Need Analysis</h3>
-      <div class="detail-block">{{ need_analysis.content|linebreaksbr|default:"—" }}</div>
+      {% if need_analysis %}
+        <div class="detail-block">{{ need_analysis.content|linebreaksbr }}</div>
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Objectives</h3>
-      <div class="detail-block">{{ objectives.content|linebreaksbr|default:"—" }}</div>
+      {% if objectives %}
+        <div class="detail-block">{{ objectives.content|linebreaksbr }}</div>
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Expected Outcomes</h3>
-      <div class="detail-block">{{ outcomes.content|linebreaksbr|default:"—" }}</div>
+      {% if outcomes %}
+        <div class="detail-block">{{ outcomes.content|linebreaksbr }}</div>
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Tentative Flow</h3>
-      <div class="detail-block">{{ flow.content|linebreaksbr|default:"—" }}</div>
+      {% if flow %}
+        <div class="detail-block">{{ flow.content|linebreaksbr }}</div>
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
     </div>
 
     <div class="fadein-card section-glass">

--- a/emt/views.py
+++ b/emt/views.py
@@ -607,11 +607,11 @@ def review_approval_step(request, step_id):
     step = get_object_or_404(ApprovalStep, id=step_id, assigned_to=request.user)
     proposal = step.proposal
 
-    # Fetch related proposal details using the proper `related_name`
-    need_analysis = getattr(proposal, "need_analysis", None)
-    objectives = getattr(proposal, "objectives", None)
-    outcomes = getattr(proposal, "expected_outcomes", None)
-    flow = getattr(proposal, "tentative_flow", None)
+    # Fetch related proposal details using safe lookups
+    need_analysis = EventNeedAnalysis.objects.filter(proposal=proposal).first()
+    objectives = EventObjectives.objects.filter(proposal=proposal).first()
+    outcomes = EventExpectedOutcomes.objects.filter(proposal=proposal).first()
+    flow = TentativeFlow.objects.filter(proposal=proposal).first()
     speakers = SpeakerProfile.objects.filter(proposal=proposal)
     expenses = ExpenseDetail.objects.filter(proposal=proposal)
 


### PR DESCRIPTION
## Summary
- Ensure event proposal review view loads Need Analysis, Objectives, Expected Outcomes, and Tentative Flow via safe queries
- Render those sections in template only when data exists

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f4ac6be54832c8ca2a3f2796fef30