### PR TITLE
Fix faculty incharge persistence

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -220,16 +220,35 @@ $(document).ready(function() {
         }).filter(Boolean);
 
         const tomselect = new TomSelect(facultySelect[0], {
-            plugins: ['remove_button'], valueField: 'id', labelField: 'text', searchField: 'text', create: false, placeholder: 'Type a faculty name…', maxItems: 10, options: existingOptions,
+            plugins: ['remove_button'],
+            valueField: 'id',
+            labelField: 'text',
+            searchField: 'text',
+            create: false,
+            placeholder: 'Type a faculty name…',
+            maxItems: 10,
+            options: existingOptions,
             load: (query, callback) => {
                 if (!query.length) return callback();
-                fetch(`${window.API_FACULTY}?q=${encodeURIComponent(query)}`).then(r => r.json()).then(callback).catch(() => callback());
+                fetch(`${window.API_FACULTY}?q=${encodeURIComponent(query)}`)
+                    .then(r => r.json())
+                    .then(callback)
+                    .catch(() => callback());
             }
         });
+
+        // Ensure selected values are mirrored into the hidden Django field
         tomselect.on('change', () => {
-            djangoFacultySelect.val(tomselect.getValue()).trigger('change');
+            const values = tomselect.getValue();
+            djangoFacultySelect.empty();
+            values.forEach(val => {
+                const text = tomselect.options[val]?.text || val;
+                djangoFacultySelect.append(new Option(text, val, true, true));
+            });
+            djangoFacultySelect.trigger('change');
             clearFieldError(facultySelect);
         });
+
         const initialValues = djangoFacultySelect.val();
         if (initialValues && initialValues.length) {
             tomselect.setValue(initialValues);

--- a/emt/views.py
+++ b/emt/views.py
@@ -135,6 +135,7 @@ def submit_proposal(request, pk=None):
     if request.method == "POST":
         post_data = request.POST.copy()
         logger.debug("submit_proposal POST data: %s", post_data)
+        logger.debug("Faculty IDs from POST: %s", post_data.getlist("faculty_incharges"))
         form = EventProposalForm(
             post_data,
             instance=proposal,


### PR DESCRIPTION
## Summary
- Sync selected faculty incharges from the dashboard's TomSelect widget back into the hidden Django field so selections are saved with proposals
- Log submitted faculty IDs during proposal submission for easier debugging

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6892425e97f4832ca4b0dfed3fdefd97