### PR TITLE
Fix faculty incharge selections not being saved

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -354,9 +354,20 @@ $(document).ready(function() {
             console.log('Registered Faculty TomSelect with autosave manager');
         }
 
+        function syncDjangoSelect(values) {
+            // Rebuild hidden Django select with matching <option> elements
+            djangoFacultySelect.empty();
+            (values || []).forEach(val => {
+                const optData = tomselect.options[val];
+                const label = optData ? optData.text : val;
+                djangoFacultySelect.append(new Option(label, val, true, true));
+            });
+            djangoFacultySelect.trigger('change');
+        }
+
         tomselect.on('change', function() {
             const values = tomselect.getValue();
-            djangoFacultySelect.val(values);
+            syncDjangoSelect(values);
             console.log('Faculty select changed:', values);
             clearFieldError($('#faculty-select'));
         });
@@ -364,6 +375,7 @@ $(document).ready(function() {
         const initialValues = djangoFacultySelect.val();
         if (initialValues && initialValues.length) {
             tomselect.setValue(initialValues);
+            syncDjangoSelect(initialValues);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure TomSelect selections for faculty incharges persist by rebuilding hidden Django select options

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689082ba3f50832cbd507ff5d9cafca5