### PR TITLE
Restrict SDG goals to UN list

### DIFF
--- a/core/migrations/0033_seed_sdg_goals.py
+++ b/core/migrations/0033_seed_sdg_goals.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+from core.models import SDG_GOALS
+
+
+def seed_sdg_goals(apps, schema_editor):
+    SDGGoal = apps.get_model('core', 'SDGGoal')
+    for name in SDG_GOALS:
+        SDGGoal.objects.get_or_create(name=name)
+    SDGGoal.objects.exclude(name__in=SDG_GOALS).delete()
+
+
+def reverse_seed(apps, schema_editor):
+    SDGGoal = apps.get_model('core', 'SDGGoal')
+    SDGGoal.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0032_popsochangenotification_popsoassignment"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_sdg_goals, reverse_seed),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -4,6 +4,26 @@ from django.conf import settings
 from django.utils import timezone
 from django.db.models import Q
 
+# Predefined Sustainable Development Goals
+SDG_GOALS = [
+    "No Poverty",
+    "Zero Hunger",
+    "Good Health and Well-Being",
+    "Quality Education",
+    "Gender Equality",
+    "Clean Water and Sanitation",
+    "Affordable and Clean Energy",
+    "Decent Work and Economic Growth",
+    "Industry, Innovation and Infrastructure",
+    "Reduced Inequalities",
+    "Sustainable Cities and Communities",
+    "Responsible Consumption and Production",
+    "Climate Action",
+    "Life Below Water",
+    "Life on Land",
+    "Peace, Justice and Strong Institutions",
+    "Partnerships for the Goals",
+]
 # ───────────────────────────────
 #  New Generic Organization Models
 # ───────────────────────────────

--- a/core/views.py
+++ b/core/views.py
@@ -1293,19 +1293,10 @@ def admin_outcome_dashboard(request):
 
 @user_passes_test(lambda u: u.is_superuser)
 def admin_sdg_management(request):
-    """Manage Sustainable Development Goals."""
-    from .models import SDGGoal
+    """Display Sustainable Development Goals."""
+    from .models import SDGGoal, SDG_GOALS
 
-    if request.method == "POST":
-        if request.POST.get("delete_goal_id"):
-            SDGGoal.objects.filter(id=request.POST["delete_goal_id"]).delete()
-            return redirect("admin_sdg_management")
-        name = request.POST.get("name", "").strip()
-        if name:
-            SDGGoal.objects.get_or_create(name=name)
-        return redirect("admin_sdg_management")
-
-    goals = SDGGoal.objects.all().order_by("id")
+    goals = SDGGoal.objects.filter(name__in=SDG_GOALS).order_by("id")
     return render(request, "core/admin_sdg_management.html", {"goals": goals})
 
 

--- a/emt/forms.py
+++ b/emt/forms.py
@@ -6,7 +6,7 @@ from .models import (
     EventExpectedOutcomes, TentativeFlow, SpeakerProfile,
     ExpenseDetail, EventReport, EventReportAttachment, CDLSupport
 )
-from core.models import Organization, OrganizationType, SDGGoal
+from core.models import Organization, OrganizationType, SDGGoal, SDG_GOALS
 
 class EventProposalForm(forms.ModelForm):
     organization_type = forms.ModelChoiceField(
@@ -36,7 +36,7 @@ class EventProposalForm(forms.ModelForm):
         widget=forms.HiddenInput(),
     )
     sdg_goals = forms.ModelMultipleChoiceField(
-        queryset=SDGGoal.objects.all(),
+        queryset=SDGGoal.objects.filter(name__in=SDG_GOALS).order_by("id"),
         required=False,
         widget=forms.CheckboxSelectMultiple,
         label='Aligned SDG Goals',

--- a/emt/tests.py
+++ b/emt/tests.py
@@ -9,10 +9,11 @@ from emt.utils import (
     unlock_optionals_after,
     skip_all_downstream_optionals,
 )
+from emt.forms import EventProposalForm
 from core.models import (
     OrganizationType, Organization, OrganizationRole, RoleAssignment,
     Program, ProgramOutcome, ProgramSpecificOutcome,
-    ApprovalFlowTemplate, ApprovalFlowConfig,
+    ApprovalFlowTemplate, ApprovalFlowConfig, SDG_GOALS,
 )
 import json
 from unittest.mock import patch
@@ -594,3 +595,11 @@ class LinkedInProfileFetchTests(TestCase):
         )
         self.assertEqual(resp.status_code, 400)
         mock_get.assert_not_called()
+
+
+class SDGGoalsFormTests(TestCase):
+    def test_form_lists_predefined_sdg_goals_only(self):
+        form = EventProposalForm()
+        names = list(form.fields["sdg_goals"].queryset.values_list("name", flat=True))
+        self.assertEqual(set(names), set(SDG_GOALS))
+        self.assertEqual(len(names), len(SDG_GOALS))

--- a/emt/views.py
+++ b/emt/views.py
@@ -24,6 +24,7 @@ from core.models import (
     ApprovalFlowTemplate,
     SDGGoal,
     Class,
+    SDG_GOALS,
 )
 from django.contrib.auth.models import User
 from emt.utils import (
@@ -284,7 +285,7 @@ def submit_proposal(request, pk=None):
         "objectives": objectives,
         "outcomes": outcomes,
         "flow": flow,
-        "sdg_goals_list": json.dumps(list(SDGGoal.objects.values('id','name'))),
+        "sdg_goals_list": json.dumps(list(SDGGoal.objects.filter(name__in=SDG_GOALS).values('id','name'))),
         "activities_json": json.dumps(activities),
         "speakers_json": json.dumps(speakers),
         "expenses_json": json.dumps(expenses),

--- a/templates/core/admin_sdg_management.html
+++ b/templates/core/admin_sdg_management.html
@@ -10,31 +10,16 @@
     <div class="sdg-title">SDG Goals Management</div>
   </div>
 
-  <div class="sdg-toolbar">
-    <form method="post" class="row">
-      {% csrf_token %}
-      <input type="text" name="name" placeholder="Add new SDG goal..." required class="input">
-      <button type="submit" class="btn btn-primary">+ Add Goal</button>
-    </form>
-  </div>
-
   {% if goals %}
   <div class="card mt">
     <div class="table-wrap">
       <table class="table">
-        <thead><tr><th>#</th><th>Goal</th><th>Action</th></tr></thead>
+        <thead><tr><th>#</th><th>Goal</th></tr></thead>
         <tbody>
         {% for goal in goals %}
           <tr>
             <td>{{ goal.id }}</td>
             <td>{{ goal.name }}</td>
-            <td>
-              <form method="post" style="display:inline">
-                {% csrf_token %}
-                <input type="hidden" name="delete_goal_id" value="{{ goal.id }}">
-                <button type="submit" class="btn btn-quiet delete-btn"><i class="fas fa-trash"></i> Delete</button>
-              </form>
-            </td>
           </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- Seed database with the 17 official UN Sustainable Development Goals
- Limit event proposal form and views to only these SDG options
- Make SDG management page read-only and add regression test

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689c1ff8b610832c80afa20ab06c4463