### PR TITLE
Persist proposal text sections

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -215,6 +215,11 @@
                     {% endif %}
                 {% endfor %}
             </div>
+        <!-- Hidden fields for additional sections -->
+        <textarea name="need_analysis" id="id_need_analysis"></textarea>
+        <textarea name="objectives" id="id_objectives"></textarea>
+        <textarea name="outcomes" id="id_outcomes"></textarea>
+        <textarea name="flow" id="id_flow"></textarea>
         </div>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- store Need Analysis, Objectives, Outcomes, and Flow text in the proposal autosave and final submission
- add helper to persist these sections and expose hidden fields in dashboard template

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68907a216340832c84a9b3448a67f416