### PR TITLE
Add test data autofill option to proposal form

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -12,6 +12,7 @@ $(document).ready(function() {
         'income': false
     };
     let audienceClassMap = {};
+    const autoFillEnabled = new URLSearchParams(window.location.search).has('autofill');
 
     initializeDashboard();
 
@@ -21,6 +22,7 @@ $(document).ready(function() {
         loadExistingData();
         checkForExistingErrors();
         enablePreviouslyVisitedSections();
+        $('#autofill-btn').on('click', autofillTestData);
         if (!$('.form-errors-banner').length) {
             setTimeout(() => {
                 activateSection('basic-info');
@@ -181,6 +183,9 @@ $(document).ready(function() {
             clearValidationErrors();
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
+            }
+            if (autoFillEnabled && section === 'basic-info') {
+                autofillTestData();
             }
         }, 100);
     }
@@ -1699,6 +1704,42 @@ function getWhyThisEventForm() {
         console.log(`Section ${section} marked as complete`);
         updateProgressBar();
         updateSubmitButton();
+    }
+
+    function autofillTestData() {
+        const today = new Date().toISOString().split('T')[0];
+        const fields = {
+            'event-title-modern': 'Test Event Title',
+            'target-audience-modern': 'Test Audience',
+            'target-audience-class-ids': '1',
+            'venue-modern': 'Main Auditorium',
+            'event-start-date': today,
+            'event-end-date': today,
+            'academic-year-modern': '2024-2025',
+            'pos-pso-modern': 'PO1, PSO2',
+            'sdg-goals-modern': 'Goal 4',
+            'num-activities-modern': '1'
+        };
+
+        Object.entries(fields).forEach(([id, value]) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.value = value;
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
+        const focusSelect = document.getElementById('event-focus-type-modern');
+        if (focusSelect && focusSelect.options.length > 1) {
+            focusSelect.selectedIndex = 1;
+            focusSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+
+        const facultySelect = document.getElementById('faculty-select');
+        if (facultySelect && facultySelect.options.length > 0) {
+            facultySelect.options[0].selected = true;
+            $(facultySelect).trigger('change');
+        }
     }
 
     function unlockNextSection(section) {

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -77,6 +77,7 @@
         <div class="content-header">
             <h1 class="content-title" id="main-title">Basic Information</h1>
             <p class="content-subtitle" id="main-subtitle">Organization details and event basics</p>
+            <button type="button" id="autofill-btn" class="btn-draft" style="margin-top:0.5rem;">Auto-Fill Test Data</button>
         </div>
 
         {% if form.errors %}


### PR DESCRIPTION
## Summary
- Add "Auto-Fill Test Data" button on event proposal page
- Introduce JavaScript flag to populate non-critical fields for testing

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689c83f36b0c832c92d3e16a83212e00