### PR TITLE
Fix autosave payload and missing function

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -82,6 +82,7 @@ function autosaveDraft() {
         }
     });
     if (proposalId) formData['proposal_id'] = proposalId;
+    console.log('Autosave payload:', formData);
     fetch(window.AUTOSAVE_URL, {
         method: "POST",
         headers: {

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -70,6 +70,17 @@ $(document).ready(function() {
         }
     }
 
+    // Basic helper to open a section and ensure the form panel is visible
+    function openFormPanel(section) {
+        activateSection(section);
+        const panel = $('#form-panel');
+        if (panel.length) {
+            $('html, body').animate({
+                scrollTop: panel.offset().top
+            }, 300);
+        }
+    }
+
     function loadFormContent(section) {
         const sectionData = getSectionData(section);
         $('#main-title').text(sectionData.title);
@@ -226,13 +237,17 @@ $(document).ready(function() {
 
     function copyDjangoField(fieldName) {
         const djangoField = $(`#django-basic-info [name="${fieldName}"]`);
-        const modernId = fieldName.replace(/_/g, '-') + '-modern';
-        const modernField = $(`#${modernId}`);
+        const baseId = fieldName.replace(/_/g, '-');
+        let modernField = $(`#${baseId}-modern`);
+        if (!modernField.length) {
+            modernField = $(`#${baseId}`);
+        }
         if (djangoField.length && modernField.length) {
             if (djangoField.is('select')) modernField.html(djangoField.html());
             modernField.val(djangoField.val());
             modernField.on('input change', function() {
-                djangoField.val($(this).val()).trigger('change');
+                const value = $(this).val();
+                djangoField.val(value).trigger('change');
                 clearFieldError($(this));
             });
         }


### PR DESCRIPTION
## Summary
- Ensure Django form fields without `-modern` IDs sync properly to hidden form fields, preventing autosave 400 errors
- Provide `openFormPanel` helper so saved sections navigate cleanly to the next form panel
- Log autosave request payload for easier debugging and CSRF verification

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68921f0e8f0c832c915ca8e456f9ce2f