### PR TITLE
Remove first-login registration prompt

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -3,8 +3,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from django.urls import reverse
 from django.utils.text import slugify
 from django.contrib.auth.models import User
-from core.models import Profile, RoleAssignment
-from emt.models import Student
+from core.models import Profile
 
 class SchoolSocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
@@ -79,14 +78,4 @@ class RoleBasedAccountAdapter(DefaultAccountAdapter):
         user = request.user
         if user.is_superuser:
             return reverse('admin_dashboard')
-        domain = user.email.split('@')[-1].lower() if user.email else ''
-        if domain.endswith('christuniversity.in'):
-            try:
-                student = user.student_profile
-            except Student.DoesNotExist:
-                return reverse('registration_form')
-            if not getattr(student, 'registration_number', ''):
-                return reverse('registration_form')
-        if not RoleAssignment.objects.filter(user=user).exists():
-            return reverse('registration_form')
         return reverse('dashboard')

--- a/core/tests/test_registration.py
+++ b/core/tests/test_registration.py
@@ -1,29 +1,21 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from core.models import OrganizationType, Organization, OrganizationRole, RoleAssignment
+from core.models import OrganizationType, Organization, OrganizationRole
 
 
-class RegistrationMiddlewareTests(TestCase):
+class RegistrationAccessTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(
             username="u1", email="u1@example.com", password="pass"
         )
         self.client.force_login(self.user)
 
-    def test_redirects_when_profile_role_blank(self):
+    def test_dashboard_access_without_registration(self):
         # Simulate an unregistered user by clearing their profile role
         profile = self.user.profile
         profile.role = ""
         profile.save(update_fields=["role"])
-        response = self.client.get(reverse("dashboard"))
-        self.assertRedirects(response, reverse("registration_form"))
-
-    def test_allows_access_after_role_assignment(self):
-        ot = OrganizationType.objects.create(name="Dept")
-        org = Organization.objects.create(name="Math", org_type=ot)
-        role = OrganizationRole.objects.create(name="Member", organization=org)
-        RoleAssignment.objects.create(user=self.user, role=role, organization=org)
         response = self.client.get(reverse("dashboard"))
         self.assertEqual(response.status_code, 200)
 

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -57,7 +57,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'allauth.account.middleware.AccountMiddleware',  # ← allauth middleware
-    'core.middleware.RegistrationRequiredMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
## Summary
- stop enforcing registration at login by removing registration middleware
- send users directly to the dashboard after login
- update tests to reflect optional registration

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c29d8bec4832caa2d893af9ef0fc8