### PR TITLE
Simplify academic year to single global setting

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -3,6 +3,7 @@ from django.utils.timesince import timesince
 from django.db.models import Q
 from datetime import timedelta
 from emt.models import EventProposal
+from transcript.models import AcademicYear
 
 def notifications(request):
     """Return proposal-related notifications for the logged-in user."""
@@ -34,3 +35,9 @@ def notifications(request):
         notif_list.append({'type': n_type, 'msg': message, 'time': time_label})
 
     return {'notifications': notif_list}
+
+
+def active_academic_year(request):
+    """Provide the single active academic year to all templates."""
+    ay = AcademicYear.objects.first()
+    return {"active_academic_year": ay}

--- a/core/urls.py
+++ b/core/urls.py
@@ -176,12 +176,6 @@ urlpatterns = [
     ),
 
     # ────────────────────────────────────────────────
-    # AJAX - Academic Year
-    # ────────────────────────────────────────────────
-    path('core-admin/set-academic-year/', views.set_academic_year, name='set_academic_year'),
-    path('core-admin/add-academic-year/', views.add_academic_year, name='add_academic_year'),
-
-    # ────────────────────────────────────────────────
     # Core APIs (Admin Dashboard)
     # ────────────────────────────────────────────────
     path('core-admin/api/auth/me', views.api_auth_me, name='api_auth_me'),

--- a/emt/views.py
+++ b/emt/views.py
@@ -211,9 +211,9 @@ def _save_income(proposal, data):
 # ──────────────────────────────
 @login_required
 def submit_proposal(request, pk=None):
-    # --- Academic year: set a default if missing (for demo/dev, set your real logic as needed) ---
-    if not request.session.get('selected_academic_year'):
-        request.session['selected_academic_year'] = "2024-2025"  # Or dynamically fetch the current active year!
+    from transcript.models import AcademicYear
+    active_year = AcademicYear.objects.first()
+    selected_academic_year = active_year.year if active_year else ""
 
     proposal = None
     if pk:
@@ -228,7 +228,7 @@ def submit_proposal(request, pk=None):
         form = EventProposalForm(
             post_data,
             instance=proposal,
-            selected_academic_year=request.session.get('selected_academic_year'),
+            selected_academic_year=selected_academic_year,
             user=request.user,
         )
 
@@ -245,12 +245,9 @@ def submit_proposal(request, pk=None):
         # --------------------------------------------------
 
     else:
-        # Always get the selected academic year from session (ensured above)
-        selected_academic_year = request.session.get('selected_academic_year')
-        
         # Only pre-populate form with existing data if it's still a draft
         form_instance = proposal if (proposal and proposal.status == 'draft') else None
