### PR TITLE
fix(approvals): hide non-forwarded optional approvers in UI using visible_for_ui()

### DIFF
--- a/emt/models.py
+++ b/emt/models.py
@@ -161,12 +161,19 @@ class ExpenseDetail(models.Model):
 #  Approval Steps
 # ────────────────────────────────────────────────────────────────
 class ApprovalStepQuerySet(models.QuerySet):
-    def visible_for_status(self):
+    def visible_for_ui(self):
+        """Hide optional steps that were never forwarded for display."""
         return self.exclude(
-            is_optional=True, optional_unlocked=False, status="pending"
+            is_optional=True,
+            optional_unlocked=False,
+            status=ApprovalStep.Status.PENDING,
         ).exclude(
-            is_optional=True, status="skipped"
+            is_optional=True,
+            status=ApprovalStep.Status.SKIPPED,
         )
+
+    # Backwards compatibility with previous helper name
+    visible_for_status = visible_for_ui
 
 class ApprovalStep(models.Model):
     """Represents a single step in the approval workflow for a proposal."""

--- a/emt/tests.py
+++ b/emt/tests.py
@@ -466,3 +466,46 @@ class ForwardingFlowTests(TestCase):
         s3.refresh_from_db()
         self.assertEqual(s3.status, ApprovalStep.Status.PENDING)
         self.assertTrue(s3.optional_unlocked)
+
+    def test_visible_for_ui_hides_locked_optional_steps(self):
+        proposal = self._create_proposal()
+        base = ApprovalStep.objects.create(
+            proposal=proposal,
+            step_order=1,
+            order_index=1,
+            assigned_to=self.user,
+            status=ApprovalStep.Status.PENDING,
+        )
+        opt = ApprovalStep.objects.create(
+            proposal=proposal,
+            step_order=2,
+            order_index=2,
+            assigned_to=self.user_b,
+            is_optional=True,
+            status=ApprovalStep.Status.PENDING,
+        )
+
+        qs = (
+            ApprovalStep.objects.filter(proposal=proposal)
+            .order_by("order_index")
+            .visible_for_ui()
+        )
+        self.assertEqual(list(qs), [base])
+
+        opt.optional_unlocked = True
+        opt.save()
+        qs2 = (
+            ApprovalStep.objects.filter(proposal=proposal)
+            .order_by("order_index")
+            .visible_for_ui()
+        )
+        self.assertEqual(list(qs2), [base, opt])
+
+        opt.status = ApprovalStep.Status.SKIPPED
+        opt.save()
+        qs3 = (
+            ApprovalStep.objects.filter(proposal=proposal)
+            .order_by("order_index")
+            .visible_for_ui()
+        )
+        self.assertEqual(list(qs3), [base])

--- a/emt/views.py
+++ b/emt/views.py
@@ -537,7 +537,7 @@ def proposal_status_detail(request, proposal_id):
     all_steps = (
         ApprovalStep.objects.filter(proposal=proposal).order_by("order_index")
     )
-    visible_steps = all_steps.visible_for_status()
+    visible_steps = all_steps.visible_for_ui()
 
     # Total budget calculation
     budget_total = ExpenseDetail.objects.filter(
@@ -944,7 +944,7 @@ def review_approval_step(request, step_id):
         optional_candidates = list(get_downstream_optional_candidates(step))
         show_optional_picker = len(optional_candidates) > 0
 
-    history_steps = proposal.approval_steps.visible_for_status().order_by("order_index")
+    history_steps = proposal.approval_steps.visible_for_ui().order_by("order_index")
 
     if request.method == 'POST':
         action = request.POST.get('action')


### PR DESCRIPTION
## Summary
- add `visible_for_ui` queryset helper to hide locked optional steps
- use `visible_for_ui` in proposal status and review views
- test that `visible_for_ui` omits locked optional steps

## Testing
- `python manage.py test emt`


------
https://chatgpt.com/codex/tasks/task_e_68978a5149b8832c82388cfbd7496a7e