### PR TITLE
Derive academic year name from start and end dates

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1247,19 +1247,26 @@ def admin_settings_dashboard(request):
 @user_passes_test(lambda u: u.is_superuser)
 def admin_academic_year_settings(request):
     from transcript.models import AcademicYear
+    from datetime import datetime
 
     academic_year = AcademicYear.objects.first()
 
     if request.method == "POST":
-        year = request.POST.get('year')
-        if year and '-' not in year:
-            try:
-                y = int(year)
-                year = f"{y}-{y + 1}"
-            except ValueError:
-                pass
         start = request.POST.get('start_date') or None
         end = request.POST.get('end_date') or None
+
+        year = None
+        if start:
+            try:
+                start_year = datetime.strptime(start, "%Y-%m-%d").year
+                if end:
+                    end_year = datetime.strptime(end, "%Y-%m-%d").year
+                else:
+                    end_year = start_year + 1
+                year = f"{start_year}-{end_year}"
+            except ValueError:
+                pass
+
         if academic_year:
             academic_year.year = year
             academic_year.start_date = start

--- a/templates/core/admin_academic_year_settings.html
+++ b/templates/core/admin_academic_year_settings.html
@@ -10,10 +10,6 @@
     <form method="post" class="year-form">
       {% csrf_token %}
       <div class="form-row">
-        <label for="yearPicker">Academic Year</label>
-        <input type="text" id="yearPicker" name="year" value="{{ academic_year.year|slice:':4' }}" placeholder="Select year" required>
-      </div>
-      <div class="form-row">
         <label for="startDate">Start Date</label>
         <input type="date" id="startDate" name="start_date" value="{{ academic_year.start_date|date:'Y-m-d' }}">
       </div>
@@ -27,15 +23,5 @@
     </form>
   </section>
 </main>
-
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-<script src="https://cdn.jsdelivr.net/npm/flatpickr/dist/plugins/yearSelect/yearSelect.min.js"></script>
-<script>
-  flatpickr("#yearPicker", {
-    plugins: [new yearSelectPlugin({dateFormat: "Y"})],
-    defaultDate: "{{ academic_year.year|slice:':4' }}"
-  });
-</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Remove manual academic year session field from settings form
- Compute academic year name automatically from selected start and end dates

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689c888d1248832c91fa2e2130fd3d8b