### PR TITLE
Improve responsive layout across pages

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -43,10 +43,11 @@
 body.command-center-layout {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: var(--gray-50);
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
   display: grid;
-  grid-template-areas: 
+  grid-template-areas:
     "topbar topbar"
     "sidebar main";
   grid-template-columns: var(--sidebar-width) 1fr;

--- a/static/core/css/proposal_status.css
+++ b/static/core/css/proposal_status.css
@@ -229,3 +229,41 @@ body {
 .btn-view-status i {
   font-size: 1rem;
 }
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .proposal-tracker-card {
+    padding: 2rem 1.5rem;
+  }
+  .tracker-timeline {
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+  .timeline-step {
+    flex-direction: row;
+  }
+  .timeline-step:not(:last-child)::after {
+    display: none;
+  }
+  .proposal-actions-bar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .tracker-title {
+    font-size: 1.5rem;
+  }
+  .proposal-status-container {
+    padding-top: 4rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .btn-back,
+  .btn-edit {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/static/core/css/user_dashboard.css
+++ b/static/core/css/user_dashboard.css
@@ -378,3 +378,15 @@ h3 {
         right: 20px;
     }
 }
+
+@media (max-width: 480px) {
+    .welcome-banner h1 {
+        font-size: 20px;
+    }
+    .nav-tab {
+        padding: 10px 12px;
+    }
+    .main-content {
+        padding: 12px;
+    }
+}


### PR DESCRIPTION
## Summary
- allow vertical scrolling and flexible height in base layout
- add mobile-friendly breakpoints for proposal status view
- tune user dashboard styles for small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6899bbac1138832cbc21ff08051aed2a