### PR TITLE
Ask for registration number only for student email addresses

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -62,10 +62,12 @@ class RoleBasedAccountAdapter(DefaultAccountAdapter):
         user = request.user
         if user.is_superuser:
             return reverse('admin_dashboard')
-        try:
-            student = user.student_profile
-        except Student.DoesNotExist:
-            return reverse('registration_form')
-        if not getattr(student, 'registration_number', ''):
-            return reverse('registration_form')
+        domain = user.email.split('@')[-1].lower() if user.email else ''
+        if domain.endswith('christuniversity.in'):
+            try:
+                student = user.student_profile
+            except Student.DoesNotExist:
+                return reverse('registration_form')
+            if not getattr(student, 'registration_number', ''):
+                return reverse('registration_form')
         return reverse('dashboard')

--- a/core/forms.py
+++ b/core/forms.py
@@ -34,8 +34,15 @@ class RoleAssignmentForm(forms.ModelForm):
 class RegistrationForm(forms.Form):
     """Capture registration number and multiple organization/role pairs."""
 
-    registration_number = forms.CharField(max_length=50)
+    registration_number = forms.CharField(max_length=50, required=False)
     assignments = forms.CharField(widget=forms.HiddenInput(), required=False)
+
+    def __init__(self, *args, include_regno=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        if include_regno:
+            self.fields["registration_number"].required = True
+        else:
+            self.fields.pop("registration_number")
 
     def clean_assignments(self):
         data = self.cleaned_data.get("assignments", "")

--- a/templates/core/Registration_form.html
+++ b/templates/core/Registration_form.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Student Onboarding Form</title>
+    <title>{% if is_student %}Student {% endif %}Onboarding Form</title>
     <link rel="stylesheet" href="{% static 'core/css/Registration_form.css' %}">
     <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet"/>
 </head>
@@ -12,13 +12,14 @@
 
     <div class="container">
         <div class="form-header">
-            <h1>Student Onboarding Form</h1>
+            <h1>{% if is_student %}Student {% endif %}Onboarding Form</h1>
             <p>Complete the required fields below</p>
         </div>
 
         <div class="form-content">
             <form id="registrationForm" method="post">
                 {% csrf_token %}
+                {% if is_student %}
                 <div class="section">
                     <h2 class="section-title">Required Fields</h2>
                     <div class="form-group">
@@ -26,6 +27,7 @@
                         {{ form.registration_number }}
                     </div>
                 </div>
+                {% endif %}
 
                 <div class="section">
                     <h2 class="section-title">Organizations and Roles</h2>


### PR DESCRIPTION
## Summary
- Hide registration number field for non-students on the registration form
- Skip redirecting non-students to registration page after login
- Include registration number only for `christuniversity.in` email addresses

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891cb21e68c832cbc3a211a4db1febc