### PR TITLE
Handle sparse indices when saving proposal details

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 import json
+import re
 from urllib.parse import urlparse
 import requests
 from django.db.models import Q
@@ -133,21 +134,23 @@ def _save_text_sections(proposal, data):
 
 def _save_activities(proposal, data):
     proposal.activities.all().delete()
-    index = 1
-    while True:
+    pattern = re.compile(r"^activity_(?:name|date)_(\d+)$")
+    indices = sorted({int(m.group(1)) for key in data.keys() if (m := pattern.match(key))})
+    for index in indices:
         name = data.get(f"activity_name_{index}")
         date = data.get(f"activity_date_{index}")
-        if not name and not date:
-            break
         if name and date:
             EventActivity.objects.create(proposal=proposal, name=name, date=date)
-        index += 1
 
 
 def _save_speakers(proposal, data, files):
     proposal.speakers.all().delete()
-    index = 0
-    while f"speaker_full_name_{index}" in data:
+    pattern = re.compile(
+        r"^speaker_(?:full_name|designation|affiliation|contact_email|contact_number|linkedin_url|photo|detailed_profile)_(\d+)$"
+    )
+    all_keys = list(data.keys()) + list(files.keys())
+    indices = sorted({int(m.group(1)) for key in all_keys if (m := pattern.match(key))})
+    for index in indices:
         full_name = data.get(f"speaker_full_name_{index}")
         if full_name:
             SpeakerProfile.objects.create(
@@ -161,13 +164,13 @@ def _save_speakers(proposal, data, files):
                 photo=files.get(f"speaker_photo_{index}"),
                 detailed_profile=data.get(f"speaker_detailed_profile_{index}", ""),
             )
-        index += 1
 
 
 def _save_expenses(proposal, data):
     proposal.expense_details.all().delete()
-    index = 0
-    while f"expense_particulars_{index}" in data or f"expense_amount_{index}" in data:
+    pattern = re.compile(r"^expense_(?:sl_no|particulars|amount)_(\d+)$")
+    indices = sorted({int(m.group(1)) for key in data.keys() if (m := pattern.match(key))})
+    for index in indices:
         particulars = data.get(f"expense_particulars_{index}")
         amount = data.get(f"expense_amount_{index}")
         if particulars and amount:
@@ -178,13 +181,15 @@ def _save_expenses(proposal, data):
                 particulars=particulars,
                 amount=amount,
             )
-        index += 1
 
 
 def _save_income(proposal, data):
     proposal.income_details.all().delete()
-    index = 0
-    while f"income_particulars_{index}" in data or f"income_amount_{index}" in data:
+    pattern = re.compile(
+        r"^income_(?:sl_no|particulars|participants|rate|amount)_(\d+)$"
+    )
+    indices = sorted({int(m.group(1)) for key in data.keys() if (m := pattern.match(key))})
+    for index in indices:
         particulars = data.get(f"income_particulars_{index}")
         participants = data.get(f"income_participants_{index}")
         rate = data.get(f"income_rate_{index}")
@@ -199,7 +204,6 @@ def _save_income(proposal, data):
                 rate=rate,
                 amount=amount,
             )
-        index += 1
 
 
 # ──────────────────────────────


### PR DESCRIPTION
## Summary
- Extract numeric indices from POST keys with regex for activities, speakers, expenses, and income helpers
- Iterate over sorted index sets so later rows save even if earlier indices are missing

## Testing
- `python manage.py test`
- `python manage.py shell -c "from django.contrib.auth.models import User; from emt.models import EventProposal; from emt.views import _save_activities, _save_speakers, _save_expenses, _save_income; u=User.objects.create(username='tester'); p=EventProposal.objects.create(submitted_by=u); _save_activities(p, {'activity_name_1':'A','activity_date_1':'2024-01-01','activity_name_3':'C','activity_date_3':'2024-01-03'}); _save_speakers(p, {'speaker_full_name_0':'S0','speaker_designation_0':'D0','speaker_affiliation_0':'A0','speaker_contact_email_0':'s0@example.com','speaker_contact_number_0':'123','speaker_detailed_profile_0':'Bio0','speaker_full_name_2':'S2','speaker_designation_2':'D2','speaker_affiliation_2':'A2','speaker_contact_email_2':'s2@example.com','speaker_contact_number_2':'456','speaker_detailed_profile_2':'Bio2'}, {}); _save_expenses(p, {'expense_sl_no_0':'1','expense_particulars_0':'Item0','expense_amount_0':'100','expense_sl_no_2':'3','expense_particulars_2':'Item2','expense_amount_2':'300'}); _save_income(p, {'income_sl_no_0':'1','income_particulars_0':'Inc0','income_participants_0':'10','income_rate_0':'5','income_amount_0':'50','income_sl_no_2':'3','income_particulars_2':'Inc2','income_participants_2':'30','income_rate_2':'5','income_amount_2':'150'}); print('Activities:', list(p.activities.values_list('name', flat=True))); print('Speakers:', list(p.speakers.values_list('full_name', flat=True))); print('Expenses:', list(p.expense_details.values_list('particulars', flat=True))); print('Income:', list(p.income_details.values_list('particulars', flat=True)))"`

------
https://chatgpt.com/codex/tasks/task_e_689c346f7dfc832c9b999904d61970f3