### PR TITLE
feat: show selected student coordinators

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -492,6 +492,7 @@ $(document).ready(function() {
         const djangoField = $('#django-basic-info [name="student_coordinators"]');
         const audienceField = $('#target-audience-modern');
         const classIdsField = $('#target-audience-class-ids');
+        const list = $('#student-coordinators-list');
         if (!select.length || !djangoField.length) return;
 
         if (select[0].tomselect) {
@@ -531,14 +532,26 @@ $(document).ready(function() {
             tom.setValue(existing.filter(v => names.includes(v)));
         }
 
+        updateList(tom.getValue());
+
         tom.on('change', () => {
             const values = tom.getValue();
             const joined = Array.isArray(values) ? values.join(', ') : '';
             djangoField.val(joined).trigger('change');
             clearFieldError(select);
+            updateList(values);
         });
 
         select[0].tomselect = tom;
+
+        function updateList(values) {
+            if (!list.length) return;
+            list.empty();
+            const arr = Array.isArray(values) ? values : [values];
+            arr.filter(Boolean).forEach(name => {
+                list.append($('<li>').text(name));
+            });
+        }
     }
 
     function setupOutcomeModal() {

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -219,9 +219,10 @@
                                 <label for="student-coordinators-modern">Student Coordinators</label>
                                 <select id="student-coordinators-modern" multiple></select>
                                 <div class="help-text">Search and select student coordinators from the target audience</div>
+                                <ul id="student-coordinators-list" class="selected-coordinators-list"></ul>
                             </div>
                         </div>
-                        
+
                         <!-- Dynamic activities section -->
                         <div id="dynamic-activities-section" class="full-width"></div>
 


### PR DESCRIPTION
## Summary
- show selected student coordinators beneath the selector in the submit proposal form
- update proposal dashboard JS to keep selected coordinators in sync with hidden field and display list

## Testing
- `python manage.py test`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689cc2134cdc832c9d4a655a670a5d6b