### PR TITLE
Fix missing admin user deactivation view

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('core-admin/user-management/', views.admin_user_panel, name='admin_user_panel'),
     path('core-admin/users/', views.admin_user_management, name='admin_user_management'),
     path('core-admin/users/<int:user_id>/edit/', views.admin_user_edit, name='admin_user_edit'),
+    path('core-admin/users/<int:user_id>/deactivate/', views.admin_user_deactivate, name='admin_user_deactivate'),
 
     # ────────────────────────────────────────────────
     # Admin - Role Management

--- a/core/views.py
+++ b/core/views.py
@@ -792,6 +792,22 @@ def admin_user_edit(request, user_id):
         },
     )
 
+
+@login_required
+@user_passes_test(lambda u: u.is_superuser)
+def admin_user_deactivate(request, user_id):
+    """Deactivate a user and redirect back to the referring page."""
+    user = get_object_or_404(User, id=user_id)
+    user.is_active = False
+    user.save()
+    messages.success(
+        request,
+        f"User '{user.get_full_name() or user.username}' deactivated successfully.",
+    )
+    return redirect(
+        request.META.get("HTTP_REFERER") or reverse("admin_user_management")
+    )
+
 @user_passes_test(lambda u: u.is_superuser)
 def admin_event_proposals(request):
     proposals = EventProposal.objects.all().order_by("-created_at")


### PR DESCRIPTION
## Summary
- add `admin_user_deactivate` view and route for superusers
- allow admin to disable users from class roster

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6899b37c641c832cb06b1a8e13bf691f