### PR TITLE
Ensure impersonation redirects to dashboard

### DIFF
--- a/core/tests/test_impersonation.py
+++ b/core/tests/test_impersonation.py
@@ -12,8 +12,11 @@ class ImpersonationTests(TestCase):
         self.client.force_login(self.admin)
 
     def test_impersonation_flow(self):
-        # start impersonation
+        # start impersonation and ensure redirect to dashboard
         response = self.client.get(reverse('admin_impersonate_user', args=[self.user.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse('dashboard'))
+        self.assertNotIn('core-admin', response.url)
         self.assertIn('impersonate_user_id', self.client.session)
         self.assertEqual(self.client.session['impersonate_user_id'], self.user.id)
         # request any page to trigger middleware

--- a/core/views.py
+++ b/core/views.py
@@ -3750,7 +3750,7 @@ def admin_impersonate_user(request, user_id):
 
     log_impersonation_start(request, target_user)
     messages.success(request, f"Now impersonating {target_user.get_full_name() or target_user.username}")
-    next_url = request.GET.get('next') or reverse('dashboard')
+    next_url = safe_next(request, fallback=reverse('dashboard'))
     return redirect(next_url)
 
 @login_required

--- a/templates/core/admin_user_management.html
+++ b/templates/core/admin_user_management.html
@@ -403,7 +403,7 @@
                             <i class="fas fa-edit"></i> Edit
                         </a>
                         {% if user != request.user %}
-                        <a href="{% url 'admin_impersonate_user' user.id %}?next={{ request.get_full_path|urlencode }}" class="btn btn-sm btn-outline-secondary ms-1">
+                        <a href="{% url 'admin_impersonate_user' user.id %}?next={% url 'dashboard' %}" class="btn btn-sm btn-outline-secondary ms-1">
                             <i class="fas fa-user-secret"></i> Login as
                         </a>
                         {% endif %}


### PR DESCRIPTION
## Summary
- Redirect "Login as" links to the regular dashboard so impersonated sessions land on a valid page
- Sanitize impersonation redirect using `safe_next` with a dashboard fallback
- Test that impersonation redirects away from admin routes

## Testing
- `python manage.py test core.tests.test_impersonation`


------
https://chatgpt.com/codex/tasks/task_e_689cb400b95c832ca9b4916f8aefedfb