### PR TITLE
Fix role management redirects causing TypeError

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -583,7 +583,7 @@ def add_org_role(request, organization_id):
                 is_active=True
                 # Remove description if not in model
             )
-    return redirect("admin_role_management") + f"?org_type_id={org.org_type.id}"
+    return redirect(f"{reverse('admin_role_management')}?org_type_id={org.org_type.id}")
 
 
 @user_passes_test(lambda u: u.is_superuser)
@@ -627,7 +627,7 @@ def update_org_role(request, role_id):
 
     if not new_name:
         messages.error(request, "Role name is required.")
-        return redirect("admin_role_management") + f"?org_type_id={org_type.id}"
+        return redirect(f"{reverse('admin_role_management')}?org_type_id={org_type.id}")
 
     # Update all roles with the old name from all organizations of this type
     updated_count = OrganizationRole.objects.filter(
@@ -639,7 +639,7 @@ def update_org_role(request, role_id):
     )
     
     messages.success(request, f"Role updated for {updated_count} {org_type.name}(s).")
-    return redirect("admin_role_management") + f"?org_type_id={org_type.id}"
+    return redirect(f"{reverse('admin_role_management')}?org_type_id={org_type.id}")
 
 
 @user_passes_test(lambda u: u.is_superuser)
@@ -669,7 +669,7 @@ def delete_org_role(request, role_id):
     ).delete()[0]
     
     messages.success(request, f"Role '{role_name}' deleted from {deleted_count} {org_type.name}(s).")
-    return redirect("admin_role_management") + f"?org_type_id={org_type.id}"
+    return redirect(f"{reverse('admin_role_management')}?org_type_id={org_type.id}")
 
 # ===================================================================
 # END OF SINGLE-PAGE ROLE MANAGEMENT


### PR DESCRIPTION
## Summary
- Construct redirect URLs with `reverse` to include query parameters for role management
- Prevents `TypeError` when adding, updating, or deleting organization roles

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b13c2209c832c9bf3751eacb0b780