### PR TITLE
Centralize academic year retrieval

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -3,7 +3,7 @@ from django.utils.timesince import timesince
 from django.db.models import Q
 from datetime import timedelta
 from emt.models import EventProposal
-from transcript.models import AcademicYear
+from transcript.models import get_active_academic_year
 
 def notifications(request):
     """Return proposal-related notifications for the logged-in user."""
@@ -38,6 +38,5 @@ def notifications(request):
 
 
 def active_academic_year(request):
-    """Provide the single active academic year to all templates."""
-    ay = AcademicYear.objects.first()
-    return {"active_academic_year": ay}
+    """Provide the active academic year to all templates."""
+    return {"active_academic_year": get_active_academic_year()}

--- a/core/views.py
+++ b/core/views.py
@@ -1009,14 +1009,10 @@ def iqac_suite_dashboard(request):
 @login_required
 @user_passes_test(lambda u: u.is_superuser)
 def admin_master_data(request):
-    from transcript.models import AcademicYear
-    import datetime
+    from transcript.models import get_active_academic_year
     import json
 
-    current_year = datetime.datetime.now().year
-    academic_year = AcademicYear.objects.first()
-    if not academic_year:
-        academic_year = AcademicYear.objects.create(year=f"{current_year}-{current_year + 1}")
+    academic_year = get_active_academic_year()
 
     org_types = OrganizationType.objects.filter(is_active=True).order_by('name')
     orgs_by_type = {}
@@ -1285,6 +1281,8 @@ def admin_academic_year_settings(request):
             obj.end_date = end
             obj.save()
         else:
+            # Ensure only one academic year is active at any time
+            AcademicYear.objects.filter(is_active=True).update(is_active=False)
             AcademicYear.objects.create(
                 year=year_str, start_date=start, end_date=end, is_active=True
             )

--- a/emt/views.py
+++ b/emt/views.py
@@ -211,8 +211,9 @@ def _save_income(proposal, data):
 # ──────────────────────────────
 @login_required
 def submit_proposal(request, pk=None):
-    from transcript.models import AcademicYear
-    active_year = AcademicYear.objects.first()
+    from transcript.models import get_active_academic_year
+
+    active_year = get_active_academic_year()
     selected_academic_year = active_year.year if active_year else ""
 
     proposal = None


### PR DESCRIPTION
## Summary
- add `get_active_academic_year` helper using IST and `is_active`
- use helper across views and context processors
- ensure only one academic year remains active

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ca964f424832c81fbba96660a68a6