### PR TITLE
Move history navigation under settings

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -236,24 +236,15 @@
       </div>
       {% endif %}
 
-      {% if user.is_superuser or request.session.role == 'admin' %}
-      <div class="nav-item">
-        <a href="/core-admin/history/" class="nav-link {% if request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}active{% endif %}">
-          <i class="fas fa-history nav-icon"></i>
-          <span class="nav-text">History</span>
-        </a>
-      </div>
-      {% endif %}
-
       <!-- Settings - Expandable (Admin Only) -->
       {% if user.is_superuser or request.session.role == 'admin' %}
-      <div class="nav-section {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' %}expanded{% endif %}">
+      <div class="nav-section {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or 'history' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' or request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}expanded{% endif %}">
         <div class="nav-section-header">
           <i class="fas fa-cog nav-icon"></i>
           <span class="nav-text">Settings</span>
-          <i class="fas fa-chevron-right expand-icon {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' %}rotated{% endif %}"></i>
+          <i class="fas fa-chevron-right expand-icon {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or 'history' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' or request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}rotated{% endif %}"></i>
         </div>
-        <div class="nav-submenu {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' %}open{% endif %}">
+        <div class="nav-submenu {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or 'history' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' or request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}open{% endif %}">
           <a href="{% url 'admin_master_data' %}" class="nav-sublink {% if request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'master_data_dashboard' %}active{% endif %}">
             <i class="fas fa-user-cog"></i> User Settings
           </a>
@@ -270,6 +261,9 @@
           </a>
           <a href="{% url 'admin_academic_year_settings' %}" class="nav-sublink {% if request.resolver_match.url_name == 'admin_academic_year_settings' %}active{% endif %}">
             <i class="fas fa-calendar-alt"></i> Academic Year Settings
+          </a>
+          <a href="{% url 'admin_history' %}" class="nav-sublink {% if request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}active{% endif %}">
+            <i class="fas fa-history"></i> History
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move admin history link into Settings sidebar section
- expand Settings when viewing history pages

## Testing
- `venv/bin/python -m pytest --ds=iqac_project.settings` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_689cbc8cda44832ca43404b1234adfad