### PR TITLE
Add PSO/PO selector for event proposals

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1008,3 +1008,52 @@
     transition: all 0.2s ease;
     box-shadow: 0 2px 4px rgba(38, 68, 135, 0.2);
 }
+
+/* Outcome selection modal */
+.outcome-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.outcome-modal.show {
+    display: flex;
+}
+
+.outcome-modal .modal-content {
+    background: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    max-width: 500px;
+    width: 90%;
+}
+
+.modal-actions {
+    margin-top: 16px;
+    text-align: right;
+}
+
+.btn-cancel,
+.btn-save {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.btn-cancel {
+    background: var(--border-color);
+    color: var(--text-dark);
+    margin-right: 8px;
+}
+
+.btn-save {
+    background: var(--primary-blue);
+    color: #fff;
+}

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -271,6 +271,29 @@
 <div class="autosave-indicator" id="autosave-indicator">
     <span class="indicator-text">Saved</span>
 </div>
+{% if proposal.organization %}
+<div id="outcomeModal" class="outcome-modal" data-url="{% url 'emt:api_outcomes' proposal.organization.id %}">
+    <div class="modal-content">
+        <h3>Select Outcomes</h3>
+        <div id="outcomeOptions">Loading...</div>
+        <div class="modal-actions">
+            <button type="button" id="outcomeCancel" class="btn-cancel">Cancel</button>
+            <button type="button" id="outcomeSave" class="btn-save">Add</button>
+        </div>
+    </div>
+</div>
+{% else %}
+<div id="outcomeModal" class="outcome-modal" data-url="">
+    <div class="modal-content">
+        <h3>Select Outcomes</h3>
+        <div id="outcomeOptions">No organization selected.</div>
+        <div class="modal-actions">
+            <button type="button" id="outcomeCancel" class="btn-cancel">Cancel</button>
+            <button type="button" id="outcomeSave" class="btn-save">Add</button>
+        </div>
+    </div>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}
@@ -285,6 +308,7 @@
         window.AUTOSAVE_CSRF = "{{ csrf_token }}";
         window.API_ORGANIZATIONS = "{% url 'emt:api_organizations' %}";
         window.API_FACULTY = "{% url 'emt:api_faculty' %}";
+        window.API_OUTCOMES_BASE = "{% url 'emt:api_outcomes' 0 %}".replace(/0\/$/, '');
     </script>
     <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
     <script src="{% static 'emt/js/proposal_dashboard.js' %}"></script>


### PR DESCRIPTION
## Summary
- add reusable outcome modal to proposal form
- load organization-specific PO and PSO options and sync with `pos_pso` field
- style outcome selector for proposal dashboard

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6892410a11f0832ca663bb01d043def7