### PR TITLE
Enable auto signup with provisional roles

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -50,4 +50,7 @@ class RegistrationRequiredMiddleware:
                 return False
             if not student.registration_number:
                 return False
+        profile = getattr(user, "profile", None)
+        if profile and profile.role:
+            return True
         return RoleAssignment.objects.filter(user=user).exists()

--- a/core/signals.py
+++ b/core/signals.py
@@ -45,10 +45,14 @@ def assign_role_on_login(sender, user, request, **kwargs):
 
     if role_assignment:
         role_name = role_assignment.role.name
-        if profile.role != role_name:
-            profile.role = role_name
-            update_fields.append("role")
-        request.session["role"] = role_name
+    else:
+        domain = user.email.split("@")[-1].lower() if user.email else ""
+        role_name = "student" if domain.endswith("christuniversity.in") else "faculty"
+
+    if profile.role != role_name:
+        profile.role = role_name
+        update_fields.append("role")
+    request.session["role"] = role_name
 
     if not user.is_active:
         user.is_active = True

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -294,12 +294,12 @@ class SocialLoginAccessTests(TestCase):
                 self.user = user
         return DummySocialLogin(user=User(username=username, email=email))
 
-    def test_unknown_email_blocked(self):
+    def test_unknown_email_allowed(self):
         request = self._build_request()
         email = "unknown@example.com"
         sociallogin = self._sociallogin(email)
-        with self.assertRaises(ImmediateHttpResponse):
-            self.adapter.pre_social_login(request, sociallogin)
+        # Should not raise and should not create a user automatically
+        self.adapter.pre_social_login(request, sociallogin)
         self.assertFalse(User.objects.filter(email=email).exists())
 
     def test_existing_user_allowed(self):

--- a/core/tests/test_registration.py
+++ b/core/tests/test_registration.py
@@ -11,7 +11,11 @@ class RegistrationMiddlewareTests(TestCase):
         )
         self.client.force_login(self.user)
 
-    def test_redirects_unregistered_user(self):
+    def test_redirects_when_profile_role_blank(self):
+        # Simulate an unregistered user by clearing their profile role
+        profile = self.user.profile
+        profile.role = ""
+        profile.save(update_fields=["role"])
         response = self.client.get(reverse("dashboard"))
         self.assertRedirects(response, reverse("registration_form"))
 

--- a/core/views_admin_org_users.py
+++ b/core/views_admin_org_users.py
@@ -239,6 +239,10 @@ def upload_csv(request, org_id):
                 },
             )
 
+            if profile.role != org_role.name:
+                profile.role = org_role.name
+                profile.save(update_fields=["role"])
+
             if org_role.name == "student" and cls is not None:
                 student_obj, _ = EmtStudent.objects.get_or_create(user=user)
                 cls.students.add(student_obj)


### PR DESCRIPTION
## Summary
- allow unknown emails to sign up via Google and assign provisional student/faculty role
- infer and persist role on first login and during bulk uploads
- treat non-empty profile roles as registered to bypass registration page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ad90a14f0832ca9c1ddc990a2893c