### PR TITLE
Improve registration form design and restrict repeat access

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -93,6 +93,10 @@ def custom_logout(request):
 def registration_form(request):
     """Collect registration number and role assignments for a user."""
     student, _ = Student.objects.get_or_create(user=request.user)
+    # Prevent already registered users from accessing the form again
+    if student.registration_number:
+        return redirect("dashboard")
+
     if request.method == "POST":
         form = RegistrationForm(request.POST)
         if form.is_valid():

--- a/static/core/css/Registration_form.css
+++ b/static/core/css/Registration_form.css
@@ -10,17 +10,17 @@ body {
     background-color: #ffffff;
     color: #333;
     line-height: 1.6;
-    padding: 20px;
+    padding: 0;
     min-height: 100vh;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
 }
 
 /* Container */
 .container {
     max-width: 800px;
-    margin: 0 auto;
+    margin: 40px auto;
     background: #ffffff;
     border-radius: 12px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -28,20 +28,46 @@ body {
 }
 
 /* Header */
-.header {
+/* Top Header Bar */
+.top-header {
+    background-color: #2A4B8D;
+    color: #fff;
+    padding: 12px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.logo-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.logo-wrapper .logo {
+    height: 40px;
+}
+
+.logo-wrapper .app-name {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+/* Form Header */
+.form-header {
     background-color: #2A4B8D;
     color: white;
     padding: 32px 24px;
     text-align: center;
 }
 
-.header h1 {
+.form-header h1 {
     font-size: 32px;
     font-weight: 600;
     margin-bottom: 8px;
 }
 
-.header p {
+.form-header p {
     font-size: 16px;
     opacity: 0.9;
 }
@@ -276,11 +302,11 @@ input[type="text"]:hover {
         border-radius: 8px;
     }
     
-    .header {
+    .form-header {
         padding: 24px 16px;
     }
-    
-    .header h1 {
+
+    .form-header h1 {
         font-size: 24px;
     }
     
@@ -304,7 +330,7 @@ input[type="text"]:hover {
 }
 
 @media (max-width: 480px) {
-    .header h1 {
+    .form-header h1 {
         font-size: 20px;
     }
     

--- a/templates/core/Registration_form.html
+++ b/templates/core/Registration_form.html
@@ -9,8 +9,15 @@
     <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet"/>
 </head>
 <body>
+    <header class="top-header">
+        <div class="logo-wrapper">
+            <img src="{% static 'core/img/campus-logo.png' %}" alt="CHRIST University" class="logo">
+            <span class="app-name">Event Management Suite</span>
+        </div>
+    </header>
+
     <div class="container">
-        <div class="header">
+        <div class="form-header">
             <h1>Student Onboarding Form</h1>
             <p>Complete the required fields below</p>
         </div>


### PR DESCRIPTION
## Summary
- add application header and improved styling to registration form
- ensure the registration form is accessible only before a student registers
- tweak layout spacing for cleaner presentation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891c6815bac832cb41dac3d78121675