### PR TITLE
feat: add toast notifications

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -732,3 +732,51 @@ body.command-center-layout {
     padding: 1rem;
   }
 }
+
+/* Toast messages */
+.toast-container {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 9999;
+}
+
+.toast-message {
+  min-width: 240px;
+  background: var(--gray-800);
+  color: var(--white);
+  padding: 0.75rem 1rem;
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast-message.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast-message.hide {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.toast-message.success {
+  background: #e6f4ea;
+  color: #267f42;
+}
+
+.toast-message.error {
+  background: #ffe6e6;
+  color: #b91c1c;
+}
+
+.toast-message.warning {
+  background: #fff4e5;
+  color: #b45309;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,14 @@
   {% block head_extra %}{% endblock %}
 </head>
 <body class="command-center-layout">
-  
+  {% if messages %}
+  <div class="toast-container">
+    {% for message in messages %}
+    <div class="toast-message {{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
   <!-- ZONE 1: TOP UTILITY BAR -->
   <div class="top-utility-bar">
     <div class="utility-bar-flex" style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
@@ -269,6 +276,13 @@
   <!-- JavaScript for interactions -->
   <script>
     document.addEventListener('DOMContentLoaded', function() {
+      const toasts = document.querySelectorAll('.toast-message');
+      toasts.forEach(toast => {
+        setTimeout(() => toast.classList.add('show'), 100);
+        setTimeout(() => toast.classList.add('hide'), 4000);
+        setTimeout(() => toast.remove(), 4500);
+      });
+
       // Profile dropdown toggle
       const profileBtn = document.querySelector('.profile-btn');
       if (profileBtn) {


### PR DESCRIPTION
## Summary
- add bottom-right toast container for Django flash messages
- animate toast display and auto-hide with JavaScript
- style toast alerts with fixed positioning and success/error/warning colors

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68921b5200a8832c962b5fe6c113c412