### PR TITLE
Enable autosave for dynamic proposal sections and sync schedule field

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -1,154 +1,150 @@
-let proposalId = window.PROPOSAL_ID || '';
-let timeoutId = null;
+// AutosaveManager handles autosaving draft proposals including dynamic fields
+// and exposing hooks for reinitializing field listeners and manual saves.
 
-// Only grab fields with a name attribute (prevents sending unnamed or irrelevant elements)
-const fields = Array.from(document.querySelectorAll('input[name], textarea[name], select[name]'));
+window.AutosaveManager = (function() {
+    let proposalId = window.PROPOSAL_ID || '';
+    let timeoutId = null;
+    let fields = [];
 
-// Unique key for this page's local storage
-const pageKey = `proposal_draft_${window.location.pathname}_new`;
+    // Unique key for this page's local storage
+    const pageKey = `proposal_draft_${window.location.pathname}_new`;
 
-// Clear localStorage immediately if this is a submitted proposal
-if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
-    localStorage.removeItem(pageKey);
-    console.log('Cleared localStorage for submitted proposal');
-}
-
-// Load any saved draft from localStorage only if no existing proposal or proposal is still a draft
-try {
-    const savedData = JSON.parse(localStorage.getItem(pageKey) || '{}');
-    // Only load draft data if we don't have a proposal ID (new proposal) or if it's still a draft
-    const shouldLoadDraft = !proposalId || (proposalId && window.PROPOSAL_STATUS === 'draft');
-    
-    console.log('Draft loading check:', {
-        proposalId,
-        status: window.PROPOSAL_STATUS,
-        shouldLoadDraft,
-        savedDataKeys: Object.keys(savedData)
-    });
-    
-    if (shouldLoadDraft && Object.keys(savedData).length > 0) {
-        if (savedData._proposal_id && !proposalId) {
-            proposalId = savedData._proposal_id;
+    function getSavedData() {
+        try {
+            return JSON.parse(localStorage.getItem(pageKey) || '{}');
+        } catch (e) {
+            console.error('Error parsing saved draft:', e);
+            return {};
         }
+    }
+
+    function saveLocal() {
+        const data = {};
         fields.forEach(f => {
-            if (savedData.hasOwnProperty(f.name)) {
+            if (!f.disabled && f.name) {
                 if (f.type === 'checkbox' || f.type === 'radio') {
-                    f.checked = savedData[f.name];
+                    data[f.name] = f.checked;
                 } else if (f.multiple) {
-                    const values = savedData[f.name] || [];
+                    data[f.name] = Array.from(f.selectedOptions).map(o => o.value);
+                } else {
+                    data[f.name] = f.value;
+                }
+            }
+        });
+        if (proposalId) {
+            data._proposal_id = proposalId;
+        }
+        localStorage.setItem(pageKey, JSON.stringify(data));
+    }
+
+    function clearLocal() {
+        localStorage.removeItem(pageKey);
+    }
+
+    function autosaveDraft() {
+        // Don't autosave for submitted proposals
+        if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
+            clearLocal();
+            return;
+        }
+
+        const formData = {};
+        fields.forEach(f => {
+            if (!f.disabled && f.name) {
+                if (f.type === 'checkbox' || f.type === 'radio') {
+                    formData[f.name] = f.checked;
+                } else if (f.multiple) {
+                    formData[f.name] = Array.from(f.selectedOptions).map(o => o.value);
+                } else {
+                    formData[f.name] = f.value;
+                }
+            }
+        });
+        if (proposalId) {
+            formData['proposal_id'] = proposalId;
+        }
+
+        fetch(window.AUTOSAVE_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': window.AUTOSAVE_CSRF
+            },
+            body: JSON.stringify(formData)
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success && data.proposal_id) {
+                proposalId = data.proposal_id;
+                saveLocal();
+            }
+        })
+        .catch(err => console.error('Autosave error:', err));
+    }
+
+    function bindField(field) {
+        if (field.dataset.autosaveBound) return;
+        const handler = () => {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(() => {
+                autosaveDraft();
+                saveLocal();
+            }, 1000);
+        };
+        field.addEventListener('input', handler);
+        if (field.tagName === 'SELECT') {
+            field.addEventListener('change', handler);
+        }
+        field.dataset.autosaveBound = 'true';
+    }
+
+    function reinitialize() {
+        fields = Array.from(document.querySelectorAll('input[name], textarea[name], select[name]'));
+        const saved = getSavedData();
+
+        fields.forEach(f => {
+            // Load saved data for new fields if empty
+            if (saved.hasOwnProperty(f.name)) {
+                if (f.type === 'checkbox' || f.type === 'radio') {
+                    f.checked = saved[f.name];
+                } else if (f.multiple) {
+                    const values = saved[f.name] || [];
                     Array.from(f.options).forEach(o => {
                         o.selected = values.includes(o.value);
                     });
                 } else if (!f.value) {
-                    f.value = savedData[f.name];
+                    f.value = saved[f.name];
                 }
             }
+            bindField(f);
         });
-        console.log('Loaded draft data from localStorage');
-    } else if (!shouldLoadDraft) {
-        // Clear localStorage for submitted proposals
-        clearLocal();
-        console.log('Cleared localStorage because proposal is not a draft');
-    }
-} catch (e) { 
-    console.error('Error loading draft:', e);
-}
 
