### PR TITLE
Add modern styling for outcomes hub and SDG management

### DIFF
--- a/static/core/css/outcomes_sdg.css
+++ b/static/core/css/outcomes_sdg.css
@@ -1,0 +1,114 @@
+:root{
+  --brand:#1e40af;            /* primary deep blue */
+  --brand-2:#3b82f6;          /* accent blue */
+  --ink:#0f172a;              /* text */
+  --muted:#64748b;            /* secondary text */
+  --bg:#f8fafc;               /* page bg */
+  --surface:#ffffff;          /* cards */
+  --ring:rgba(30,64,175,.25);
+  --shadow-sm:0 2px 8px rgba(2,6,23,.06);
+  --shadow-md:0 12px 30px rgba(2,6,23,.10);
+  --radius:18px;
+  --radius-sm:12px;
+  --gap:clamp(12px,1.8vw,24px);
+}
+
+.outcomes-page{padding-inline:clamp(16px,2.8vw,48px); padding-block:clamp(16px,3vw,40px); background:var(--bg);}
+.outcomes-title{
+  display:flex; align-items:center; gap:12px; margin-bottom:1.2rem;
+  font-weight:800; color:var(--brand); font-size:clamp(22px,2.2vw,36px);
+}
+.outcomes-title .icon{
+  width:44px; height:44px; border-radius:14px; display:grid; place-items:center;
+  background:linear-gradient(135deg, var(--brand), var(--brand-2));
+  color:#fff; box-shadow:var(--shadow-sm);
+}
+
+/* ===== Hub (two tiles) ===== */
+.tile-grid{
+  display:grid; gap:var(--gap);
+  grid-template-columns: repeat(12, 1fr);
+  margin-top:clamp(8px,1.6vw,16px);
+}
+.tile-card{
+  grid-column: span 6;
+  display:flex; align-items:flex-start; gap:16px;
+  background:var(--surface); border-radius:var(--radius);
+  padding:clamp(16px,2.4vw,28px); box-shadow:var(--shadow-sm);
+  border:1px solid rgba(2,6,23,.06); transition:transform .2s ease, box-shadow .2s ease;
+}
+.tile-card:hover{ transform:translateY(-2px); box-shadow:var(--shadow-md); }
+.tile-card .tile-icon{
+  width:56px; height:56px; border-radius:16px; flex:0 0 auto;
+  background:rgba(30,64,175,.08); color:var(--brand); display:grid; place-items:center; font-size:24px;
+}
+.tile-card h3{
+  margin:0; font-size:clamp(16px,1.4vw,20px); color:var(--ink); font-weight:700;
+}
+.tile-card p{ margin:.25rem 0 0; color:var(--muted); font-size:clamp(12px,1vw,14px); }
+.tile-card .chev{
+  margin-left:auto; align-self:center; opacity:.6; transition:opacity .2s, transform .2s;
+}
+.tile-card:hover .chev{ opacity:1; transform:translateX(2px); }
+
+@media (max-width: 920px){
+  .tile-card{ grid-column: span 12; }
+}
+
+/* ===== SDG Goals page ===== */
+.sdg-admin{ background:var(--bg); padding-inline:clamp(16px,2.8vw,48px); padding-block:clamp(16px,3vw,40px);}
+.sdg-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:clamp(12px,1.8vw,20px);}
+.sdg-title{ font-weight:800; color:var(--brand); font-size:clamp(22px,2.2vw,34px); }
+
+.sdg-toolbar{
+  display:flex; gap:10px; flex-wrap:wrap;
+  background:var(--surface); padding:12px; border-radius:var(--radius-sm); box-shadow:var(--shadow-sm);
+  border:1px solid rgba(2,6,23,.06);
+}
+.input{
+  height:40px; padding:0 12px; border-radius:12px; background:#fff;
+  border:1px solid rgba(2,6,23,.12); min-width:260px; color:var(--ink);
+  outline:none; transition:border-color .15s, box-shadow .15s;
+}
+.input:focus{ border-color:var(--brand); box-shadow:0 0 0 4px var(--ring); }
+
+.btn{
+  height:40px; padding:0 16px; border-radius:12px; border:1px solid transparent;
+  font-weight:700; cursor:pointer; transition:transform .05s ease, box-shadow .2s ease, background .2s;
+}
+.btn:active{ transform:translateY(1px); }
+.btn-primary{ background:var(--brand); color:#fff; box-shadow:var(--shadow-sm); }
+.btn-primary:hover{ background:#18348a; box-shadow:var(--shadow-md); }
+.btn-quiet{ background:#fff; color:var(--brand); border-color:rgba(30,64,175,.25); }
+.btn-quiet:hover{ background:rgba(30,64,175,.06); }
+
+.card{
+  background:var(--surface); border:1px solid rgba(2,6,23,.06);
+  border-radius:var(--radius); box-shadow:var(--shadow-sm);
+  padding:clamp(14px,2vw,22px);
+}
+
+/* table */
+.table-wrap{ overflow-x:auto; -webkit-overflow-scrolling:touch; }
+.table{ width:100%; border-collapse:separate; border-spacing:0; min-width:620px; }
+.table th, .table td{
+  padding:12px 14px; text-align:left; border-bottom:1px solid rgba(2,6,23,.06);
+  color:var(--ink);
+}
+.table th{ font-size:12px; letter-spacing:.04em; text-transform:uppercase; color:var(--muted); background:rgba(2,6,23,.015); }
+.table tr:hover td{ background:rgba(59,130,246,.04); }
+.badge{
+  display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px;
+  background:rgba(30,64,175,.08); color:var(--brand); font-weight:700; font-size:12px;
+}
+
+/* empty state */
+.empty{
+  display:grid; place-items:center; min-height:220px; color:var(--muted);
+  border:1px dashed rgba(2,6,23,.12); border-radius:16px;
+}
+
+/* small helpers */
+.stack{ display:grid; gap:12px; }
+.row{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+.mt{ margin-top:var(--gap); }

--- a/templates/core/admin_outcome_dashboard.html
+++ b/templates/core/admin_outcome_dashboard.html
@@ -3,47 +3,28 @@
 
 {% block content %}
 <link rel="stylesheet" href="{% static 'core/css/admin_settings_dashboard.css' %}">
+<link rel="stylesheet" href="{% static 'core/css/outcomes_sdg.css' %}?v=1.0">
 
-<div class="admin-settings-dashboard-bg">
-  <div class="admin-settings-dashboard-container">
-    <div class="admin-settings-header">
-      <div class="admin-settings-icon">
-        <i class="fa-solid fa-graduation-cap"></i>
+<div class="outcomes-page">
+  <div class="outcomes-title"><span class="icon">🎓</span> PO, PSO &amp; SDG Management</div>
+  <div class="tile-grid">
+    <a class="tile-card" href="{% url 'admin_pso_po_management' %}">
+      <div class="tile-icon">📋</div>
+      <div>
+        <h3>PO &amp; PSO Management</h3>
+        <p>Add or update programme outcomes</p>
       </div>
-      <h1 class="admin-settings-title">PO, PSO &amp; SDG Management</h1>
-    </div>
+      <div class="chev">➜</div>
+    </a>
 
-    <div class="admin-settings-cards">
-      <a href="{% url 'admin_pso_po_management' %}" class="admin-settings-card">
-        <div class="admin-settings-card-content">
-          <div class="admin-settings-card-icon">
-            <i class="fa-solid fa-clipboard-list"></i>
-          </div>
-          <div class="admin-settings-card-info">
-            <div class="admin-settings-card-title">PO &amp; PSO Management</div>
-            <div class="admin-settings-card-desc">Add or update programme outcomes</div>
-          </div>
-        </div>
-        <div class="admin-settings-card-arrow">
-          <i class="fa-solid fa-chevron-right"></i>
-        </div>
-      </a>
-
-      <a href="{% url 'admin_sdg_management' %}" class="admin-settings-card">
-        <div class="admin-settings-card-content">
-          <div class="admin-settings-card-icon">
-            <i class="fa-solid fa-globe"></i>
-          </div>
-          <div class="admin-settings-card-info">
-            <div class="admin-settings-card-title">SDG Goals Management</div>
-            <div class="admin-settings-card-desc">Add or remove SDG goals</div>
-          </div>
-        </div>
-        <div class="admin-settings-card-arrow">
-          <i class="fa-solid fa-chevron-right"></i>
-        </div>
-      </a>
-    </div>
+    <a class="tile-card" href="{% url 'admin_sdg_management' %}">
+      <div class="tile-icon">🌍</div>
+      <div>
+        <h3>SDG Goals Management</h3>
+        <p>Add or remove SDG goals</p>
+      </div>
+      <div class="chev">➜</div>
+    </a>
   </div>
 </div>
 

--- a/templates/core/admin_sdg_management.html
+++ b/templates/core/admin_sdg_management.html
@@ -3,49 +3,46 @@
 
 {% block content %}
 <link rel="stylesheet" href="{% static 'core/css/admin_master_data.css' %}">
+<link rel="stylesheet" href="{% static 'core/css/outcomes_sdg.css' %}?v=1.0">
 
-<div class="main-container">
-  <div class="page-header">
-    <h1 class="page-title">SDG Goals Management</h1>
+<div class="sdg-admin">
+  <div class="sdg-header">
+    <div class="sdg-title">SDG Goals Management</div>
   </div>
 
-  <div class="table-container">
-    <table class="data-table">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Goal</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for goal in goals %}
-        <tr>
-          <td>{{ goal.id }}</td>
-          <td>{{ goal.name }}</td>
-          <td>
-            <form method="post" style="display:inline">
-              {% csrf_token %}
-              <input type="hidden" name="delete_goal_id" value="{{ goal.id }}">
-              <button type="submit" class="delete-btn"><i class="fas fa-trash"></i> Delete</button>
-            </form>
-          </td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="3">No SDG goals added yet.</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-
-  <div class="pso-po-management" style="margin-top:20px;">
-    <form method="post">
+  <div class="sdg-toolbar">
+    <form method="post" class="row">
       {% csrf_token %}
-      <input type="text" name="name" placeholder="Add new SDG goal..." required>
-      <button type="submit"><i class="fas fa-plus"></i> Add Goal</button>
+      <input type="text" name="name" placeholder="Add new SDG goal..." required class="input">
+      <button type="submit" class="btn btn-primary">+ Add Goal</button>
     </form>
   </div>
+
+  {% if goals %}
+  <div class="card mt">
+    <div class="table-wrap">
+      <table class="table">
+        <thead><tr><th>#</th><th>Goal</th><th>Action</th></tr></thead>
+        <tbody>
+        {% for goal in goals %}
+          <tr>
+            <td>{{ goal.id }}</td>
+            <td>{{ goal.name }}</td>
+            <td>
+              <form method="post" style="display:inline">
+                {% csrf_token %}
+                <input type="hidden" name="delete_goal_id" value="{{ goal.id }}">
+                <button type="submit" class="btn btn-quiet delete-btn"><i class="fas fa-trash"></i> Delete</button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% else %}
+  <div class="empty mt">No SDG goals added yet.</div>
+  {% endif %}
 </div>
-
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- add `outcomes_sdg.css` with responsive card grid and SDG management UI styling
- rebuild PO/PSO/SDG hub and SDG goals pages using new classes and stylesheet

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689783bc3398832c9666ae7769b7bedb