### PR TITLE
fix: persist committee ids for target audience

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -352,10 +352,14 @@ $(document).ready(function() {
     function setupCommitteesTomSelect() {
         const select = $('#committees-collaborations-modern');
         const djangoField = $('#django-basic-info [name="committees_collaborations"]');
+        const idsField = $('#django-basic-info [name="committees_collaborations_ids"]');
         if (!select.length || !djangoField.length || select[0].tomselect) return;
 
-        const existing = djangoField.val()
+        const existingNames = djangoField.val()
             ? djangoField.val().split(',').map(s => s.trim()).filter(Boolean)
+            : [];
+        const existingIds = idsField.length && idsField.val()
+            ? idsField.val().split(',').map(s => s.trim()).filter(Boolean)
             : [];
 
         const tom = new TomSelect(select[0], {
@@ -379,14 +383,18 @@ $(document).ready(function() {
             const ids = tom.getValue();
             const names = ids.map(id => tom.options[id]?.text || id);
             djangoField.val(names.join(', ')).trigger('change');
-            // store selected ids for later use (e.g., audience modal)
-            select.data('selected-org-ids', ids);
+            if (idsField.length) {
+                idsField.val(ids.join(', ')).trigger('change');
+            }
             clearFieldError(select);
         });
 
-        if (existing.length) {
-            existing.forEach(name => tom.addOption({ id: name, text: name }));
-            tom.setValue(existing);
+        if (existingNames.length) {
+            existingNames.forEach((name, idx) => {
+                const id = existingIds[idx] || name;
+                tom.addOption({ id, text: name });
+            });
+            tom.setValue(existingIds.length ? existingIds : existingNames);
         }
 
         const orgSelect = $('#django-basic-info [name="organization"]');

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -279,6 +279,7 @@
                     {{ form.pos_pso }}
                     {{ form.committees_collaborations.label_tag }}
                     {{ form.committees_collaborations }}
+                    <input type="hidden" name="committees_collaborations_ids" id="committees-collaborations-ids">
                     {{ form.sdg_goals.label_tag }}
                     {{ form.sdg_goals }}
                     {{ form.academic_year.label_tag }}


### PR DESCRIPTION
## Summary
- store selected committee IDs in a hidden field so they persist across autosave
- initialize committee selector with stored IDs to keep classes available after refresh

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c2b13ae08832cad023d93b4c87713