### PR TITLE
Expand faculty role matching in API

### DIFF
--- a/emt/tests.py
+++ b/emt/tests.py
@@ -67,6 +67,28 @@ class FacultyAPITests(TestCase):
         ids = {item["id"] for item in data}
         self.assertIn(user4.id, ids)
 
+    def test_api_faculty_accepts_incharge_variants(self):
+        user5 = User.objects.create(
+            username="f5",
+            first_name="Epsilon",
+            email="epsilon@example.com",
+        )
+        variant_role = OrganizationRole.objects.create(
+            organization=self.org,
+            name="Faculty Incharge",
+        )
+        RoleAssignment.objects.create(
+            user=user5,
+            role=variant_role,
+            organization=self.org,
+        )
+
+        resp = self.client.get(reverse("emt:api_faculty"), {"q": "Epsilon"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(user5.id, ids)
+
 
 class OutcomesAPITests(TestCase):
     def setUp(self):

--- a/emt/views.py
+++ b/emt/views.py
@@ -30,16 +30,6 @@ FACULTY_ROLE = ApprovalStep.Role.FACULTY.value
 DEAN_ROLE = ApprovalStep.Role.DEAN.value
 ACADEMIC_COORDINATOR_ROLE = "academic_coordinator"
 
-# Roles that should appear in the faculty search API
-FACULTY_LIKE_ROLES = [
-    ApprovalStep.Role.FACULTY.value,
-    ApprovalStep.Role.FACULTY_INCHARGE.value,
-    "Faculty",
-    "Faculty In-Charge",
-]
-
-# Fallback profile roles for faculty search when no role assignments exist
-PROFILE_FACULTY_ROLES = ["faculty"]
 from django.contrib import messages
 from django.utils import timezone
 from django.db import models
@@ -583,8 +573,8 @@ def api_faculty(request):
     users = (
         User.objects
             .filter(
-                Q(role_assignments__role__name__in=FACULTY_LIKE_ROLES) |
-                Q(profile__role__in=PROFILE_FACULTY_ROLES)
+                Q(role_assignments__role__name__icontains="faculty") |
+                Q(profile__role__icontains="faculty")
             )
             .filter(
                 Q(first_name__icontains=q) |


### PR DESCRIPTION
## Summary
- simplify `/api/faculty/` role filtering to match any role containing "faculty"
- add test verifying `Faculty Incharge` variant is returned

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6890a08d86bc832c830b59295e4bb6b5