### PR TITLE
Add responsive checklist and correct admin view roles stylesheet

### DIFF
--- a/docs/responsive_checklist.md
+++ b/docs/responsive_checklist.md
@@ -1,0 +1,61 @@
+# Responsive Design Checklist
+
+This document maps each CSS file in `static/core/css/` to the templates that include it and provides a placeholder checklist for manual responsive testing. Fill in the test results after verifying each page at multiple zoom levels and screen widths.
+
+## CSS to Template Mapping
+
+| CSS File | Templates |
+| --- | --- |
+| Registration_form.css | Registration_form.html |
+| admin_approval_flow.css | admin_approval_flow_manage.html |
+| admin_dashboard.css | admin_dashboard.html, admin_user_panel.html |
+| admin_event_proposals.css | admin_event_proposals.html |
+| admin_master_data.css | admin_master_data.html, master_data_dashboard.html, admin_approval_flow_list.html, admin_sdg_management.html, admin_pso_po_management.html |
+| admin_proposal_detail.css | admin_proposal_detail.html |
+| admin_pso_po_management.css | admin_pso_po_management.html |
+| admin_role_management.css | admin_role_management.html |
+| admin_settings_dashboard.css | admin_settings.html, admin_approval_dashboard.html, admin_outcome_dashboard.html |
+| admin_user_edit.css | admin_user_edit.html |
+| admin_user_management.css | admin_user_management.html |
+| admin_view_roles.css | admin_view_roles.html |
+| base.css | base.html |
+| command-center.css | base.html |
+| dashboard.css | dashboard.html, admin_dashboard.html, admin_approval_dashboard.html, admin_settings.html, user_dashboard.html, admin_user_panel.html, admin_outcome_dashboard.html |
+| login.css | login.html |
+| outcomes_sdg.css | admin_outcome_dashboard.html, admin_sdg_management.html |
+| proposal_status.css | proposal_status.html |
+| reports.css | admin_reports.html |
+| student_event_details.css | student_event_details.html |
+| user_dashboard.css | user_dashboard.html |
+
+## Manual Testing Checklist
+
+For each page, verify behavior at 80%, 100%, 125%, and 150% zoom levels across common resolutions (mobile, tablet, desktop). Note any overflow, collapsed layouts, or misaligned components.
+
+- [ ] Registration_form.html – notes: _____________________
+- [ ] admin_approval_flow_manage.html – notes: _____________________
+- [ ] admin_dashboard.html – notes: _____________________
+- [ ] admin_user_panel.html – notes: _____________________
+- [ ] admin_event_proposals.html – notes: _____________________
+- [ ] admin_master_data.html – notes: _____________________
+- [ ] master_data_dashboard.html – notes: _____________________
+- [ ] admin_approval_flow_list.html – notes: _____________________
+- [ ] admin_sdg_management.html – notes: _____________________
+- [ ] admin_pso_po_management.html – notes: _____________________
+- [ ] admin_proposal_detail.html – notes: _____________________
+- [ ] admin_role_management.html – notes: _____________________
+- [ ] admin_view_roles.html – notes: _____________________
+- [ ] admin_settings.html – notes: _____________________
+- [ ] admin_approval_dashboard.html – notes: _____________________
+- [ ] admin_outcome_dashboard.html – notes: _____________________
+- [ ] admin_user_edit.html – notes: _____________________
+- [ ] admin_user_management.html – notes: _____________________
+- [ ] dashboard.html – notes: _____________________
+- [ ] login.html – notes: _____________________
+- [ ] admin_outcome_dashboard.html – notes: _____________________
+- [ ] admin_reports.html – notes: _____________________
+- [ ] proposal_status.html – notes: _____________________
+- [ ] student_event_details.html – notes: _____________________
+- [ ] user_dashboard.html – notes: _____________________
+
+*Replace each note section with observations from manual testing.*

--- a/templates/core/admin_view_roles.html
+++ b/templates/core/admin_view_roles.html
@@ -4,7 +4,7 @@
 {% block title %}Role Management{% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{% static 'css/admin_role_management.css' %}">
+<link rel="stylesheet" href="{% static 'core/css/admin_view_roles.css' %}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- Document mapping of CSS files to templates and provide manual testing checklist
- Correct `admin_view_roles.html` to load its own stylesheet

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6899bf3c7e38832ca9a1b072c0801ad5