### PR TITLE
Add management command to delete all users

### DIFF
--- a/core/management/commands/delete_all_users.py
+++ b/core/management/commands/delete_all_users.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+
+class Command(BaseCommand):
+    """Delete all user accounts."""
+    help = "Remove all users from the database. Use with caution."
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        count = User.objects.count()
+        User.objects.all().delete()
+        self.stdout.write(self.style.SUCCESS(f"Deleted {count} user(s)."))


### PR DESCRIPTION
## Summary
- Add `delete_all_users` management command to remove all users from the database

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6891d20d1900832c8580b45327b9db45