### PR TITLE
Tidy role dropdowns on user edit page

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -19,6 +19,8 @@ class RoleAssignmentForm(forms.ModelForm):
         self.fields["organization"].queryset = (
             Organization.objects.filter(org_filter).order_by("name")
         )
+        # Replace Django's default blank label ("---------") with a clearer prompt
+        self.fields["organization"].empty_label = "Select Organization"
 
         # Include active roles plus the currently assigned role (even if inactive)
         role_filter = Q(is_active=True)
@@ -29,6 +31,8 @@ class RoleAssignmentForm(forms.ModelForm):
             .select_related("organization")
             .order_by("name")
         )
+        # Remove the implicit blank option from the role dropdown
+        self.fields["role"].empty_label = "Select Role"
 
 
 class RegistrationForm(forms.Form):


### PR DESCRIPTION
## Summary
- Replace Django's default "---------" option in organization/role dropdowns with clear "Select Organization" and "Select Role" prompts

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b196e69bc832c9e784aa7f679b0f7