### PR TITLE
Fix Event Proposal panel overlap with sidebar

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -65,30 +65,38 @@ body {
 }
 
 .dashboard-container.split-view {
-  padding: 1rem;
-  width: 50%;
-  position: fixed;
-  left: 0;
-  top: 170px;
-  height: calc(100vh - 170px);
-  overflow-y: auto;
+    padding: 1rem;
+    width: 50%;
+    position: fixed;
+    left: 260px;
+    top: 170px;
+    height: calc(100vh - 170px);
+    overflow-y: auto;
 }
 
 /* Event Proposal page layout fix */
-.event-form-wrapper {
-  margin-left: var(--sidebar-width);
-  padding: 2rem;
+.event-dashboard-container {
+    display: flex;
+    margin-left: 260px;
+    gap: 2rem;
+    padding: 2rem;
 }
 
-.event-form-wrapper .dashboard-container {
-  padding: 0;
+.event-dashboard-container .dashboard-container {
+    padding: 0;
 }
 
 @media (max-width: 768px) {
-  .event-form-wrapper {
-    margin-left: 0;
-    padding: 1rem;
-  }
+    .dashboard-container.split-view {
+        left: 0;
+        width: 100%;
+    }
+
+    .event-dashboard-container {
+        margin-left: 0;
+        flex-direction: column;
+        padding: 1rem;
+    }
 }
 
 /* ===== HEADER ===== */

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="event-form-wrapper">
+<div class="event-dashboard-container">
 <div class="dashboard-container" id="dashboard-container">
     <div class="dashboard-header">
         <h1>Event Proposal Dashboard</h1>
@@ -217,6 +217,7 @@
             </div>
         </div>
     </form>
+</div>
 
     <!-- Form Panel (Right Side) -->
     <div class="form-panel" id="form-panel">
@@ -239,8 +240,6 @@
     <div class="autosave-indicator" id="autosave-indicator">
         <span class="indicator-text">Saved</span>
     </div>
-
-</div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- offset split-view panel from sidebar and add responsive event dashboard wrapper

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f72e9f628832c9b7c725bf809a253