### PR TITLE
Allow first-time login for bulk-uploaded users

### DIFF
--- a/core/auth_backends.py
+++ b/core/auth_backends.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.backends import ModelBackend
+
+
+class AllowInactiveFirstLoginBackend(ModelBackend):
+    """Allow users who have never activated to authenticate once.
+
+    Standard ModelBackend refuses to authenticate users with ``is_active`` set
+    to ``False``.  When users are bulk uploaded, their accounts start inactive
+    and they should be able to log in once to activate themselves.  This backend
+    permits authentication for such users while still blocking logins for
+    accounts that have been explicitly deactivated after activation.
+    """
+
+    def user_can_authenticate(self, user):
+        if user.is_active:
+            return True
+        profile = getattr(user, "profile", None)
+        if profile and getattr(profile, "activated_at", None) is None:
+            return True
+        return False

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -37,8 +37,8 @@ class UserRoleAssignmentTests(TestCase):
         session = self.client.session
         session['org_id'] = self.org.id
         session.save()
-        user = User.objects.get(username=username)
-        self.client.force_login(user)
+        success = self.client.login(username=username, password=password)
+        self.assertTrue(success)
 
     def test_student_role_assigned_on_login(self):
         user = User.objects.create_user(
@@ -95,7 +95,7 @@ class ApprovalFlowViewTests(TestCase):
         user = User.objects.create_user("user", "u@x.com", "pass", is_active=False)
         role = OrganizationRole.objects.create(organization=org, name="Member")
         RoleAssignment.objects.create(user=user, role=role, organization=org)
-        self.client.force_login(user)
+        self.assertTrue(self.client.login(username="user", password="pass"))
 
         resp = self.client.post(
             f"/core-admin/approval-flow/{org.id}/save/",
@@ -142,7 +142,7 @@ class SaveApprovalFlowTests(TestCase):
         user = User.objects.create_user("user", "u@x.com", "pass", is_active=False)
         role = OrganizationRole.objects.create(organization=self.org, name="Member")
         RoleAssignment.objects.create(user=user, role=role, organization=self.org)
-        self.client.force_login(user)
+        self.assertTrue(self.client.login(username="user", password="pass"))
 
         resp = self.client.post(
             f"/core-admin/approval-flow/{self.org.id}/save/",

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -106,7 +106,7 @@ DATABASES = {
 # AUTHENTICATION
 # ──────────────────────────────────────────────────────────────────────────────
 AUTHENTICATION_BACKENDS = [
-    'django.contrib.auth.backends.ModelBackend',
+    'core.auth_backends.AllowInactiveFirstLoginBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
 


### PR DESCRIPTION
## Summary
- allow inactive bulk-uploaded users to authenticate on their first login
- enable backend activation via a custom auth backend
- test bulk upload and user activation flows

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689ae0712da4832cb301a6a23a1cfa51