### PR TITLE
feat: add searchable student coordinators

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -33,8 +33,7 @@ class EventProposalForm(forms.ModelForm):
     )
     student_coordinators = forms.CharField(
         required=False,
-        widget=forms.Textarea(attrs={'rows': 2, 'placeholder': 'e.g., Alice, Bob'}),
-        help_text="Enter student coordinator names, separated by commas."
+        widget=forms.HiddenInput(),
     )
     sdg_goals = forms.ModelMultipleChoiceField(
         queryset=SDGGoal.objects.all(),

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -217,8 +217,8 @@
                             </div>
                             <div class="input-group">
                                 <label for="student-coordinators-modern">Student Coordinators</label>
-                                <input type="text" id="student-coordinators-modern" placeholder="Names of student coordinators">
-                                <div class="help-text">List the names of student coordinators</div>
+                                <select id="student-coordinators-modern" multiple></select>
+                                <div class="help-text">Search and select student coordinators from the target audience</div>
                             </div>
                         </div>
                         


### PR DESCRIPTION
## Summary
- allow selecting student coordinators via searchable multiselect limited to chosen target audience
- hide raw student coordinator text field in form
- update proposal dashboard JS to sync with Django form and manage options dynamically

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689c1ae5c23c832c819a4c9e874f4164