### PR TITLE
feat: auto-fill speakers via LinkedIn

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -368,6 +368,7 @@
         window.API_FACULTY = "{% url 'emt:api_faculty' %}";
         window.API_CLASSES_BASE = "{% url 'emt:api_classes' 0 %}".split('0/')[0];
         window.API_OUTCOMES_BASE = "{% url 'emt:api_outcomes' 0 %}".replace(/0\/$/, '');
+        window.API_FETCH_LINKEDIN = "{% url 'emt:fetch_linkedin_profile' %}";
         window.SDG_GOALS = {{ sdg_goals_list|safe }};
         window.EXISTING_ACTIVITIES = {{ activities_json|safe }};
         window.EXISTING_SPEAKERS = {{ speakers_json|safe }};


### PR DESCRIPTION
## Summary
- allow LinkedIn URLs to auto-populate speaker info on the submit proposal page
- preview LinkedIn profile photos and attach them to the form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689cc804d400832cb206be0ea2c20d12