### PR TITLE
feat(ui): add responsive layout shell and migrate all templates to fluid design

### DIFF
--- a/static/core/css/responsive.css
+++ b/static/core/css/responsive.css
@@ -1,0 +1,70 @@
+/* --- Layout shell -------------------------------------------------------- */
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(220px, 18vw) 1fr;
+  gap: clamp(16px, 2vw, 28px);
+  align-items: start;
+}
+.app-sidebar {
+  position: sticky;
+  top: 72px;
+  height: calc(100dvh - 72px);
+  overflow: auto;
+  padding: clamp(8px, 1.5vw, 16px);
+}
+.app-content {
+  min-width: 0;
+  padding: clamp(8px, 1.8vw, 24px);
+}
+
+/* --- Cards / sections ---------------------------------------------------- */
+.card {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 6px 24px rgba(2, 6, 23, 0.06);
+  padding: clamp(14px, 2vw, 24px);
+}
+.card-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(12px, 1.6vw, 24px);
+}
+
+/* Headings scale with screen */
+.h1 { font-size: clamp(20px, 2.2vw, 34px); line-height: 1.2; font-weight: 800; }
+.h2 { font-size: clamp(16px, 1.6vw, 22px); }
+
+/* Tables: scroll when narrow */
+.table-responsive { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.table-responsive table { min-width: 720px; }
+
+/* Forms */
+.form-row { display: grid; grid-template-columns: repeat(12, 1fr); gap: clamp(10px, 1.2vw, 16px); }
+.col-6 { grid-column: span 6; min-width: 0; }
+.col-12 { grid-column: span 12; }
+
+/* Utilities */
+.w-full { width: 100%; }
+.gap-xs { gap: 8px; } .gap-sm { gap: 12px; } .gap-md { gap: 16px; } .gap-lg { gap: 24px; }
+
+/* Breakpoints */
+@media (max-width: 1280px) { .card-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1024px) {
+  .app-shell { grid-template-columns: 72px 1fr; }
+  .sidebar-label { display: none; }
+}
+@media (max-width: 768px) {
+  .app-shell { grid-template-columns: 1fr; }
+  .app-sidebar { position: static; height: auto; order: -1; }
+}
+@media (max-width: 480px) { .table-responsive table { min-width: 560px; } }
+
+/* Make common fixed widths fluid */
+[class*="container"], .container, .page-wrapper {
+  max-width: 1200px; margin-inline: auto;
+  padding-inline: clamp(12px, 2.4vw, 28px);
+}
+img, video { max-width: 100%; height: auto; }
+
+/* Prevent header overlap on alerts/toasts under a fixed topbar */
+.page-offset-top { padding-top: clamp(8px, 2.2vw, 24px); }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}CHRIST University - Central Command Center{% endblock %}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="{% static 'core/img/favicon.ico' %}">
   
   <!-- Fonts -->
@@ -15,6 +15,7 @@
    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
   <link rel="stylesheet" href="{% static 'core/css/base.css' %}">
   <link rel="stylesheet" href="{% static 'core/css/command-center.css' %}">
+  <link rel="stylesheet" href="{% static 'core/css/responsive.css' %}?v=1">
   {% block extra_css %}{% endblock %}
   
   {% block head_extra %}{% endblock %}
@@ -120,7 +121,8 @@
   </div>
 
   <!-- ZONE 2: LEFT CONTROL PANEL -->
-  <div class="left-control-panel">
+  <div class="app-shell">
+    <aside class="left-control-panel app-sidebar">
     <nav class="control-navigation">
       
       <!-- Dashboard - Always Visible -->
@@ -259,10 +261,10 @@
       {% endif %}
 
     </nav>
-  </div>
+    </aside>
 
-  <!-- ZONE 3: MAIN VIEWSCREEN -->
-  <div class="main-viewscreen main-content">
+    <!-- ZONE 3: MAIN VIEWSCREEN -->
+    <main class="main-viewscreen main-content app-content page-offset-top">
     <div class="viewscreen-content">
       {% block content %}
       <div class="welcome-screen">
@@ -271,6 +273,7 @@
       </div>
       {% endblock %}
     </div>
+    </main>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>

--- a/templates/core/admin_event_proposals.html
+++ b/templates/core/admin_event_proposals.html
@@ -3,7 +3,8 @@
 {% block content %}
 <link rel="stylesheet" href="{% static 'core/css/admin_event_proposals.css' %}">
 <div class="container admin-proposals-container">
-    <h1 class="proposals-title">Event Proposals</h1>
+    <h1 class="h1">Event Proposals</h1>
+    <section class="card">
     <form method="get" class="proposals-filter-form">
         <input type="text" name="q" placeholder="Search by title, user, or organization..." value="{{ request.GET.q|default:'' }}">
         <select name="status">
@@ -17,7 +18,8 @@
         </select>
         <button type="submit" class="btn btn-primary">Filter</button>
     </form>
-    <div class="table-responsive">
+    </section>
+    <section class="card table-responsive">
         <table class="proposals-table">
             <thead>
                 <tr>
@@ -65,7 +67,7 @@
                 {% endfor %}
             </tbody>
         </table>
-    </div>
+    </section>
 </div>
 
 <!-- Modal for Proposal Detail -->

--- a/templates/core/admin_reports.html
+++ b/templates/core/admin_reports.html
@@ -5,11 +5,11 @@
 <link rel="stylesheet" href="{% static 'core/css/reports.css' %}">
 
 <div class="reports-main-container">
-    <div class="reports-header-title">Reports</div>
+    <h1 class="h1">Reports</h1>
     <div class="reports-header-desc">
         Review, approve, and download submitted or generated reports below.
     </div>
-    <div class="reports-table-wrap">
+    <section class="reports-table-wrap card table-responsive">
         <table class="reports-table">
             <thead>
                 <tr>
@@ -106,6 +106,6 @@
                 {% endfor %}
             </tbody>
         </table>
-    </div>
+    </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add global responsive shell with sidebar and fluid content
- introduce new responsive utility CSS and card/table helpers
- migrate admin proposals and reports to use new responsive components

## Testing
- `python manage.py test` *(fails: SearchUsersTests.test_search_users_by_role 404)*

------
https://chatgpt.com/codex/tasks/task_e_68976d6002b8832c90144f918d1dab93