### PR TITLE
fix: preserve organization selection on event proposal page

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -220,7 +220,9 @@ $(document).ready(function() {
                     }
                 });
                 if (orgTypeSelect.val()) {
-                    orgTypeTS.setValue(orgTypeSelect.val());
+                    // Set the initial org type without triggering the change handler
+                    // so the pre-selected organization value is preserved.
+                    orgTypeTS.setValue(orgTypeSelect.val(), true);
                     const initialText = orgTypeOptions.find(opt => opt.value === orgTypeSelect.val())?.text?.toLowerCase().trim() || '';
                     if (initialText) {
                         setTimeout(() => {


### PR DESCRIPTION
## Summary
- prevent initial change handler from clearing organization selection
- keep user's organization automatically selected when loading proposal page

## Testing
- `python manage.py test emt`

------
https://chatgpt.com/codex/tasks/task_e_689c5fa0be7c832caae78f6bffbf5217