### PR TITLE
Revamp academic year admin UI

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1246,17 +1246,18 @@ def admin_settings_dashboard(request):
 @login_required
 @user_passes_test(lambda u: u.is_superuser)
 def admin_academic_year_settings(request):
-    from datetime import date
     from transcript.models import AcademicYear
 
     academic_year = AcademicYear.objects.first()
 
-    # Generate a range of academic years for selection, e.g., 2020-2021
-    current_year = date.today().year
-    year_options = [f"{y}-{y + 1}" for y in range(current_year - 5, current_year + 6)]
-
     if request.method == "POST":
         year = request.POST.get('year')
+        if year and '-' not in year:
+            try:
+                y = int(year)
+                year = f"{y}-{y + 1}"
+            except ValueError:
+                pass
         start = request.POST.get('start_date') or None
         end = request.POST.get('end_date') or None
         if academic_year:
@@ -1273,7 +1274,6 @@ def admin_academic_year_settings(request):
         'core/admin_academic_year_settings.html',
         {
             'academic_year': academic_year,
-            'year_options': year_options,
         },
     )
 

--- a/static/core/css/admin_academic_year.css
+++ b/static/core/css/admin_academic_year.css
@@ -1,0 +1,94 @@
+/* Academic Year Settings Page Styles */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+body {
+  background: linear-gradient(135deg, #f5f9ff 0%, #e8f4fd 100%);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
+.academic-year-settings-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 80px 1rem 2rem 1rem;
+}
+
+.academic-year-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(20, 40, 150, 0.08);
+  padding: 2rem 2.5rem;
+  border: 1px solid rgba(22, 95, 178, 0.1);
+}
+
+.card-title {
+  text-align: center;
+  margin-top: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #165fb2;
+}
+
+.year-form {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-row label {
+  font-weight: 600;
+  color: #22315a;
+}
+
+.form-row input {
+  padding: 0.75rem 1rem;
+  border: 1px solid #dfe3e8;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-row input:focus {
+  border-color: #1064c8;
+  box-shadow: 0 0 0 3px rgba(16, 100, 200, 0.15);
+  outline: none;
+}
+
+.form-actions {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.btn-save {
+  display: inline-block;
+  padding: 0.75rem 1.8rem;
+  background: #1064c8;
+  color: #fff;
+  border: none;
+  border-radius: 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(16, 100, 200, 0.2);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-save:hover {
+  background: #164799;
+  box-shadow: 0 4px 12px rgba(16, 100, 200, 0.3);
+}
+
+@media (max-width: 600px) {
+  .academic-year-card {
+    padding: 1.5rem 1.25rem;
+  }
+}

--- a/templates/core/admin_academic_year_settings.html
+++ b/templates/core/admin_academic_year_settings.html
@@ -2,42 +2,40 @@
 {% load static %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'core/css/admin_master_data.css' %}">
+<link rel="stylesheet" href="{% static 'core/css/admin_academic_year.css' %}">
 
-<div class="main-container">
-  <div class="page-header">
-    <h1 class="page-title">Academic Year Settings</h1>
-  </div>
+<main class="academic-year-settings-container">
+  <section class="academic-year-card">
+    <h1 class="card-title">Academic Year Settings</h1>
+    <form method="post" class="year-form">
+      {% csrf_token %}
+      <div class="form-row">
+        <label for="yearPicker">Academic Year</label>
+        <input type="text" id="yearPicker" name="year" value="{{ academic_year.year|slice:':4' }}" placeholder="Select year" required>
+      </div>
+      <div class="form-row">
+        <label for="startDate">Start Date</label>
+        <input type="date" id="startDate" name="start_date" value="{{ academic_year.start_date|date:'Y-m-d' }}">
+      </div>
+      <div class="form-row">
+        <label for="endDate">End Date</label>
+        <input type="date" id="endDate" name="end_date" value="{{ academic_year.end_date|date:'Y-m-d' }}">
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="btn-save">Save</button>
+      </div>
+    </form>
+  </section>
+</main>
 
-  <form method="post">
-    {% csrf_token %}
-    <table class="data-table">
-      <thead>
-        <tr>
-          <th>Year</th>
-          <th>Start Date</th>
-          <th>End Date</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <select name="year">
-              {% for y in year_options %}
-                <option value="{{ y }}" {% if academic_year and academic_year.year == y %}selected{% endif %}>{{ y }}</option>
-              {% endfor %}
-            </select>
-          </td>
-          <td><input type="date" name="start_date" value="{{ academic_year.start_date|date:'Y-m-d' }}"></td>
-          <td><input type="date" name="end_date" value="{{ academic_year.end_date|date:'Y-m-d' }}"></td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="form-actions" style="margin-top: 1rem;">
-      <button type="submit" class="btn btn-primary">Save</button>
-    </div>
-  </form>
-</div>
-
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/plugins/yearSelect/yearSelect.min.js"></script>
+<script>
+  flatpickr("#yearPicker", {
+    plugins: [new yearSelectPlugin({dateFormat: "Y"})],
+    defaultDate: "{{ academic_year.year|slice:':4' }}"
+  });
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Refresh academic year admin page with card-style layout and flatpickr-based year picker
- Add dedicated CSS for academic year settings
- Convert numeric year input into academic year range in view

## Testing
- `python -m pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689c845b6000832cba0fab22dcd17198