### PR TITLE
Ensure autosave triggers for TomSelect interactions

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -30,13 +30,18 @@ try {
 } catch (e) { /* ignore JSON errors */ }
 
 fields.forEach(field => {
-    field.addEventListener('input', () => {
+    const handler = () => {
         clearTimeout(timeoutId);
         timeoutId = setTimeout(() => {
             autosaveDraft();
             saveLocal();
         }, 1000); // Save after 1 second idle
-    });
+    };
+
+    field.addEventListener('input', handler);
+    if (field.tagName === 'SELECT') {
+        field.addEventListener('change', handler);
+    }
 });
 
 function saveLocal() {

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -305,6 +305,9 @@ $(document).ready(function() {
                     } else {
                         callback();
                     }
+                },
+                onChange: function() {
+                    facultySelect.trigger('change');
                 }
             });
 
@@ -417,7 +420,7 @@ $(document).ready(function() {
                         .catch(() => callback());
                 },
                 onChange: function(value) {
-                    hiddenField.val(value);
+                    hiddenField.val(value).trigger('change');
                     clearFieldError(newSelect);
                 },
                 placeholder: placeholder,


### PR DESCRIPTION
## Summary
- Extend autosave handler to listen for change events on select fields
- Trigger change events on underlying selects when TomSelect selections change to keep autosave in sync

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689089e03b18832cbfd58c17d67728d7