### PR TITLE
Fix speaker count display in proposal review

### DIFF
--- a/emt/templates/emt/proposal_status_detail.html
+++ b/emt/templates/emt/proposal_status_detail.html
@@ -18,7 +18,7 @@
         {% if proposal.association %}
           <div><span class="label">Association:</span> {{ proposal.association.name }}</div>
         {% endif %}
-        <div><span class="label">Speakers:</span> {{ proposal.speakerprofile_set.count }}</div>
+        <div><span class="label">Speakers:</span> {{ proposal.speakers.count }}</div>
         <div><span class="label">Total Budget:</span> ₹{{ budget_total }}</div>
         <div>
           <span class="label">Current Status:</span>


### PR DESCRIPTION
## Summary
- fix speaker count not appearing by using correct related name

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68904f1ee1e8832ca057d37d2a6df2aa