### PR TITLE
Support employee IDs for faculty bulk upload

### DIFF
--- a/core/templates/core_admin_org_users/faculty.html
+++ b/core/templates/core_admin_org_users/faculty.html
@@ -7,8 +7,8 @@
   <div class="card p-4 mb-4">
     <h3 class="mb-3">Bulk CSV Upload</h3>
     <p class="text-muted mb-3">
-      Upload a CSV with columns: <code>register_no, name, email, role</code>.
-      <a href="{% url 'admin_org_users_csv_template' org.id %}">Download template</a>
+      Upload a CSV with columns: <code>emp_id, name, email, role</code>.
+      <a href="{% url 'admin_org_users_csv_template' org.id %}?role=faculty">Download template</a>
     </p>
     <form method="post" enctype="multipart/form-data" action="{% url 'admin_org_users_upload_csv' org.id %}">
       {% csrf_token %}

--- a/core/templates/core_admin_org_users/students.html
+++ b/core/templates/core_admin_org_users/students.html
@@ -8,7 +8,7 @@
     <h3 class="mb-3">Bulk CSV Upload</h3>
     <p class="text-muted mb-3">
       Upload a CSV with columns: <code>register_no, name, email, role</code>.
-      <a href="{% url 'admin_org_users_csv_template' org.id %}">Download template</a>
+      <a href="{% url 'admin_org_users_csv_template' org.id %}?role=student">Download template</a>
     </p>
     <form method="post" enctype="multipart/form-data" action="{% url 'admin_org_users_upload_csv' org.id %}">
       {% csrf_token %}


### PR DESCRIPTION
## Summary
- Allow admin CSV imports to use `emp_id` for faculty instead of `register_no`
- Generate CSV templates with `emp_id` or `register_no` based on role

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68988be9f68c832c8feec7d14c9d0300