### PR TITLE
Remove draft option and delay proposal submission

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1104,7 +1104,6 @@ $(document).ready(function() {
                 <div class="form-row full-width">
                     <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
                         <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                        <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                         <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
                     </div>
                 </div>
@@ -1511,8 +1510,8 @@ function getWhyThisEventForm() {
                 </div>
 
                 <div class="form-row full-width">
-                    <div class="submit-section-container">
-                        <button type="submit" name="final_submit" class="btn-submit" id="submit-proposal-btn">
+                    <div class="submit-section">
+                        <button type="submit" name="final_submit" class="btn-submit" id="submit-proposal-btn" disabled>
                             Submit Proposal
                         </button>
                         <div class="submit-help-text">

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -244,19 +244,11 @@
                         <div class="form-row full-width">
                             <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
                                 <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                                <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                                 <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-
-
-            <div class="submit-section">
-                <button type="submit" name="final_submit" class="btn-submit" id="submit-proposal-btn" disabled>Submit Proposal</button>
-                <button type="submit" name="save_draft" class="btn-draft" id="save-draft-btn">Save as Draft</button>
-                <div class="submit-help-text">Complete all sections above to enable submission</div>
             </div>
 
             <div style="display: none;" id="django-forms">


### PR DESCRIPTION
## Summary
- remove unused Save as Draft buttons from proposal workflow
- show submit button only on final proposal step and disable until all sections complete

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689cae687cb0832ca4a830d4d057603c