### PR TITLE
Add archived classes toggle on bulk upload page

### DIFF
--- a/core/templates/core_admin_org_users/students.html
+++ b/core/templates/core_admin_org_users/students.html
@@ -35,9 +35,8 @@
     </div>
   </div>
 
-  {% if classes %}
   <div class="card p-4">
-    <h3 class="mb-3">Uploaded Classes</h3>
+    <h3 class="mb-3">{% if show_archived %}Archived Classes{% else %}Uploaded Classes{% endif %}</h3>
     <table class="table">
       <thead>
         <tr><th>Class</th><th>Academic Year</th><th>Students</th><th>Actions</th></tr>
@@ -45,12 +44,12 @@
       <tbody>
         {% for cls in classes %}
         <tr>
-          <td>{{ cls.name }}{% if not cls.is_active %} (Archived){% endif %}</td>
+          <td>{{ cls.name }}</td>
           <td>{{ cls.academic_year }}</td>
           <td>{{ cls.student_count }}</td>
           <td>
             <a href="{% url 'admin_org_users_class_detail' org.id cls.id %}">View</a>
-            <form method="post" action="{% url 'admin_org_users_class_toggle' org.id cls.id %}" style="display:inline;">
+            <form method="post" action="{% url 'admin_org_users_class_toggle' org.id cls.id %}{% if show_archived %}?archived=1{% endif %}" style="display:inline;">
               {% csrf_token %}
               <button class="btn btn-link p-0" type="submit">
                 {% if cls.is_active %}Archive{% else %}Activate{% endif %}
@@ -58,10 +57,20 @@
             </form>
           </td>
         </tr>
+        {% empty %}
+        <tr>
+          <td colspan="4" class="text-center text-muted">No {% if show_archived %}archived {% endif %}classes</td>
+        </tr>
         {% endfor %}
       </tbody>
     </table>
+    <div class="d-flex justify-content-end">
+      {% if show_archived %}
+      <a href="{% url 'admin_org_users_students' org.id %}" class="btn btn-secondary btn-sm">Show Active Classes</a>
+      {% else %}
+      <a href="?archived=1" class="btn btn-secondary btn-sm">View Archived Classes</a>
+      {% endif %}
+    </div>
   </div>
-  {% endif %}
 </div>
 {% endblock %}

--- a/core/tests/test_class_management.py
+++ b/core/tests/test_class_management.py
@@ -8,7 +8,7 @@ class ClassManagementTests(TestCase):
         self.admin = User.objects.create_superuser('admin', 'admin@example.com', 'pass')
         ot = OrganizationType.objects.create(name='Dept')
         self.org = Organization.objects.create(name='Math', org_type=ot)
-        self.cls = Class.objects.create(name='A', code='A', organization=self.org)
+        self.cls = Class.objects.create(name='ActiveClass', code='A', organization=self.org)
 
     def test_class_toggle_archives(self):
         self.client.force_login(self.admin)
@@ -17,6 +17,26 @@ class ClassManagementTests(TestCase):
         self.client.post(url)
         self.cls.refresh_from_db()
         self.assertFalse(self.cls.is_active)
+
+    def test_students_view_filters_active_and_archived(self):
+        archived = Class.objects.create(name='ArchivedClass', code='B', organization=self.org, is_active=False)
+        self.client.force_login(self.admin)
+        url = reverse('admin_org_users_students', args=[self.org.id])
+        resp = self.client.get(url)
+        self.assertContains(resp, self.cls.name)
+        self.assertNotContains(resp, 'ArchivedClass')
+        resp = self.client.get(url + '?archived=1')
+        self.assertContains(resp, 'ArchivedClass')
+        self.assertNotContains(resp, self.cls.name)
+
+    def test_toggle_redirect_retains_archived_param(self):
+        self.client.force_login(self.admin)
+        self.cls.is_active = False
+        self.cls.save()
+        url = reverse('admin_org_users_class_toggle', args=[self.org.id, self.cls.id]) + '?archived=1'
+        resp = self.client.post(url)
+        expected = reverse('admin_org_users_students', args=[self.org.id]) + '?archived=1'
+        self.assertEqual(resp['Location'], expected)
 
     def test_user_activate(self):
         user = User.objects.create_user('stud', 'stud@example.com', 'pass', is_active=False)


### PR DESCRIPTION
## Summary
- Hide archived classes by default on the bulk upload page
- Add archived classes view with ability to reactivate classes
- Preserve archived view after toggling class status

## Testing
- `python manage.py test core.tests.test_class_management`

------
https://chatgpt.com/codex/tasks/task_e_6899bf30f238832c88bfeb0984b6140b