### PR TITLE
Honor user overrides for approval card visibility

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -849,8 +849,6 @@ def suite_dashboard(request):
     for ra in ras:
         role_vis = getattr(ra.role, "approval_visibility", None)
         can_view = role_vis.can_view if role_vis else True
-        if not can_view:
-            continue
         user_override = UserEventApprovalVisibility.objects.filter(
             user=request.user, role=ra.role
         ).first()


### PR DESCRIPTION
## Summary
- Always consider per-user `UserEventApprovalVisibility` when deciding to show the Event Approvals dashboard card, even if the role-level visibility is disabled

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f85045b80832cbc79e6c4b109a3d5