### PR TITLE
Avoid duplicate roles in user management

### DIFF
--- a/core/tests/test_admin_user_management.py
+++ b/core/tests/test_admin_user_management.py
@@ -21,3 +21,29 @@ class AdminUserManagementRoleFilterTests(TestCase):
         resp = self.client.get(url, {'organization[]': str(self.org1.id)})
         self.assertContains(resp, 'Role A')
         self.assertNotContains(resp, 'Role B')
+
+
+class AdminUserManagementRoleDisplayTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser('admin', 'admin@example.com', 'pass')
+        self.client.force_login(self.admin)
+
+        org_type = OrganizationType.objects.create(name='Department')
+        self.org = Organization.objects.create(name='Commerce', org_type=org_type)
+        self.role = OrganizationRole.objects.create(organization=self.org, name='student')
+
+    def test_user_role_not_duplicated_when_assignment_exists(self):
+        user = User.objects.create(username='student1', email='student1@example.com')
+        # RoleAssignment created via bulk upload should replace profile role display
+        from core.models import RoleAssignment
+
+        RoleAssignment.objects.create(user=user, organization=self.org, role=self.role)
+
+        url = reverse('admin_user_management')
+        resp = self.client.get(url)
+        self.assertContains(
+            resp,
+            '<span class="badge bg-primary">student</span>',
+            count=1,
+            html=True,
+        )

--- a/templates/core/admin_user_management.html
+++ b/templates/core/admin_user_management.html
@@ -363,14 +363,15 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if user.profile %}
+                        {% if user.role_assignments.all %}
+                            {% for ra in user.role_assignments.all %}
+                                <div class="{% if not forloop.first %}mt-1{% endif %}">
+                                    <span class="badge {% if forloop.first %}bg-primary{% else %}bg-secondary{% endif %}">{{ ra.role.name }}</span>
+                                </div>
+                            {% endfor %}
+                        {% elif user.profile %}
                             <span class="badge bg-primary">{{ user.profile.get_role_display }}</span>
                         {% endif %}
-                        {% for ra in user.role_assignments.all %}
-                            <div class="mt-1">
-                                <span class="badge bg-secondary">{{ ra.role.name }}</span>
-                            </div>
-                        {% endfor %}
                     </td>
                     <td>
                         {% for ra in user.role_assignments.all %}


### PR DESCRIPTION
## Summary
- prevent duplicate role badges in admin user management by showing profile role only when no assignments exist
- test that users with both profile and assignment roles display the role once

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689c0c29eec8832c963da7f13ca62214