### PR TITLE
Add command to delete duplicate academic year entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,3 +335,13 @@ Pune Lavasa Campus – Infotech R&D Team
 Email: infotech.lavasa@christuniversity.in  
 GitHub: [CHRISTInfotech](https://github.com/CHRISTInfotech)  
 Website: https://christuniversity.in/lavasa
+
+### Removing an Academic Year Entry
+
+If you created an academic year with an incorrect year value or need to clear a duplicate entry, you can remove it using the provided management command:
+
+```bash
+python manage.py delete_academic_year 2025-2026
+```
+
+Replace `2025-2026` with the year you want to delete.

--- a/transcript/management/commands/delete_academic_year.py
+++ b/transcript/management/commands/delete_academic_year.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from transcript.models import AcademicYear
+
+
+class Command(BaseCommand):
+    """Delete AcademicYear entries for a specified year."""
+    help = "Delete AcademicYear entries matching the given year string."
+
+    def add_arguments(self, parser):
+        parser.add_argument("year", help="Year value to delete, e.g., 2025-2026")
+
+    def handle(self, *args, **options):
+        year = options["year"]
+        deleted, _ = AcademicYear.objects.filter(year=year).delete()
+        if deleted:
+            self.stdout.write(self.style.SUCCESS(f"Deleted {deleted} AcademicYear(s) with year '{year}'."))
+        else:
+            self.stdout.write(self.style.WARNING(f"No AcademicYear found with year '{year}'."))


### PR DESCRIPTION
## Summary
- add `delete_academic_year` management command for removing academic year rows by year string
- document how to run the cleanup command in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ca549bd28832caf3857c6c11ab393