### PR TITLE
Add registration onboarding and role assignment features

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils.text import slugify
 from django.contrib.auth.models import User
 from core.models import Profile
+from emt.models import Student
 
 class SchoolSocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
@@ -61,4 +62,10 @@ class RoleBasedAccountAdapter(DefaultAccountAdapter):
         user = request.user
         if user.is_superuser:
             return reverse('admin_dashboard')
+        try:
+            student = user.student_profile
+        except Student.DoesNotExist:
+            return reverse('registration_form')
+        if not getattr(student, 'registration_number', ''):
+            return reverse('registration_form')
         return reverse('dashboard')

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.db.models import Q
+import json
 
 from .models import RoleAssignment, OrganizationRole, Organization
 
@@ -28,3 +29,33 @@ class RoleAssignmentForm(forms.ModelForm):
             .select_related("organization")
             .order_by("name")
         )
+
+
+class RegistrationForm(forms.Form):
+    """Capture registration number and multiple organization/role pairs."""
+
+    registration_number = forms.CharField(max_length=50)
+    assignments = forms.CharField(widget=forms.HiddenInput(), required=False)
+
+    def clean_assignments(self):
+        data = self.cleaned_data.get("assignments", "")
+        if not data:
+            return []
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError:
+            raise forms.ValidationError("Invalid role assignment data.")
+
+        cleaned = []
+        for item in payload:
+            org_id = item.get("organization")
+            role_id = item.get("role")
+            if not org_id or not role_id:
+                continue
+            # Ensure the IDs exist
+            if not Organization.objects.filter(id=org_id).exists():
+                continue
+            if not OrganizationRole.objects.filter(id=role_id).exists():
+                continue
+            cleaned.append({"organization": org_id, "role": role_id})
+        return cleaned

--- a/core/urls.py
+++ b/core/urls.py
@@ -10,6 +10,8 @@ urlpatterns = [
     path('logout/', views.logout_view, name='logout'),
     path('accounts/logout/', custom_logout, name='account_logout'),
 
+    path('register/', views.registration_form, name='registration_form'),
+
     # ────────────────────────────────────────────────
     # General Dashboard and Proposal Views
     # ────────────────────────────────────────────────
@@ -106,6 +108,9 @@ urlpatterns = [
     # Additional APIs from other branch
     path('api/search/', views.api_global_search, name='api_global_search'),  # (Keep only if needed, else remove duplicate)
     path('admin-dashboard-api/', views.admin_dashboard_api, name='admin_dashboard_api'),
+
+    path('api/organizations/', views.api_organizations, name='api_organizations'),
+    path('api/roles/', views.api_roles, name='api_roles'),
 
     # ────────────────────────────────────────────────
     # Optional: User Dashboard (if not admin)

--- a/static/core/js/registration_autocomplete.js
+++ b/static/core/js/registration_autocomplete.js
@@ -1,0 +1,86 @@
+// Registration form dynamic role assignment with TomSelect
+
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.getElementById('role-assignments');
+  const addBtn = document.getElementById('add-role-btn');
+  const assignmentsInput = document.getElementById('assignments-json');
+  const form = document.getElementById('registrationForm');
+
+  function initRow(row) {
+    const orgSelect = row.querySelector('.organization-select');
+    const roleSelect = row.querySelector('.role-select');
+
+    const orgTom = new TomSelect(orgSelect, {
+      valueField: 'id',
+      labelField: 'text',
+      searchField: 'text',
+      maxOptions: 20,
+      load: function (query, callback) {
+        fetch(`/api/organizations/?q=${encodeURIComponent(query)}`)
+          .then((r) => r.json())
+          .then((data) => callback(data.organizations || []))
+          .catch(() => callback());
+      },
+      onChange: function (value) {
+        roleTom.clear();
+        roleTom.clearOptions();
+        if (!value) return;
+        fetch(`/api/roles/?organization=${value}`)
+          .then((r) => r.json())
+          .then((data) => {
+            roleTom.addOptions(data.roles || []);
+          });
+      },
+    });
+
+    const roleTom = new TomSelect(roleSelect, {
+      valueField: 'id',
+      labelField: 'text',
+      searchField: 'text',
+      maxOptions: 20,
+      load: function (query, callback) {
+        const orgId = orgSelect.value;
+        if (!orgId) return callback();
+        fetch(`/api/roles/?organization=${orgId}&q=${encodeURIComponent(query)}`)
+          .then((r) => r.json())
+          .then((data) => callback(data.roles || []))
+          .catch(() => callback());
+      },
+    });
+  }
+
+  function addRow() {
+    const row = document.createElement('div');
+    row.className = 'assignment-row';
+    row.innerHTML = `
+      <select class="organization-select" placeholder="Organization"></select>
+      <select class="role-select" placeholder="Role"></select>
+    `;
+    container.appendChild(row);
+    initRow(row);
+  }
+
+  if (addBtn) {
+    addBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      addRow();
+    });
+  }
+
+  // Initialize with one row
+  if (container) {
+    addRow();
+  }
+
+  if (form) {
+    form.addEventListener('submit', function () {
+      const data = [];
+      container.querySelectorAll('.assignment-row').forEach((row) => {
+        const org = row.querySelector('.organization-select').value;
+        const role = row.querySelector('.role-select').value;
+        if (org && role) data.push({ organization: org, role: role });
+      });
+      assignmentsInput.value = JSON.stringify(data);
+    });
+  }
+});

