### PR TITLE
Aggregate user events on dashboard calendar

### DIFF
--- a/templates/core/user_dashboard.html
+++ b/templates/core/user_dashboard.html
@@ -149,10 +149,6 @@
 
     {{ calendar_events|json_script:"calendarEventsJson" }}
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-    <script>
-        try { window.DASHBOARD_EVENTS = JSON.parse(document.getElementById('calendarEventsJson').textContent); }
-        catch { window.DASHBOARD_EVENTS = []; }
-    </script>
     <script src="{% static 'core/user_dashboard.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- collect user organization IDs and gather finalized event proposals relevant to the user, returning structured calendar data
- expose calendar events to dashboard template for JavaScript consumption
- mark calendar days with events and show daily event listings

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689cca9534f4832c88543d1330d533a2