### PR TITLE
fix(approvals): hide optional approvers unless forwarded; don’t show skipped optionals on status page

### DIFF
--- a/emt/models.py
+++ b/emt/models.py
@@ -160,6 +160,14 @@ class ExpenseDetail(models.Model):
 # ────────────────────────────────────────────────────────────────
 #  Approval Steps
 # ────────────────────────────────────────────────────────────────
+class ApprovalStepQuerySet(models.QuerySet):
+    def visible_for_status(self):
+        return self.exclude(
+            is_optional=True, optional_unlocked=False, status="pending"
+        ).exclude(
+            is_optional=True, status="skipped"
+        )
+
 class ApprovalStep(models.Model):
     """Represents a single step in the approval workflow for a proposal."""
     class Status(models.TextChoices):
@@ -201,6 +209,8 @@ class ApprovalStep(models.Model):
     decided_at = models.DateTimeField(null=True, blank=True)
     note = models.TextField(blank=True)
     comment = models.TextField(blank=True)
+
+    objects = ApprovalStepQuerySet.as_manager()
 
     class Meta:
         ordering = ['order_index']

--- a/emt/templates/emt/proposal_status_detail.html
+++ b/emt/templates/emt/proposal_status_detail.html
@@ -46,7 +46,7 @@
     <div class="timeline-column">
       <div class="approval-timeline">
         <ul class="timeline-list">
-          {% for step in approval_steps %}
+          {% for step in steps %}
             <li class="timeline-item {{ step.status }}">
               <div class="timeline-dot"></div>
               <div class="timeline-card">


### PR DESCRIPTION
## Summary
- add `ApprovalStepQuerySet.visible_for_status` to skip locked or skipped optional approvers
- use `visible_for_status` in proposal status and review views and pass filtered steps to template
- update proposal status template to iterate over filtered steps

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6897852f68bc832c917e0e2341c8f15c