-        
+
         form = EventProposalForm(
             instance=form_instance,
             selected_academic_year=selected_academic_year,

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -78,6 +78,7 @@ TEMPLATES = [
                 'django.template.context_processors.csrf',
                 'django.contrib.messages.context_processors.messages',
                 'core.context_processors.notifications',
+                'core.context_processors.active_academic_year',
             ],
             'libraries': {
                 'dict_filters': 'core.templatetags.dict_filters',

--- a/static/core/js/admin_master_data.js
+++ b/static/core/js/admin_master_data.js
@@ -36,8 +36,6 @@ function initializeMasterData() {
     // Initialize form handlers
     initializeFormHandlers();
     
-    // Initialize academic year functionality
-    initializeAcademicYear();
     
     // Show success message if redirected after operation
     const urlParams = new URLSearchParams(window.location.search);
@@ -433,59 +431,6 @@ function initializeFormHandlers() {
     }
 }
 
-// Academic Year functionality
-function initializeAcademicYear() {
-    const academicYearSelect = document.querySelector('#academicYearSelect');
-    if (academicYearSelect && academicYearSelect.value) {
-        localStorage.setItem('selectedAcademicYear', academicYearSelect.value);
-    }
-}
-
-function setAcademicYear(year) {
-    localStorage.setItem('selectedAcademicYear', year);
-    fetch('/core-admin/set-academic-year/', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': getCsrfToken()
-        },
-        body: JSON.stringify({ academic_year: year })
-    }).then(() => {
-        window.location.href = '?year=' + encodeURIComponent(year);
-    }).catch(() => {
-        window.location.href = '?year=' + encodeURIComponent(year);
-    });
-}
-
-function showAddAcademicYearForm() {
-    const year = prompt("Enter new academic year (format: YYYY-YYYY):\nExample: 2025-2026");
-    if (year && year.match(/^\d{4}-\d{4}$/)) {
-        addAcademicYear(year);
-    } else if (year) {
-        showToast("Please enter academic year in correct format: YYYY-YYYY (e.g., 2025-2026)", 'error');
-    }
-}
-
-function addAcademicYear(yearString) {
-    fetch('/core-admin/add-academic-year/', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': getCsrfToken()
-        },
-        body: JSON.stringify({ academic_year: yearString })
-    }).then(response => response.json())
-    .then(data => {
-        if (data.success) {
-            window.location.reload();
-        } else {
-            showToast(data.error || 'Failed to add academic year', 'error');
-        }
-    }).catch(() => {
-        showToast('Error adding academic year', 'error');
-    });
-}
-
 // CRUD Operations
 function addNewEntry() {
     const categorySelect = document.getElementById("categorySelect");
@@ -712,6 +657,3 @@ function createToastElement() {
 }
 
 // Export functions for global access
-window.setAcademicYear = setAcademicYear;
-window.showAddAcademicYearForm = showAddAcademicYearForm;
-window.addAcademicYear = addAcademicYear;

--- a/templates/core/admin_academic_year_settings.html
+++ b/templates/core/admin_academic_year_settings.html
@@ -17,25 +17,13 @@
           <th>Year</th>
           <th>Start Date</th>
           <th>End Date</th>
-          <th>Active</th>
         </tr>
       </thead>
       <tbody>
-        {% for ay in academic_years %}
         <tr>
-          <td>{{ ay.year }}</td>
-          <td><input type="date" name="start_date_{{ ay.id }}" value="{{ ay.start_date|date:'Y-m-d' }}"></td>
-          <td><input type="date" name="end_date_{{ ay.id }}" value="{{ ay.end_date|date:'Y-m-d' }}"></td>
-          <td class="text-center"><input type="radio" name="active_year" value="{{ ay.id }}" {% if ay.is_active %}checked{% endif %}></td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="4">No academic years available.</td></tr>
-        {% endfor %}
-        <tr>
-          <td><input type="text" name="new_year" placeholder="YYYY-YYYY"></td>
-          <td><input type="date" name="new_start"></td>
-          <td><input type="date" name="new_end"></td>
-          <td class="text-center"><input type="radio" name="active_year" value="new"></td>
+          <td><input type="text" name="year" value="{{ academic_year.year|default:'' }}" placeholder="YYYY-YYYY"></td>
+          <td><input type="date" name="start_date" value="{{ academic_year.start_date|date:'Y-m-d' }}"></td>
+          <td><input type="date" name="end_date" value="{{ academic_year.end_date|date:'Y-m-d' }}"></td>
         </tr>
       </tbody>
     </table>

--- a/templates/core/admin_master_data.html
+++ b/templates/core/admin_master_data.html
@@ -14,17 +14,8 @@
   <div class="page-header">
     <h1>Master Data Management</h1>
     <div class="academic-year-filter">
-      <label for="academicYearSelect">Academic Year:</label>
-      <select id="academicYearSelect" onchange="setAcademicYear(this.value)">
-        {% for year in academic_years %}
-          <option value="{{ year.value }}" {% if year.value == selected_year.value %}selected{% endif %}>
-            {{ year.display }}
-          </option>
-        {% endfor %}
-      </select>
-      <button class="btn btn-secondary btn-sm" onclick="showAddAcademicYearForm()" title="Add New Academic Year">
-        <i class="fas fa-plus"></i>
-      </button>
+      <label>Academic Year:</label>
+      <span>{{ academic_year.year }}</span>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Provide global active academic year via context processor
- Replace multi-year management with single academic year settings
- Display active year across admin pages

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c52d32c58832c8e6bd0cf2f93e2b9