### PR TITLE
Use related managers for proposal detail

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -25,10 +25,7 @@ from .models import (
     Class,
     OrganizationRole,
 )
-from emt.models import (
-    EventProposal, EventNeedAnalysis, EventObjectives, EventExpectedOutcomes, TentativeFlow,
-    ExpenseDetail, SpeakerProfile, ApprovalStep, Student
-)
+from emt.models import EventProposal, Student
 from django.views.decorators.http import require_GET, require_POST
 from .models import ApprovalFlowTemplate, ApprovalFlowConfig
 from django.core.exceptions import PermissionDenied
@@ -890,31 +887,14 @@ def admin_master_data_delete(request, model_name, pk):
 
 @user_passes_test(lambda u: u.is_superuser)
 def admin_proposal_detail(request, proposal_id):
-    proposal = get_object_or_404(EventProposal, id=proposal_id)
-    need_analysis = EventNeedAnalysis.objects.filter(proposal=proposal).first()
-    objectives = EventObjectives.objects.filter(proposal=proposal).first()
-    outcomes = EventExpectedOutcomes.objects.filter(proposal=proposal).first()
-    flow = TentativeFlow.objects.filter(proposal=proposal).first()
-    speakers = SpeakerProfile.objects.filter(proposal=proposal)
-    expenses = ExpenseDetail.objects.filter(proposal=proposal)
-    approval_steps = ApprovalStep.objects.filter(proposal=proposal).order_by('step_order')
-    # Sum the "amount" field from each expense entry to calculate the total
-    # budget. Using "total" as the aggregate key avoids clashes with any model
-    # field names while still providing a descriptive context variable.
-    budget_total = expenses.aggregate(total=Sum("amount"))['total'] or 0
+    proposal = get_object_or_404(
+        EventProposal.objects.select_related("organization").prefetch_related(
+            "faculty_incharges", "speakers", "expense_details", "approval_steps"
+        ),
+        id=proposal_id,
+    )
 
-    context = {
-        "proposal": proposal,
-        "need_analysis": need_analysis,
-        "objectives": objectives,
-        "outcomes": outcomes,
-        "flow": flow,
-        "speakers": speakers,
-        "expenses": expenses,
-        "approval_steps": approval_steps,
-        "budget_total": budget_total,
-    }
-    return render(request, "core/admin_proposal_detail.html", context)
+    return render(request, "core/admin_proposal_detail.html", {"proposal": proposal})
 
 @user_passes_test(lambda u: u.is_superuser)
 def admin_settings_dashboard(request):

--- a/templates/core/admin_proposal_detail.html
+++ b/templates/core/admin_proposal_detail.html
@@ -46,44 +46,42 @@
 
     <div class="fadein-card section-glass">
       <h3>Need Analysis</h3>
-      <div class="detail-block">{{ need_analysis.content|linebreaksbr|default:"—" }}</div>
+      <div class="detail-block">{{ proposal.need_analysis.content|linebreaksbr|default:"—" }}</div>
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Objectives</h3>
-      <div class="detail-block">{{ objectives.content|linebreaksbr|default:"—" }}</div>
+      <div class="detail-block">{{ proposal.objectives.content|linebreaksbr|default:"—" }}</div>
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Expected Outcomes</h3>
-      <div class="detail-block">{{ outcomes.content|linebreaksbr|default:"—" }}</div>
+      <div class="detail-block">{{ proposal.expected_outcomes.content|linebreaksbr|default:"—" }}</div>
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Tentative Flow</h3>
-      <div class="detail-block">{{ flow.content|linebreaksbr|default:"—" }}</div>
+      <div class="detail-block">{{ proposal.tentative_flow.content|linebreaksbr|default:"—" }}</div>
     </div>
 
     <div class="fadein-card section-glass">
       <h3>Speaker Profile</h3>
-      {% if speakers %}
-        {% for sp in speakers %}
-          <div class="speaker-profile-block">
-            <div>
-              <b>{{ sp.full_name }}</b> <span class="profile-aff">{{ sp.designation }}, {{ sp.affiliation }}</span>
-              {% if sp.photo %}
-                <img src="{{ sp.photo.url }}" class="speaker-photo" alt="Speaker Photo">
-              {% endif %}
-              <div class="profile-meta">
-                <span>{{ sp.contact_email }}</span> &bull; <span>{{ sp.contact_number }}</span>
-              </div>
-              <div class="profile-desc">{{ sp.detailed_profile|default:"—" }}</div>
+      {% for sp in proposal.speakers.all %}
+        <div class="speaker-profile-block">
+          <div>
+            <b>{{ sp.full_name }}</b> <span class="profile-aff">{{ sp.designation }}, {{ sp.affiliation }}</span>
+            {% if sp.photo %}
+              <img src="{{ sp.photo.url }}" class="speaker-photo" alt="Speaker Photo">
+            {% endif %}
+            <div class="profile-meta">
+              <span>{{ sp.contact_email }}</span> &bull; <span>{{ sp.contact_number }}</span>
             </div>
+            <div class="profile-desc">{{ sp.detailed_profile|default:"—" }}</div>
           </div>
-        {% endfor %}
-      {% else %}
+        </div>
+      {% empty %}
         <div class="detail-block">—</div>
-      {% endif %}
+      {% endfor %}
     </div>
 
     <!-- INCOME & EXPENSES SIDE BY SIDE -->
@@ -146,7 +144,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for exp in expenses %}
+              {% for exp in proposal.expense_details.all %}
                 <tr>
                   <td>{{ exp.sl_no }}</td>
                   <td>{{ exp.particulars }}</td>
@@ -168,7 +166,7 @@
       <h3>Approval History</h3>
       <div class="approval-history-ul">
         <ul>
-          {% for hist in approval_steps %}
+              {% for hist in proposal.approval_steps.all %}
             <li>
               <span class="history-role">{{ hist.get_role_required_display }}</span>
               <span class="history-person">


### PR DESCRIPTION
## Summary
- Optimize proposal detail view with select/prefetch related queries
- Use proposal's related managers directly in admin proposal template

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6890580f3dc8832c8421bedf92fcf3ba