### PR TITLE
Allow unregistered users to fetch registration organizations and roles

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -24,6 +24,8 @@ class RegistrationRequiredMiddleware:
             reverse('registration_form'),
             reverse('logout'),
             reverse('login'),
+            reverse('api_organizations'),
+            reverse('api_roles'),
         }
         if path in exempt_paths:
             return True

--- a/core/tests/test_registration.py
+++ b/core/tests/test_registration.py
@@ -22,3 +22,32 @@ class RegistrationMiddlewareTests(TestCase):
         RoleAssignment.objects.create(user=self.user, role=role, organization=org)
         response = self.client.get(reverse("dashboard"))
         self.assertEqual(response.status_code, 200)
+
+
+class RegistrationAPITests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="u2", email="u2@example.com", password="pass"
+        )
+        self.client.login(username="u2", password="pass")
+        self.ot = OrganizationType.objects.create(name="Dept")
+        self.org = Organization.objects.create(name="Science", org_type=self.ot)
+        self.role = OrganizationRole.objects.create(
+            name="Member", organization=self.org
+        )
+
+    def test_api_organizations_accessible(self):
+        response = self.client.get(reverse("api_organizations"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["organizations"]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["text"], self.org.name)
+
+    def test_api_roles_accessible(self):
+        response = self.client.get(
+            reverse("api_roles"), {"organization": self.org.id}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()["roles"]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["text"], self.role.name)


### PR DESCRIPTION
## Summary
- Exempt organization and role APIs from registration middleware
- Add tests confirming unauthenticated registration users can fetch organizations and roles

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6891d81c5f90832c8302e89933a658a2