### PR TITLE
Fix header overlap with flash messages

### DIFF
--- a/static/core/css/command-center.css
+++ b/static/core/css/command-center.css
@@ -444,9 +444,9 @@
      FLASH MESSAGES
      ============================================================================= */
   .messages {
-    position: sticky !important;
-    top: 0 !important;
-    z-index: 50 !important;
+    position: relative !important;
+    z-index: 2000 !important;
+    margin-top: var(--topbar-height);
     margin-bottom: 1rem !important;
   }
 


### PR DESCRIPTION
## Summary
- prevent flash messages from sitting under fixed top header by offsetting them

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688fc83529b8832c9ec6d84de4f013f2