-fields.forEach(field => {
-    // Don't add event listeners for submitted proposals
-    if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
-        return;
+        if (saved._proposal_id && !proposalId) {
+            proposalId = saved._proposal_id;
+        }
+
+        // Clear local storage immediately if this is a submitted proposal
+        if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
+            clearLocal();
+        }
     }
-    
-    const handler = () => {
-        clearTimeout(timeoutId);
-        timeoutId = setTimeout(() => {
-            autosaveDraft();
-            saveLocal();
-        }, 1000); // Save after 1 second idle
+
+    function manualSave() {
+        autosaveDraft();
+        saveLocal();
+    }
+
+    // Initial setup
+    reinitialize();
+
+    const formEl = document.querySelector('form');
+    if (formEl) {
+        formEl.addEventListener('submit', clearLocal);
+    }
+
+    return {
+        reinitialize,
+        manualSave
     };
+})();
 
-    field.addEventListener('input', handler);
-    if (field.tagName === 'SELECT') {
-        field.addEventListener('change', handler);
-    }
-});
-
-function saveLocal() {
-    const data = {};
-    fields.forEach(f => {
-        if (!f.disabled && f.name) {
-            if (f.type === 'checkbox' || f.type === 'radio') {
-                data[f.name] = f.checked;
-            } else if (f.multiple) {
-                data[f.name] = Array.from(f.selectedOptions).map(o => o.value);
-            } else {
-                data[f.name] = f.value;
-            }
-        }
-    });
-    if (proposalId) {
-        data._proposal_id = proposalId;
-    }
-    localStorage.setItem(pageKey, JSON.stringify(data));
-}
-
-function clearLocal() {
-    localStorage.removeItem(pageKey);
-}
-
-function autosaveDraft() {
-    // Don't autosave if this is a submitted proposal
-    if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
-        console.log('Skipping autosave - proposal is not a draft');
-        return;
-    }
-    
-    const formData = {};
-    fields.forEach(f => {
-        // Only include enabled, not-disabled fields
-        if (!f.disabled && f.name) {
-            if (f.type === 'checkbox' || f.type === 'radio') {
-                formData[f.name] = f.checked;
-            } else if (f.multiple) {
-                formData[f.name] = Array.from(f.selectedOptions).map(o => o.value);
-            } else {
-                formData[f.name] = f.value;
-            }
-        }
-    });
-    if (proposalId) formData['proposal_id'] = proposalId;
-    console.log('Autosave payload:', formData);
-    fetch(window.AUTOSAVE_URL, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "X-CSRFToken": window.AUTOSAVE_CSRF
-        },
-        body: JSON.stringify(formData)
-    })
-    .then(res => res.json())
-    .then(data => {
-        if (data.success && data.proposal_id) {
-            proposalId = data.proposal_id;
-            saveLocal(); // persist id with draft
-            console.log('Autosave successful');
-        } else {
-            console.log('Autosave failed:', data);
-        }
-    })
-    .catch(err => { 
-        console.error('Autosave error:', err);
-    });
-}
-
-// Remove saved draft on form submit
-const formEl = document.querySelector('form');
-if (formEl) {
-    formEl.addEventListener('submit', clearLocal);
-}
-
-// Clear localStorage for already submitted proposals
-if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
-    clearLocal();
-}

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -274,6 +274,9 @@ $(document).ready(function() {
                         $(`#activity_date_${index}`).val(act.date);
                     });
                 }
