### PR TITLE
Use Django faculty field with TomSelect

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -285,100 +285,38 @@ $(document).ready(function() {
         copyDjangoField('academic_year');
         copyDjangoField('student_coordinators');
         copyDjangoField('num_activities');
-        
-        setupFacultyTomSelect();
+
+        const facultySelect = $('#id_faculty_incharges');
+        if (facultySelect.length && typeof TomSelect !== 'undefined') {
+            const facultyTS = new TomSelect(facultySelect[0], {
+                plugins: ['remove_button'],
+                valueField: 'id',
+                labelField: 'text',
+                searchField: 'text',
+                create: false,
+                load: function(query, callback) {
+                    if (!query.length) return callback();
+
+                    if (window.API_FACULTY) {
+                        fetch(window.API_FACULTY + '?q=' + encodeURIComponent(query))
+                            .then(response => response.json())
+                            .then(callback)
+                            .catch(() => callback());
+                    } else {
+                        callback();
+                    }
+                }
+            });
+
+            $('#faculty-incharges-container').append(facultyTS.$wrapper);
+
+            if (window.AutosaveManager && window.AutosaveManager.registerTomSelect) {
+                window.AutosaveManager.registerTomSelect('id_faculty_incharges', facultyTS);
+                console.log('Registered Faculty TomSelect with autosave manager');
+            }
+        }
     }
     
-    function setupFacultyTomSelect() {
-        const facultySelect = $('#faculty-select');
-        const djangoFacultySelect = $('#django-basic-info [name="faculty_incharges"]');
-
-        if (!facultySelect.length || !djangoFacultySelect.length) {
-             console.log('Faculty select fields not found.');
-             return;
-        }
-
-        const existingOptions = [];
-        djangoFacultySelect.find('option').each(function() {
-            if ($(this).val()) {
-                existingOptions.push({
-                    id: $(this).val(),
-                    text: $(this).text()
-                });
-            }
-        });
-
-        if (typeof TomSelect === 'undefined') {
-            console.log('TomSelect not available, using simple select for faculty.');
-            facultySelect.html(djangoFacultySelect.html());
-            facultySelect.prop('multiple', true);
-            facultySelect.on('change', function() {
-                djangoFacultySelect.val($(this).val());
-            });
-            return;
-        }
-
-        const tomselect = new TomSelect('#faculty-select', {
-            plugins: ['remove_button'],
-            valueField: 'id',
-            labelField: 'text',
-            searchField: 'text',
-            create: false,
-            placeholder: 'Type a faculty name…',
-            maxItems: 10,
-            options: existingOptions,
-            load: function(query, callback) {
-                if (!query.length) return callback();
-                
-                if (window.API_FACULTY) {
-                    fetch(window.API_FACULTY + '?q=' + encodeURIComponent(query))
-                        .then(response => response.json())
-                        .then(data => callback(data))
-                        .catch(() => callback());
-                } else {
-                    // Mock faculty data for testing
-                    const mockFaculty = [
-                        {id: 1, text: 'Dr. John Smith (Computer Science)'},
-                        {id: 2, text: 'Prof. Jane Doe (Mathematics)'},
-                        {id: 3, text: 'Dr. Mike Johnson (Physics)'}
-                    ].filter(item => 
-                        item.text.toLowerCase().includes(query.toLowerCase())
-                    );
-                    callback(mockFaculty);
-                }
-            }
-        });
-        
-        if (window.AutosaveManager && window.AutosaveManager.registerTomSelect) {
-            window.AutosaveManager.registerTomSelect('faculty-select', tomselect);
-            console.log('Registered Faculty TomSelect with autosave manager');
-        }
-
-        function syncDjangoSelect(values) {
-            // Rebuild hidden Django select with matching <option> elements
-            djangoFacultySelect.empty();
-            (values || []).forEach(val => {
-                const optData = tomselect.options[val];
-                const label = optData ? optData.text : val;
-                djangoFacultySelect.append(new Option(label, val, true, true));
-            });
-            djangoFacultySelect.trigger('change');
-        }
-
-        tomselect.on('change', function() {
-            const values = tomselect.getValue();
-            syncDjangoSelect(values);
-            console.log('Faculty select changed:', values);
-            clearFieldError($('#faculty-select'));
-        });
-
-        const initialValues = djangoFacultySelect.val();
-        if (initialValues && initialValues.length) {
-            tomselect.setValue(initialValues);
-            syncDjangoSelect(initialValues);
-        }
-    }
-
     function copyDjangoField(fieldName) {
         const djangoField = $(`#django-basic-info [name="${fieldName}"]`);
         const modernField = $(`#${fieldName.replace(/_/g, '-')}-modern`);
@@ -560,9 +498,8 @@ $(document).ready(function() {
 
                 <div class="form-row full-width">
                     <div class="input-group">
-                        <label for="faculty-select">Faculty Incharges *</label>
-                        <select id="faculty-select" multiple>
-                            </select>
+                        <label for="id_faculty_incharges">Faculty Incharges *</label>
+                        <div id="faculty-incharges-container"></div>
                     </div>
                 </div>
                 
@@ -816,7 +753,7 @@ $(document).ready(function() {
             // Skip fields already handled or special cases
             const id = $(this).attr('id');
             if (
-                id === 'faculty-select' ||
+                id === 'id_faculty_incharges' ||
                 id === 'event-focus-type-modern' ||
                 $(this).closest('.org-specific-field').length ||
                 (id && id.startsWith('org-type'))
@@ -830,7 +767,7 @@ $(document).ready(function() {
         });
         
         // Special check for faculty select (TomSelect)
-        const facultyTomSelect = $('#faculty-select')[0]?.tomselect;
+        const facultyTomSelect = $('#id_faculty_incharges')[0]?.tomselect;
         if (facultyTomSelect && facultyTomSelect.getValue().length === 0) {
             showFieldError(facultyTomSelect.$wrapper, 'At least one Faculty Incharge is required.');
             isValid = false;

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -298,21 +298,6 @@
     orgTS.clearOptions();
   });
 
-  // Faculty dropdown setup (already working)
-  new TomSelect('#faculty-select', {
-    plugins: ['remove_button'],
-    valueField: 'id',
-    labelField: 'text',
-    searchField: 'text',
-    create: false,
-    load: (query, callback) => {
-      if (!query.length) return callback();
-      fetch(window.API_FACULTY + '?q=' + encodeURIComponent(query))
-        .then(r => r.json())
-        .then(callback)
-        .catch(() => callback());
-    }
-  });
 });
 
     </script>


### PR DESCRIPTION
## Summary
- Replace the custom faculty selector with the real `faculty_incharges` form field and expose it in the basic‑info panel
- Initialize TomSelect on `#id_faculty_incharges` and mount its UI into the panel container, eliminating manual sync code
- Remove obsolete inline TomSelect setup for the old `#faculty-select`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689086c3bd54832c8ebaea73b26be0d6