### PR TITLE
Enable admin user impersonation with logging

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -5,7 +5,7 @@ from django.urls import path
 from django.shortcuts import redirect
 from django.contrib import messages
 
-from .models import SDGGoal
+from .models import SDGGoal, log_impersonation_start
 
 
 class ImpersonationUserAdmin(BaseUserAdmin):
@@ -32,6 +32,7 @@ class ImpersonationUserAdmin(BaseUserAdmin):
             target_user = User.objects.get(id=user_id, is_active=True)
             request.session['impersonate_user_id'] = target_user.id
             request.session['original_user_id'] = request.user.id
+            log_impersonation_start(request, target_user)
             messages.success(request, f'Now impersonating {target_user.get_full_name() or target_user.username}')
             return redirect('/')  # Redirect to main site
         except User.DoesNotExist:

--- a/core/templatetags/admin_tags.py
+++ b/core/templatetags/admin_tags.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 
 register = template.Library()
 
-@register.inclusion_tag('core/partials/impersonation_banner.html', takes_context=True)
+@register.inclusion_tag('partials/impersonation_banner.html', takes_context=True)
 def impersonation_banner(context):
     """Display impersonation banner"""
     request = context['request']

--- a/core/tests/test_impersonation.py
+++ b/core/tests/test_impersonation.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from core.models import ImpersonationLog
+
+
+class ImpersonationTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser('admin', 'admin@example.com', 'pass')
+        self.user = User.objects.create_user('alice', 'alice@example.com', 'pass')
+        self.client.force_login(self.admin)
+
+    def test_impersonation_flow(self):
+        # start impersonation
+        response = self.client.get(reverse('admin_impersonate_user', args=[self.user.id]))
+        self.assertIn('impersonate_user_id', self.client.session)
+        self.assertEqual(self.client.session['impersonate_user_id'], self.user.id)
+        # request any page to trigger middleware
+        resp = self.client.get(reverse('dashboard'))
+        req = resp.wsgi_request
+        self.assertTrue(req.is_impersonating)
+        self.assertEqual(req.user, self.user)
+        self.assertEqual(req.original_user, self.admin)
+        # log entry created
+        log = ImpersonationLog.objects.get()
+        self.assertEqual(log.original_user, self.admin)
+        self.assertEqual(log.impersonated_user, self.user)
+        self.assertIsNone(log.ended_at)
+        # stop impersonation
+        self.client.get(reverse('stop_impersonation'))
+        log.refresh_from_db()
+        self.assertIsNotNone(log.ended_at)

--- a/core/urls.py
+++ b/core/urls.py
@@ -32,6 +32,8 @@ urlpatterns = [
     path('core-admin/users/<int:user_id>/edit/', views.admin_user_edit, name='admin_user_edit'),
     path('core-admin/users/<int:user_id>/deactivate/', views.admin_user_deactivate, name='admin_user_deactivate'),
     path('core-admin/users/<int:user_id>/activate/', views.admin_user_activate, name='admin_user_activate'),
+    path('core-admin/users/<int:user_id>/impersonate/', views.admin_impersonate_user, name='admin_impersonate_user'),
+    path('core-admin/stop-impersonation/', views.stop_impersonation, name='stop_impersonation'),
 
     # ────────────────────────────────────────────────
     # Admin - Role Management

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -56,6 +56,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'core.middleware.ImpersonationMiddleware',
     'allauth.account.middleware.AccountMiddleware',  # ← allauth middleware
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load static group_filters %}
+{% load static group_filters admin_tags %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -28,6 +28,8 @@
     {% endfor %}
   </div>
   {% endif %}
+
+  {% impersonation_banner %}
 
   <!-- ZONE 1: TOP UTILITY BAR -->
   <div class="top-utility-bar">

--- a/templates/core/admin_user_management.html
+++ b/templates/core/admin_user_management.html
@@ -402,6 +402,11 @@
                         <a href="{% url 'admin_user_edit' user.id %}" class="btn btn-sm btn-outline-primary">
                             <i class="fas fa-edit"></i> Edit
                         </a>
+                        {% if user != request.user %}
+                        <a href="{% url 'admin_impersonate_user' user.id %}?next={{ request.get_full_path|urlencode }}" class="btn btn-sm btn-outline-secondary ms-1">
+                            <i class="fas fa-user-secret"></i> Login as
+                        </a>
+                        {% endif %}
                     </td>
                 </tr>
                 {% empty %}

--- a/templates/partials/impersonation_banner.html
+++ b/templates/partials/impersonation_banner.html
@@ -1,8 +1,8 @@
 {# Placeholder stub: renders only if your backend sets a session flag #}
-{% if request and request.session.impersonating %}
+{% if is_impersonating and impersonated_user %}
 <div class="impersonation-banner"
      style="background:#fff7ed;border:1px solid #fdba74;color:#9a3412;padding:8px 12px;border-radius:8px;margin-bottom:12px;display:flex;justify-content:space-between;align-items:center;">
-  <span>Impersonating {{ request.session.impersonating_as|default:"another user" }}</span>
-  <a href="#" style="font-weight:600;color:#7c2d12;text-decoration:underline">Stop</a>
+  <span>Impersonating {{ impersonated_user.get_full_name|default:impersonated_user.username }}</span>
+  <a href="{% url 'stop_impersonation' %}" style="font-weight:600;color:#7c2d12;text-decoration:underline">Stop</a>
 </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- allow admins to impersonate other users and record actions
- show impersonation banner and login-as button on user management
- log impersonation start/end and track via middleware

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689caf7fd970832cad5ed7703f92c430