--- a/templates/core/Registration_form.html
+++ b/templates/core/Registration_form.html
@@ -1,10 +1,12 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Student Onboarding Form</title>
-    <link rel="stylesheet" href="Registration_form.css">
+    <link rel="stylesheet" href="{% static 'core/css/Registration_form.css' %}">
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet"/>
 </head>
 <body>
     <div class="container">
@@ -14,52 +16,32 @@
         </div>
 
         <div class="form-content">
-            <form id="studentForm">
-                <!-- Required Fields Section -->
+            <form id="registrationForm" method="post">
+                {% csrf_token %}
                 <div class="section">
                     <h2 class="section-title">Required Fields</h2>
-                    
                     <div class="form-group">
-                        <label for="registrationNumber">Registration Number <span class="required">*</span></label>
-                        <input type="text" id="registrationNumber" name="registrationNumber" required>
+                        {{ form.registration_number.label_tag }}
+                        {{ form.registration_number }}
                     </div>
                 </div>
 
-                <!-- Organization Information Section -->
                 <div class="section">
-                    <h2 class="section-title">Organizations you are a part of</h2>
-                    <p class="section-description">(optional, does not have to be filled if you are not a part of any yet)</p>
-                    
-                    <div class="form-group">
-                        <label>Are you part of any organization?</label>
-                        <div class="button-group">
-                            <button type="button" id="orgYesBtn" class="choice-btn">Yes</button>
-                            <button type="button" id="orgNoBtn" class="choice-btn">No</button>
-                        </div>
-                    </div>
-
-                    <div class="conditional-field" id="organizationDetailsField" style="display: none;">
-                        <div class="form-group">
-                            <label for="organizationName">Organization Name</label>
-                            <input type="text" id="organizationName" name="organizationName" placeholder="Enter organization name">
-                        </div>
-
-                        <div class="form-group">
-                            <label for="organizationRole">What role are you assigned in the organization</label>
-                            <input type="text" id="organizationRole" name="organizationRole" placeholder="Enter your role in the organization">
-                        </div>
-                    </div>
+                    <h2 class="section-title">Organizations and Roles</h2>
+                    <p class="section-description">Add any organizations and roles you belong to.</p>
+                    <div id="role-assignments"></div>
+                    <button id="add-role-btn" class="btn btn-secondary" type="button">Add Role</button>
                 </div>
 
-                <!-- Submit Section -->
+                <input type="hidden" id="assignments-json" name="assignments">
                 <div class="submit-section">
                     <button type="submit" class="submit-btn">Submit Application</button>
-                    <button type="reset" class="reset-btn">Clear Form</button>
                 </div>
             </form>
         </div>
     </div>
 
-    <script src="Registration_form.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>
+    <script src="{% static 'core/js/registration_autocomplete.js' %}"></script>
 </body>
 </html>

--- a/templates/core/admin_role_management.html
+++ b/templates/core/admin_role_management.html
@@ -112,7 +112,71 @@
                 </div>
             </div>
         </div>
-        
+
+    {% elif step == 'single_org_roles' %}
+        <!-- Roles and assignments for a single organization -->
+        <div class="card">
+            <div class="card-header bg-info text-white">
+                <div class="d-flex justify-content-between align-items-center">
+                    <h4 class="mb-0">
+                        <i class="fas fa-building"></i> {{ selected_organization.name }} Roles
+                    </h4>
+                    <a href="{% url 'admin_role_management' %}?org_type_id={{ selected_organization.org_type.id }}" class="btn btn-light btn-sm">
+                        <i class="fas fa-arrow-left"></i> Back
+                    </a>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="section-header">
+                    <h5><i class="fas fa-list"></i> Defined Roles</h5>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-bordered table-striped" style="max-width: 900px; margin: 0 auto;">
+                        <thead>
+                            <tr class="text-center">
+                                <th>Role Name</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for role in roles %}
+                            <tr class="text-center">
+                                <td>{{ role.name }}</td>
+                                <td>{% if role.is_active %}<span class="badge badge-primary">Active</span>{% else %}<span class="badge badge-secondary">Inactive</span>{% endif %}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="2" class="text-center">No roles found.</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="section-header mt-4">
+                    <h5><i class="fas fa-users"></i> Current Assignments</h5>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-bordered table-striped" style="max-width: 900px; margin: 0 auto;">
+                        <thead>
+                            <tr class="text-center">
+                                <th>User</th>
+                                <th>Role</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for ra in role_assignments %}
+                            <tr class="text-center">
+                                <td>{{ ra.user.get_full_name|default:ra.user.username }}</td>
+                                <td>{{ ra.role.name }}</td>
+                            </tr>
+                            {% empty %}
+                            <tr><td colspan="2" class="text-center">No assignments found.</td></tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
     {% else %}
         <!-- Show organization types -->
         <div class="card">


### PR DESCRIPTION
## Summary
- add `RegistrationForm` for capturing registration number and role assignments
- provide registration view with organization/role APIs and redirect users without registration number
- list users and their roles in admin role management

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6891b88779c4832c9863d22984102893