### PR TITLE
Align speaker and expense templates with standard UI

### DIFF
--- a/emt/templates/emt/expense_details.html
+++ b/emt/templates/emt/expense_details.html
@@ -18,24 +18,25 @@
     <form method="post">
       {% csrf_token %}
       {{ formset.management_form }}
-      
+
       <div class="section">
         <h3>Expense List</h3>
-        <div class="formset-table">
-          {% for form in formset %}
-            <div class="expense-row">
-              <div class="input-group">{{ form.sl_no.label_tag }} {{ form.sl_no }}</div>
-              <div class="input-group">{{ form.particulars.label_tag }} {{ form.particulars }}</div>
-              <div class="input-group">{{ form.amount.label_tag }} {{ form.amount }}</div>
-              <div class="input-group">{{ form.DELETE.label_tag }} {{ form.DELETE }}</div>
-            </div>
-            <hr>
-          {% endfor %}
-        </div>
+        {% for form in formset %}
+          <div class="section expense-form">
+            <h4>Expense {{ forloop.counter }}</h4>
+            <div class="input-group">{{ form.sl_no.label_tag }} {{ form.sl_no }}</div>
+            <div class="input-group">{{ form.particulars.label_tag }} {{ form.particulars }}</div>
+            <div class="input-group">{{ form.amount.label_tag }} {{ form.amount }}</div>
+            {% if form.DELETE %}
+              <div class="input-group">{{ form.DELETE }} Remove this expense</div>
+            {% endif %}
+          </div>
+          <hr>
+        {% endfor %}
       </div>
 
       <div class="input-group">
-        <button type="submit" class="btn">Submit</button>
+        <button type="submit" class="btn">Save &amp; Continue</button>
       </div>
     </form>
   </div>

--- a/emt/templates/emt/speaker_profile.html
+++ b/emt/templates/emt/speaker_profile.html
@@ -18,24 +18,27 @@
     <form method="post" enctype="multipart/form-data">
       {% csrf_token %}
       {{ formset.management_form }}
-      {% for form in formset %}
-        <div class="section speaker-form">
-          <h3>Speaker {{ forloop.counter }}</h3>
-          <div class="input-group">{{ form.full_name.label_tag }} {{ form.full_name }}</div>
-          <div class="input-group">{{ form.designation.label_tag }} {{ form.designation }}</div>
-          <div class="input-group">{{ form.affiliation.label_tag }} {{ form.affiliation }}</div>
-          <div class="input-group">{{ form.contact_email.label_tag }} {{ form.contact_email }}</div>
-          <div class="input-group">{{ form.contact_number.label_tag }} {{ form.contact_number }}</div>
-          <div class="input-group">{{ form.photo.label_tag }} {{ form.photo }}</div>
-          <div class="input-group">{{ form.detailed_profile.label_tag }} {{ form.detailed_profile }}</div>
-          {% if form.DELETE %}
-            <div class="input-group">{{ form.DELETE }} Remove this speaker</div>
-          {% endif %}
-        </div>
-        <hr>
-      {% endfor %}
+      <div class="section">
+        <h3>Speaker Profiles</h3>
+        {% for form in formset %}
+          <div class="section speaker-form">
+            <h4>Speaker {{ forloop.counter }}</h4>
+            <div class="input-group">{{ form.full_name.label_tag }} {{ form.full_name }}</div>
+            <div class="input-group">{{ form.designation.label_tag }} {{ form.designation }}</div>
+            <div class="input-group">{{ form.affiliation.label_tag }} {{ form.affiliation }}</div>
+            <div class="input-group">{{ form.contact_email.label_tag }} {{ form.contact_email }}</div>
+            <div class="input-group">{{ form.contact_number.label_tag }} {{ form.contact_number }}</div>
+            <div class="input-group">{{ form.photo.label_tag }} {{ form.photo }}</div>
+            <div class="input-group">{{ form.detailed_profile.label_tag }} {{ form.detailed_profile }}</div>
+            {% if form.DELETE %}
+              <div class="input-group">{{ form.DELETE }} Remove this speaker</div>
+            {% endif %}
+          </div>
+          <hr>
+        {% endfor %}
+      </div>
       <div class="input-group">
-        <button type="submit" class="btn">Save & Continue</button>
+        <button type="submit" class="btn">Save &amp; Continue</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Render expense items in section-based layout with save-and-continue control
- Wrap speaker profiles in shared section for consistent styling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68942cf383c4832c8d4f4e65a02e1d45