### PR TITLE
fix: prevent sidebar overlap on mobile

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -701,7 +701,15 @@ body.command-center-layout {
     left: 0;
     box-shadow: var(--shadow-lg);
   }
-  
+
+  .main-content {
+    transition: margin-left 0.3s ease;
+  }
+
+  .left-control-panel.mobile-open + .main-content {
+    margin-left: var(--sidebar-width);
+  }
+
   .utility-center {
     display: none;
   }

--- a/static/core/css/command-center.css
+++ b/static/core/css/command-center.css
@@ -684,7 +684,15 @@
       left: 0 !important;
       box-shadow: var(--shadow-lg) !important;
     }
-    
+
+    .main-content {
+      transition: margin-left 0.3s ease !important;
+    }
+
+    .left-control-panel.mobile-open + .main-content {
+      margin-left: var(--sidebar-width) !important;
+    }
+
     .utility-center {
       display: none !important;
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -253,7 +253,7 @@
   </div>
 
   <!-- ZONE 3: MAIN VIEWSCREEN -->
-  <div class="main-viewscreen">
+  <div class="main-viewscreen main-content">
     <div class="viewscreen-content">
       {% block content %}
       <div class="welcome-screen">


### PR DESCRIPTION
## Summary
- shift main content when sidebar is opened so it no longer overlaps

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f6d836290832ca3755cbf33d890d1