### PR TITLE
Fix sidebar overlap on Event Proposal page

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -74,6 +74,23 @@ body {
   overflow-y: auto;
 }
 
+/* Event Proposal page layout fix */
+.event-form-wrapper {
+  margin-left: var(--sidebar-width);
+  padding: 2rem;
+}
+
+.event-form-wrapper .dashboard-container {
+  padding: 0;
+}
+
+@media (max-width: 768px) {
+  .event-form-wrapper {
+    margin-left: 0;
+    padding: 1rem;
+  }
+}
+
 /* ===== HEADER ===== */
 .dashboard-header {
   text-align: center;

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block content %}
+<div class="event-form-wrapper">
 <div class="dashboard-container" id="dashboard-container">
     <div class="dashboard-header">
         <h1>Event Proposal Dashboard</h1>
@@ -238,6 +239,8 @@
     <div class="autosave-indicator" id="autosave-indicator">
         <span class="indicator-text">Saved</span>
     </div>
+
+</div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap Event Proposal form content in `.event-form-wrapper`
- apply responsive left margin matching sidebar width

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f6ff26d90832c80c7f8fa5602b22d