### PR TITLE
Fix duplicate role assignments on bulk upload

### DIFF
--- a/core/views_admin_org_users.py
+++ b/core/views_admin_org_users.py
@@ -293,8 +293,8 @@ def upload_csv(request, org_id):
             RoleAssignment.objects.update_or_create(
                 user=user,
                 organization=org,
+                role=org_role,
                 defaults={
-                    "role": org_role,
                     "academic_year": ay,
                     "class_name": class_name if org_role.name == "student" else None,
                 },


### PR DESCRIPTION
## Summary
- prevent duplicate entries when bulk uploading users by keying RoleAssignment on role

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b0883712c832ca9655b8a7b5a65cc