### PR TITLE
Restrict faculty choices to proposal organization

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -302,6 +302,7 @@ $(document).ready(function() {
     function setupFacultyTomSelect() {
         const facultySelect = $('#faculty-select');
         const djangoFacultySelect = $('#django-basic-info [name="faculty_incharges"]');
+        const djangoOrgSelect = $('#django-basic-info [name="organization"]');
         if (!facultySelect.length || !djangoFacultySelect.length || facultySelect[0].tomselect) return;
 
         const existingOptions = Array.from(djangoFacultySelect.find('option')).map(opt => {
@@ -318,8 +319,9 @@ $(document).ready(function() {
             maxItems: 10,
             options: existingOptions,
             load: (query, callback) => {
-                if (!query.length) return callback();
-                fetch(`${window.API_FACULTY}?q=${encodeURIComponent(query)}`)
+                const orgId = djangoOrgSelect.val();
+                if (!query.length || !orgId) return callback();
+                fetch(`${window.API_FACULTY}?org_id=${orgId}&q=${encodeURIComponent(query)}`)
                     .then(r => r.json())
                     .then(callback)
                     .catch(() => callback());
@@ -489,7 +491,9 @@ $(document).ready(function() {
                     })
                     .catch(() => { list.text('Error loading.'); });
             } else {
-                fetch(window.API_FACULTY)
+                const orgId = djangoOrgSelect.val();
+                if (!orgId) { list.text('Select an organization first.'); return; }
+                fetch(`${window.API_FACULTY}?org_id=${orgId}`)
                     .then(r => r.json())
                     .then(data => {
                         list.empty();

--- a/emt/tests.py
+++ b/emt/tests.py
@@ -97,6 +97,26 @@ class FacultyAPITests(TestCase):
         ids = {item["id"] for item in data}
         self.assertIn(user5.id, ids)
 
+    def test_api_faculty_filters_by_organization(self):
+        other_org = Organization.objects.create(name="Arts", org_type=self.ot)
+        other_role = OrganizationRole.objects.create(
+            organization=other_org, name=ApprovalStep.Role.FACULTY.value
+        )
+        other_user = User.objects.create(
+            username="f3", first_name="Gamma", email="gamma@example.com"
+        )
+        RoleAssignment.objects.create(
+            user=other_user, role=other_role, organization=other_org
+        )
+
+        resp = self.client.get(reverse("emt:api_faculty"), {"org_id": self.org.id})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(self.user1.id, ids)
+        self.assertIn(self.user2.id, ids)
+        self.assertNotIn(other_user.id, ids)
+
 
 class OutcomesAPITests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- Filter `api_faculty` results by optional `org_id`
- Limit audience modal and faculty selector to users from the chosen organization
- Test filtering to ensure users from other organizations are excluded

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c093032d4832cb0d71feb0fd770d1