### PR TITLE
Integrate Percy visual testing

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,19 @@
+name: Visual Regression
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npx percy exec -- playwright test
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,11 @@ full_data.json
 # Data files
 *.json
 emt.txt
+# Allow Node package manifests
+!package.json
+!package-lock.json
 
 media/
+
+# Visual test snapshots
+visual-tests/**-snapshots

--- a/docs/visual-testing.md
+++ b/docs/visual-testing.md
@@ -1,0 +1,15 @@
+# Visual Testing
+
+To run visual regression tests locally with Percy, first set your project token:
+
+```bash
+export PERCY_TOKEN="<your-token>"
+```
+
+Then execute the Playwright tests through Percy:
+
+```bash
+npx percy exec -- playwright test
+```
+
+This command wraps `playwright test` so that snapshots are uploaded to Percy.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "iqac-suite",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "percy:exec": "percy exec -- playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.39.0",
+    "@percy/cli": "^1.0.0",
+    "@percy/playwright": "^1.0.0"
+  }
+}

--- a/visual-tests/critical.spec.js
+++ b/visual-tests/critical.spec.js
@@ -1,0 +1,8 @@
+import { test } from '@playwright/test';
+import percySnapshot from '@percy/playwright';
+
+test('critical paths render correctly', async ({ page }) => {
+  await page.goto('https://example.com');
+  const label = 'critical-path';
+  await percySnapshot(page, label, { widths: [1280] });
+});


### PR DESCRIPTION
## Summary
- ignore committed Playwright snapshot folders and ensure `package.json` is tracked
- add Percy CLI and Playwright bindings with a `percy:exec` script
- switch critical visual test to use Percy snapshots
- document running Percy-powered Playwright tests locally
- wrap CI visual regression job with `percy exec` and project token

## Testing
- `npx percy exec -- playwright test visual-tests/critical.spec.js` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899c6735458832c8492b167c28f733e