### PR TITLE
Handle missing related proposal sections

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -623,11 +623,28 @@ def review_approval_step(request, step_id):
         .get(pk=step.proposal_id)
     )
 
-    # Use related attributes directly from the prefetched proposal
-    need_analysis = getattr(proposal, "need_analysis", None)
-    objectives = getattr(proposal, "objectives", None)
-    outcomes = getattr(proposal, "expected_outcomes", None)
-    flow = getattr(proposal, "tentative_flow", None)
+    # Fetch related sections gracefully; some proposals may not have
+    # completed every part yet, so the related objects could be missing.
+    try:
+        need_analysis = proposal.need_analysis
+    except EventNeedAnalysis.DoesNotExist:
+        need_analysis = None
+
+    try:
+        objectives = proposal.objectives
+    except EventObjectives.DoesNotExist:
+        objectives = None
+
+    try:
+        outcomes = proposal.expected_outcomes
+    except EventExpectedOutcomes.DoesNotExist:
+        outcomes = None
+
+    try:
+        flow = proposal.tentative_flow
+    except TentativeFlow.DoesNotExist:
+        flow = None
+
     speakers = proposal.speakers.all()
     expenses = proposal.expense_details.all()
 


### PR DESCRIPTION
## Summary
- avoid crashes when review view loads proposals that are missing optional sections
- safely fetch need analysis, objectives, outcomes, and flow so any available data is rendered

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890511bc62c832c8faaebeba1969a65