### PR TITLE
Skip redundant approvers and enable optional escalation

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -103,6 +103,7 @@ urlpatterns = [
     path('core-admin/api/org-type/<int:org_type_id>/organizations/', views.api_org_type_organizations, name='api_org_type_organizations'),
     path('core-admin/api/org-type/<int:org_type_id>/roles/', views.api_org_type_roles, name='api_org_type_roles'),
     path('core-admin/api/organization/<int:org_id>/roles/', views.api_organization_roles, name='api_organization_roles'),
+    path('core-admin/api/search-users/', views.search_users, name='search_users'),
     path('core-admin/api/search/', views.api_global_search, name='api_global_search'),
 
     # ────────────────────────────────────────────────

--- a/emt/utils.py
+++ b/emt/utils.py
@@ -39,6 +39,8 @@ def build_approval_chain(proposal):
             idx += 1
 
     for tmpl in flow:
+        if getattr(tmpl, 'optional', False):
+            continue
         # Skip duplicate faculty in-charge steps if they're already added above
         if fic_first and tmpl.role_required == ApprovalStep.Role.FACULTY_INCHARGE:
             continue


### PR DESCRIPTION
## Summary
- Skip optional approval templates when building chains
- Allow gatekeepers to forward proposals to optional approvers and auto-skip duplicate approvals
- Expose search-users API endpoint and cover new approval logic with tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68976bb41398832c9aecd472c0a4ae3c