### PR TITLE
Return to roster after editing users

### DIFF
--- a/templates/core/admin/class_roster_detail.html
+++ b/templates/core/admin/class_roster_detail.html
@@ -29,8 +29,10 @@
         <td>{{ ra.user.username }}</td>
         <td>{{ ra.role.name }}</td>
         <td>
-          <a class="btn btn-sm btn-outline-primary" href="{% url 'admin_user_edit' ra.user.id %}">Edit</a>
-          <a class="btn btn-sm btn-outline-danger" href="{% url 'admin_user_deactivate' ra.user.id %}">Deactivate</a>
+          <a class="btn btn-sm btn-outline-primary"
+             href="{% url 'admin_user_edit' ra.user.id %}?next={{ request.get_full_path|urlencode }}">Edit</a>
+          <a class="btn btn-sm btn-outline-danger"
+             href="{% url 'admin_user_deactivate' ra.user.id %}?next={{ request.get_full_path|urlencode }}">Deactivate</a>
         </td>
       </tr>
     {% empty %}

--- a/templates/core/admin_user_edit.html
+++ b/templates/core/admin_user_edit.html
@@ -17,6 +17,7 @@
 
   <form id="user-edit-form" method="post" autocomplete="off">
     {% csrf_token %}
+    <input type="hidden" name="next" value="{{ next }}">
 
     <!-- Basic info -->
     <div class="form-group">
@@ -83,7 +84,7 @@
 
     <div class="form-btn-group">
       <button type="submit" class="btn-submit">Save</button>
-      <a href="{% url 'admin_user_management' %}" class="btn-cancel">Cancel</a>
+      <a href="{{ next }}" class="btn-cancel">Cancel</a>
     </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- Add `next` parameter to roster action links so admin returns to the same roster after editing or deactivating a user
- Preserve `next` in admin user edit form with hidden field and cancel link
- Introduce `safe_next` helper and use it in user edit and deactivate views

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6899b6b0f9a0832cb4f6066309983aa8