### PR TITLE
Fix approval flow modal hidden by Bootstrap styles

### DIFF
--- a/static/core/css/admin_approval_flow.css
+++ b/static/core/css/admin_approval_flow.css
@@ -208,6 +208,10 @@ body {
   overflow: hidden;
   transform: translateY(-10px);
   transition: transform var(--transition);
+  /* Override Bootstrap modal defaults so our custom modal is visible */
+  display: block;
+  position: relative;
+  height: auto;
 }
 
 .modal-overlay.show .modal {


### PR DESCRIPTION
## Summary
- ensure admin approval flow modal displays by overriding Bootstrap's default `.modal` rules

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68942dcd2c88832ca48871a0d2f43908