### PR TITLE
Enforce user registration before access

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -3,7 +3,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from django.urls import reverse
 from django.utils.text import slugify
 from django.contrib.auth.models import User
-from core.models import Profile
+from core.models import Profile, RoleAssignment
 from emt.models import Student
 
 class SchoolSocialAccountAdapter(DefaultSocialAccountAdapter):
@@ -70,4 +70,6 @@ class RoleBasedAccountAdapter(DefaultAccountAdapter):
                 return reverse('registration_form')
             if not getattr(student, 'registration_number', ''):
                 return reverse('registration_form')
+        if not RoleAssignment.objects.filter(user=user).exists():
+            return reverse('registration_form')
         return reverse('dashboard')

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import reverse
+from core.models import RoleAssignment
+from emt.models import Student
+
+
+class RegistrationRequiredMiddleware:
+    """Redirect authenticated users to the registration form until they register."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user = request.user
+        if user.is_authenticated and not user.is_superuser and not self._is_exempt_path(request.path):
+            if not self._user_is_registered(user):
+                return redirect('registration_form')
+        return self.get_response(request)
+
+    def _is_exempt_path(self, path):
+        """Return True if the path should bypass registration enforcement."""
+        exempt_paths = {
+            reverse('registration_form'),
+            reverse('logout'),
+            reverse('login'),
+        }
+        if path in exempt_paths:
+            return True
+        exempt_prefixes = (
+            '/accounts/',
+            '/admin/',
+            '/core-admin/',
+            settings.STATIC_URL,
+            settings.MEDIA_URL,
+        )
+        return any(path.startswith(prefix) for prefix in exempt_prefixes)
+
+    def _user_is_registered(self, user):
+        """Check whether the user has completed registration."""
+        domain = user.email.split('@')[-1].lower() if user.email else ''
+        is_student = domain.endswith('christuniversity.in')
+        if is_student:
+            try:
+                student = user.student_profile
+            except Student.DoesNotExist:
+                return False
+            if not student.registration_number:
+                return False
+        return RoleAssignment.objects.filter(user=user).exists()

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -75,6 +75,8 @@ class ApprovalFlowViewTests(TestCase):
         ot = OrganizationType.objects.create(name="Dept")
         org = Organization.objects.create(name="Math", org_type=ot)
         user = User.objects.create_user("user", "u@x.com", "pass")
+        role = OrganizationRole.objects.create(organization=org, name="Member")
+        RoleAssignment.objects.create(user=user, role=role, organization=org)
         self.client.force_login(user)
 
         resp = self.client.post(
@@ -118,6 +120,8 @@ class SaveApprovalFlowTests(TestCase):
 
     def test_save_approval_flow_forbidden_for_non_superuser(self):
         user = User.objects.create_user("user", "u@x.com", "pass")
+        role = OrganizationRole.objects.create(organization=self.org, name="Member")
+        RoleAssignment.objects.create(user=user, role=role, organization=self.org)
         self.client.force_login(user)
 
         resp = self.client.post(

--- a/core/tests/test_registration.py
+++ b/core/tests/test_registration.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
+from core.models import OrganizationType, Organization, OrganizationRole, RoleAssignment
+
+
+class RegistrationMiddlewareTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="u1", email="u1@example.com", password="pass"
+        )
+        self.client.login(username="u1", password="pass")
+
+    def test_redirects_unregistered_user(self):
+        response = self.client.get(reverse("dashboard"))
+        self.assertRedirects(response, reverse("registration_form"))
+
+    def test_allows_access_after_role_assignment(self):
+        ot = OrganizationType.objects.create(name="Dept")
+        org = Organization.objects.create(name="Math", org_type=ot)
+        role = OrganizationRole.objects.create(name="Member", organization=org)
+        RoleAssignment.objects.create(user=self.user, role=role, organization=org)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)

--- a/emt/tests.py
+++ b/emt/tests.py
@@ -98,6 +98,13 @@ class OutcomesAPITests(TestCase):
         self.po = ProgramOutcome.objects.create(program=program, description="PO1")
         self.pso = ProgramSpecificOutcome.objects.create(program=program, description="PSO1")
         self.user = User.objects.create(username="user")
+        RoleAssignment.objects.create(
+            user=self.user,
+            role=OrganizationRole.objects.create(
+                organization=self.org, name="Member"
+            ),
+            organization=self.org,
+        )
         self.client.force_login(self.user)
 
     def test_api_outcomes_returns_outcomes(self):
@@ -125,6 +132,9 @@ class AutosaveProposalTests(TestCase):
         )
         RoleAssignment.objects.create(
             user=self.f2, role=self.faculty_role, organization=self.org
+        )
+        RoleAssignment.objects.create(
+            user=self.submitter, role=self.faculty_role, organization=self.org
         )
         self.client.force_login(self.submitter)
 
@@ -167,6 +177,20 @@ class EventApprovalsNavTests(TestCase):
     def setUp(self):
         self.faculty = User.objects.create_user("faculty", password="pass")
         self.student = User.objects.create_user("student", password="pass")
+        ot = OrganizationType.objects.create(name="Dept")
+        org = Organization.objects.create(name="Science", org_type=ot)
+        fac_role = OrganizationRole.objects.create(
+            organization=org, name=ApprovalStep.Role.FACULTY.value
+        )
+        student_role = OrganizationRole.objects.create(
+            organization=org, name="Student"
+        )
+        RoleAssignment.objects.create(
+            user=self.faculty, role=fac_role, organization=org
+        )
+        RoleAssignment.objects.create(
+            user=self.student, role=student_role, organization=org
+        )
 
     def _set_role(self, role):
         session = self.client.session

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -57,6 +57,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'allauth.account.middleware.AccountMiddleware',  # ← allauth middleware
+    'core.middleware.RegistrationRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
## Summary
- Redirect authenticated users without role assignments to the registration form via new middleware
- Ensure login flow sends unregistered users to registration before dashboard
- Cover registration enforcement with tests and update existing test fixtures

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6891d5cef970832c9023a4b492b35a3e