### PR TITLE
Enable student coordinator search by name

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -218,7 +218,7 @@
                             <div class="input-group">
                                 <label for="student-coordinators-modern">Student Coordinators</label>
                                 <select id="student-coordinators-modern" multiple></select>
-                                <div class="help-text">Search and select student coordinators from the target audience</div>
+                                <div class="help-text">Search and select student coordinators by name</div>
                                 <ul id="student-coordinators-list" class="selected-coordinators-list"></ul>
                             </div>
                         </div>

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
 
     # Faculty remains as is
     path("api/faculty/", views.api_faculty, name="api_faculty"),
+    path("api/students/", views.api_students, name="api_students"),
     path('api/classes/<int:org_id>/', views.api_classes, name='api_classes'),
     path('api/fetch-linkedin-profile/', views.fetch_linkedin_profile, name='fetch_linkedin_profile'),
 


### PR DESCRIPTION
## Summary
- add `api/students` endpoint to fetch students by name
- use new endpoint in proposal dashboard to search student coordinators
- update proposal form help text

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689cc58c0148832ca201a4c8e7a18263