### PR TITLE
Show sponsorship income on event review page

### DIFF
--- a/emt/templates/emt/review_approval_step.html
+++ b/emt/templates/emt/review_approval_step.html
@@ -118,7 +118,7 @@
               </tr>
             </thead>
             <tbody>
-              {% if proposal.fest_fee_participants or proposal.fest_fee_rate or proposal.fest_fee_amount %}
+              {% if proposal.fest_fee_participants or proposal.fest_fee_rate or proposal.fest_fee_amount or proposal.fest_sponsorship_amount %}
                 <tr>
                   <td>1</td>
                   <td>Participation Fee [Fest]</td>
@@ -133,7 +133,7 @@
                   <td>{{ proposal.fest_sponsorship_amount|default:"—" }}</td>
                 </tr>
               {% endif %}
-              {% if proposal.conf_fee_participants or proposal.conf_fee_rate or proposal.conf_fee_amount %}
+              {% if proposal.conf_fee_participants or proposal.conf_fee_rate or proposal.conf_fee_amount or proposal.conf_sponsorship_amount %}
                 <tr>
                   <td>3</td>
                   <td>Participation Fee [Conference]</td>


### PR DESCRIPTION
## Summary
- Ensure income table displays when only sponsorship amounts are provided by updating conditions in event review template.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f9ccc7844832cb5399ab353d1e7f0