### PR TITLE
Add command to remove duplicate users

### DIFF
--- a/core/management/commands/delete_duplicate_users.py
+++ b/core/management/commands/delete_duplicate_users.py
@@ -1,0 +1,46 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+from django.db.models import Count
+from django.db.models.functions import Lower
+
+
+class Command(BaseCommand):
+    """Remove duplicate user accounts based on email."""
+    help = (
+        "Remove duplicate user accounts based on email (case-insensitive). "
+        "Keeps the oldest account and deletes the rest."
+    )
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        duplicates = (
+            User.objects.exclude(email__isnull=True)
+            .exclude(email__exact="")
+            .annotate(email_lower=Lower("email"))
+            .values("email_lower")
+            .annotate(email_count=Count("id"))
+            .filter(email_count__gt=1)
+        )
+
+        total_deleted = 0
+        for entry in duplicates:
+            email = entry["email_lower"]
+            users = User.objects.filter(email__iexact=email).order_by("id")
+            keeper = users.first()
+            to_delete = users[1:]
+            count = to_delete.count()
+            if count:
+                User.objects.filter(id__in=list(to_delete.values_list("id", flat=True))).delete()
+                total_deleted += count
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Deleted {count} duplicate user(s) with email {email}; kept user {keeper.id}."
+                    )
+                )
+
+        if total_deleted:
+            self.stdout.write(
+                self.style.SUCCESS(f"Deleted {total_deleted} duplicate user(s).")
+            )
+        else:
+            self.stdout.write(self.style.SUCCESS("No duplicate users found."))

--- a/core/tests/test_delete_duplicate_users_command.py
+++ b/core/tests/test_delete_duplicate_users_command.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from django.core.management import call_command
+from django.contrib.auth import get_user_model
+
+
+class DeleteDuplicateUsersCommandTests(TestCase):
+    def test_duplicates_removed(self):
+        User = get_user_model()
+        User.objects.create(username="user1", email="dup@example.com")
+        User.objects.create(username="user2", email="dup@example.com")
+        User.objects.create(username="user3", email="unique@example.com")
+
+        call_command("delete_duplicate_users")
+
+        self.assertEqual(User.objects.filter(email__iexact="dup@example.com").count(), 1)
+        self.assertEqual(User.objects.count(), 2)


### PR DESCRIPTION
## Summary
- add management command to delete duplicate users by email while keeping oldest account
- add test for delete_duplicate_users management command

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689c5a4e6610832ca128167b0447c2a5