### PR TITLE
Connect user dashboard calendar and chart to backend

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2204,7 +2204,21 @@ def api_student_achievements(request):
 
 @login_required
 def user_dashboard(request):
-    return render(request, 'core/user_dashboard.html')
+    """Render the simplified user dashboard with calendar events."""
+    events = EventProposal.objects.filter(
+        status="finalized", event_datetime__isnull=False
+    )
+    calendar_events = [
+        {
+            "id": e.id,
+            "title": e.event_title,
+            "date": e.event_datetime.strftime("%Y-%m-%d"),
+            "datetime": e.event_datetime.strftime("%Y-%m-%d %H:%M"),
+            "venue": e.venue or "",
+        }
+        for e in events
+    ]
+    return render(request, "core/user_dashboard.html", {"calendar_events": calendar_events})
 
 @login_required
 @require_GET

--- a/static/core/css/user_dashboard.css
+++ b/static/core/css/user_dashboard.css
@@ -217,6 +217,23 @@ body.is-student .nav-content .student-only {
     box-shadow: var(--shadow);
 }
 
+/* Chart and Calendar Sections */
+.chart-section, .calendar-section {
+    margin-top: 24px;
+    background-color: var(--card-background);
+    border-radius: var(--border-radius);
+    padding: 20px;
+    box-shadow: var(--shadow);
+}
+
+.chart-section canvas {
+    width: 100%;
+    max-width: 300px;
+    height: 200px;
+    display: block;
+    margin: 0 auto;
+}
+
 h3 {
     margin-top: 0;
     font-size: 18px;

--- a/templates/core/user_dashboard.html
+++ b/templates/core/user_dashboard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>User Dashboard - CHRIST University</title>
     <link rel="stylesheet" href="{% static 'core/user_dashboard.css' %}">
+    <link rel="stylesheet" href="{% static 'core/css/dashboard.css' %}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
@@ -70,6 +71,23 @@
         <!-- Overview Tab -->
         <div id="overview" class="tab-content active">
             <div class="stats-grid" id="statsGrid"></div>
+            <div class="chart-section">
+                <canvas id="eventContributionChart"></canvas>
+            </div>
+            <div class="calendar-section">
+                <div class="mini-cal" id="miniCalendar">
+                    <div class="cal-head">
+                        <button class="cal-nav" id="calPrev" aria-label="Previous month"><i class="fa-solid fa-chevron-left"></i></button>
+                        <div id="calTitle">Month YYYY</div>
+                        <button class="cal-nav" id="calNext" aria-label="Next month"><i class="fa-solid fa-chevron-right"></i></button>
+                    </div>
+                    <div class="cal-weekdays">
+                        <span>S</span><span>M</span><span>T</span><span>W</span><span>T</span><span>F</span><span>S</span>
+                    </div>
+                    <div class="cal-grid" id="calGrid"></div>
+                </div>
+                <div id="upcomingWrap" class="upcoming"></div>
+            </div>
             <div class="mentees-section faculty-only" id="menteesSection"></div>
             <div class="attributes-section student-only" id="attributesSection"></div>
             <div class="remarks-section student-only" id="remarksSection"></div>
@@ -129,6 +147,12 @@
         </div>
     </div>
 
+    {{ calendar_events|json_script:"calendarEventsJson" }}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script>
+        try { window.DASHBOARD_EVENTS = JSON.parse(document.getElementById('calendarEventsJson').textContent); }
+        catch { window.DASHBOARD_EVENTS = []; }
+    </script>
     <script src="{% static 'core/user_dashboard.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Populate user dashboard with finalized event data for calendar display
- Load Chart.js donut chart from backend event contribution API
- Style chart and calendar sections for user dashboard

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689cc4851124832c95dd062f9fe4f562