### PR TITLE
Add class roster views and CSV upload redirect

### DIFF
--- a/core/migrations/0026_roleassignment_academic_year_class_name.py
+++ b/core/migrations/0026_roleassignment_academic_year_class_name.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0025_class_academic_year_class_organization"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="roleassignment",
+            name="academic_year",
+            field=models.CharField(blank=True, db_index=True, max_length=9, null=True),
+        ),
+        migrations.AddField(
+            model_name="roleassignment",
+            name="class_name",
+            field=models.CharField(blank=True, db_index=True, max_length=64, null=True),
+        ),
+        migrations.AddIndex(
+            model_name="roleassignment",
+            index=models.Index(fields=["organization", "academic_year", "class_name"], name="core_ra_org_year_class_idx"),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -55,10 +55,18 @@ class OrganizationRole(models.Model):
 class RoleAssignment(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='role_assignments')
     role = models.ForeignKey('OrganizationRole', on_delete=models.CASCADE, null=True)
-    organization = models.ForeignKey(Organization, null=True, blank=True, on_delete=models.SET_NULL,related_name='role_assignments')
+    organization = models.ForeignKey(Organization, null=True, blank=True, on_delete=models.SET_NULL, related_name='role_assignments')
+    academic_year = models.CharField(max_length=9, null=True, blank=True, db_index=True)
+    class_name = models.CharField(max_length=64, null=True, blank=True, db_index=True)
 
     class Meta:
         unique_together = ("user", "role", "organization")
+        indexes = [
+            models.Index(
+                fields=["organization", "academic_year", "class_name"],
+                name="core_ra_org_year_class_idx",
+            )
+        ]
 
     def __str__(self):
         parts = [self.role.name]  # Use the OrganizationRole name

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from . import views
+from core import views as core_views
 from core.views import custom_logout
 from . import views_admin_org_users as orgu
 
@@ -144,6 +145,16 @@ urlpatterns = [
         "core-admin/org-users/fetch/by-type/<int:type_id>/",
         orgu.fetch_by_type,
         name="admin_org_fetch_by_type",
+    ),
+    path(
+        "core-admin/org-users/<int:org_id>/classes/",
+        core_views.class_rosters,
+        name="class_rosters",
+    ),
+    path(
+        "core-admin/org-users/<int:org_id>/classes/<str:class_name>/",
+        core_views.class_roster_detail,
+        name="class_roster_detail",
     ),
 
     # ────────────────────────────────────────────────

--- a/templates/core/admin/class_roster_detail.html
+++ b/templates/core/admin/class_roster_detail.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1>{{ class_name }} — {{ organization.name }}{% if academic_year %} ({{ academic_year }}){% endif %}</h1>
+  <form method="get" class="d-flex" style="gap:.5rem;">
+    {% if academic_year %}<input type="hidden" name="year" value="{{ academic_year }}">{% endif %}
+    <input name="q" value="{{ q }}" class="form-control" placeholder="Search name/email/username">
+    <button class="btn btn-secondary">Search</button>
+  </form>
+</div>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Username</th>
+      <th>Role</th>
+      <th style="width:140px;">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for ra in page_obj.object_list %}
+      <tr>
+        <td>{{ forloop.counter0|add:page_obj.start_index }}</td>
+        <td>{{ ra.user.get_full_name|default:ra.user.username }}</td>
+        <td>{{ ra.user.email }}</td>
+        <td>{{ ra.user.username }}</td>
+        <td>{{ ra.role.name }}</td>
+        <td>
+          <a class="btn btn-sm btn-outline-primary" href="{% url 'admin_user_edit' ra.user.id %}">Edit</a>
+          <a class="btn btn-sm btn-outline-danger" href="{% url 'admin_user_deactivate' ra.user.id %}">Deactivate</a>
+        </td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="6" class="text-center">No users in this class.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<nav aria-label="Pagination">
+  <ul class="pagination">
+    {% if page_obj.has_previous %}
+      <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}&year={{ academic_year }}&q={{ q }}">Prev</a></li>
+    {% endif %}
+    <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span></li>
+    {% if page_obj.has_next %}
+      <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}&year={{ academic_year }}&q={{ q }}">Next</a></li>
+    {% endif %}
+  </ul>
+</nav>
+
+<a class="btn btn-light" href="{% url 'class_rosters' organization.id %}?year={{ academic_year }}">← Back to Classes</a>
+{% endblock %}

--- a/templates/core/admin/class_rosters.html
+++ b/templates/core/admin/class_rosters.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page-header">
+  <h1>Classes: {{ organization.name }}{% if academic_year %} — {{ academic_year }}{% endif %}</h1>
+</div>
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Class</th>
+      <th>Students</th>
+      <th style="width:120px;">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in classes %}
+      <tr>
+        <td>{{ row.class_name|default:"(Unassigned)" }}</td>
+        <td>{{ row.student_count }}</td>
+        <td>
+          <a class="btn btn-primary btn-sm"
+             href="{% url 'class_roster_detail' organization.id row.class_name %}?year={{ academic_year }}">
+            View
+          </a>
+        </td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="3" class="text-center">No classes found.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add academic_year and class_name to RoleAssignment and index by organization/year/class
- introduce class roster listing and detail views
- store uploaded students' class in RoleAssignment and redirect to roster after CSV import

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6899af60bc2c832cbf94600b72975aa3