### PR TITLE
Include proposal text sections in submission data

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -85,7 +85,11 @@
 
         <form method="post" enctype="multipart/form-data" id="proposal-form" autocomplete="off">
             {% csrf_token %}
-            
+            <textarea name="need_analysis" hidden>{{ need_analysis.content|default_if_none:'' }}</textarea>
+            <textarea name="objectives" hidden>{{ objectives.content|default_if_none:'' }}</textarea>
+            <textarea name="outcomes" hidden>{{ outcomes.content|default_if_none:'' }}</textarea>
+            <textarea name="flow" hidden>{{ flow.content|default_if_none:'' }}</textarea>
+
             <div class="form-panel" id="form-panel">
                 <div class="form-panel-content" id="form-panel-content">
                     <div class="form-grid">

--- a/emt/views.py
+++ b/emt/views.py
@@ -202,10 +202,19 @@ def submit_proposal(request, pk=None):
             return ""
         return ""
 
+    need_analysis = EventNeedAnalysis.objects.filter(proposal=proposal).first() if proposal else None
+    objectives = EventObjectives.objects.filter(proposal=proposal).first() if proposal else None
+    outcomes = EventExpectedOutcomes.objects.filter(proposal=proposal).first() if proposal else None
+    flow = TentativeFlow.objects.filter(proposal=proposal).first() if proposal else None
+
     ctx = {
         "form": form,
         "proposal": proposal,
         "org_types": OrganizationType.objects.filter(is_active=True).order_by('name'),
+        "need_analysis": need_analysis,
+        "objectives": objectives,
+        "outcomes": outcomes,
+        "flow": flow,
     }
 
 


### PR DESCRIPTION
## Summary
- Pass need analysis, objectives, outcomes, and flow objects to the proposal submission view
- Embed hidden textareas for these text sections so `_save_text_sections` captures them

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689233f0ab14832cbd83a0e6825a0d9a