+                if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                    window.AutosaveManager.reinitialize();
+                }
             }
         }
         numActivitiesInput.addEventListener('input', () => {
@@ -792,7 +795,7 @@ function getWhyThisEventForm() {
                 <div class="form-row full-width">
                     <div class="input-group">
                         <label for="schedule-modern">Event timeline and schedule *</label>
-                        <textarea id="schedule-modern" rows="8" required placeholder="9:00 AM - Registration&#10;9:30 AM - Opening Ceremony..."></textarea>
+                        <textarea id="schedule-modern" name="flow" rows="8" required placeholder="9:00 AM - Registration&#10;9:30 AM - Opening Ceremony..."></textarea>
                         <div class="help-text">Provide a detailed timeline for each activity.</div>
                     </div>
                 </div>
@@ -924,6 +927,9 @@ function getWhyThisEventForm() {
             `;
             container.append(html);
             index++;
+            if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                window.AutosaveManager.reinitialize();
+            }
         }
 
         function updateSpeakerHeaders() {
@@ -957,6 +963,9 @@ function getWhyThisEventForm() {
             $(this).closest('.speaker-form-container').remove();
             updateSpeakerHeaders();
             showEmptyState();
+            if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                window.AutosaveManager.reinitialize();
+            }
         });
 
         if (window.EXISTING_SPEAKERS && window.EXISTING_SPEAKERS.length) {
@@ -1017,6 +1026,9 @@ function getWhyThisEventForm() {
             `;
             container.append(html);
             index++;
+            if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                window.AutosaveManager.reinitialize();
+            }
         }
 
         function updateExpenseHeaders() {
@@ -1050,6 +1062,9 @@ function getWhyThisEventForm() {
             $(this).closest('.expense-form-container').remove();
             updateExpenseHeaders();
             showEmptyState();
+            if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                window.AutosaveManager.reinitialize();
+            }
         });
 
         if (window.EXISTING_EXPENSES && window.EXISTING_EXPENSES.length) {
@@ -1105,8 +1120,14 @@ function getWhyThisEventForm() {
         $('#form-panel-content').on('input.sync change.sync', 'input, textarea, select', function() {
             const fieldId = $(this).attr('id');
             if (fieldId && fieldId.endsWith('-modern')) {
-                const baseName = fieldId.replace('-modern', '').replace(/-/g, '_');
-                const djangoField = $(`#django-forms [name="${baseName}"]`);
+                let baseName = fieldId.replace('-modern', '').replace(/-/g, '_');
+                if (fieldId === 'schedule-modern') {
+                    baseName = 'flow';
+                }
+                let djangoField = $(`#django-forms [name="${baseName}"]`);
+                if (!djangoField.length && baseName === 'flow') {
+                    djangoField = $(`textarea[name="flow"]`);
+                }
                 if (djangoField.length) {
                     djangoField.val($(this).val());
                     console.log(`Synced ${baseName}:`, $(this).val());


### PR DESCRIPTION
## Summary
- Map schedule textarea to flow field and ensure its value posts with the form
- Introduce AutosaveManager for autosave/reinitialize/manual save functionality
- Persist dynamically added speakers, activities, and expenses during autosave

## Testing
- `pytest`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689868bdb200832c8949a3c3cd162091