### PR TITLE
Validate LinkedIn URL before fetching profile

### DIFF
--- a/emt/urls.py
+++ b/emt/urls.py
@@ -33,7 +33,8 @@ urlpatterns = [
 
     # Faculty remains as is
     path("api/faculty/", views.api_faculty, name="api_faculty"),
-    
+    path('api/fetch-linkedin-profile/', views.fetch_linkedin_profile, name='fetch_linkedin_profile'),
+
     # Report assignment APIs
     path('api/event-participants/<int:proposal_id>/', views.api_event_participants, name='api_event_participants'),
     path('api/assign-report/<int:proposal_id>/', views.assign_report_task, name='assign_report_task'),


### PR DESCRIPTION
## Summary
- safeguard LinkedIn profile fetch endpoint with URL validation
- expose new fetch-linkedin-profile API route
- test LinkedIn fetch behavior for valid and invalid URLs

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6899695660fc832cb86bf3de65b4a977