### PR TITLE
Filter user-management roles by organization

### DIFF
--- a/core/tests/test_admin_user_management.py
+++ b/core/tests/test_admin_user_management.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from core.models import OrganizationType, Organization, OrganizationRole
+
+
+class AdminUserManagementRoleFilterTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser('admin', 'admin@example.com', 'pass')
+        self.client.force_login(self.admin)
+
+        org_type = OrganizationType.objects.create(name='Department')
+        self.org1 = Organization.objects.create(name='Org One', org_type=org_type)
+        self.org2 = Organization.objects.create(name='Org Two', org_type=org_type)
+        OrganizationRole.objects.create(organization=self.org1, name='Role A')
+        OrganizationRole.objects.create(organization=self.org2, name='Role B')
+
+    def test_roles_filtered_by_selected_organization(self):
+        url = reverse('admin_user_management')
+        resp = self.client.get(url, {'organization[]': str(self.org1.id)})
+        self.assertContains(resp, 'Role A')
+        self.assertNotContains(resp, 'Role B')

--- a/core/views.py
+++ b/core/views.py
@@ -735,7 +735,14 @@ def admin_user_management(request):
         users = paginator.page(paginator.num_pages)
 
     # Filter options data
-    all_roles = OrganizationRole.objects.filter(is_active=True).order_by('name')
+    all_roles = OrganizationRole.objects.filter(is_active=True)
+    if org_ids:
+        # Restrict roles to those belonging to the selected organizations
+        all_roles = all_roles.filter(organization_id__in=org_ids)
+    if role_ids:
+        # Ensure currently selected roles remain available in the dropdown
+        all_roles = all_roles | OrganizationRole.objects.filter(id__in=role_ids)
+    all_roles = all_roles.select_related('organization').order_by('name').distinct()
     all_organizations = Organization.objects.filter(is_active=True).order_by('name')
     all_org_types = OrganizationType.objects.filter(is_active=True).order_by('name')
 


### PR DESCRIPTION
## Summary
- filter role options in admin user management by selected organizations
- ensure selected roles remain visible when organizations change
- add regression test for organization-based role filtering

## Testing
- `python manage.py test core.tests.test_admin_user_management core.tests.test_user_activation`


------
https://chatgpt.com/codex/tasks/task_e_689b14f7c918832cb51bcdb0e29f8c60