### PR TITLE
feat: highlight upcoming events on dashboard calendar

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2219,6 +2219,8 @@ def user_dashboard(request):
         .values_list("organization_id", flat=True)
     )
 
+    today = timezone.now().date()
+
     events = (
         EventProposal.objects.filter(status="finalized")
         .filter(
@@ -2226,6 +2228,12 @@ def user_dashboard(request):
             | Q(faculty_incharges=user)
             | Q(organization_id__in=user_org_ids)
             | Q(participants__user=user)
+        )
+        # Only include events with a date and scheduled for today or later
+        .filter(
+            Q(event_datetime__date__gte=today)
+            | Q(event_start_date__gte=today)
+            | Q(event_end_date__gte=today)
         )
         .filter(
             Q(event_datetime__isnull=False)

--- a/static/core/css/user_dashboard.css
+++ b/static/core/css/user_dashboard.css
@@ -226,6 +226,19 @@ body.is-student .nav-content .student-only {
     box-shadow: var(--shadow);
 }
 
+/* Calendar event indicator */
+.day.has-event::after {
+    content: "";
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: #e74c3c;
+}
+
 .chart-section canvas {
     width: 100%;
     max-width: 300px;

--- a/static/core/js/user_dashboard.js
+++ b/static/core/js/user_dashboard.js
@@ -8,6 +8,20 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch {
         window.DASHBOARD_EVENTS = [];
     }
+    // Precompute a Set of ISO date strings that contain events for quick lookup
+    window.EVENT_DATE_SET = new Set();
+    (window.DASHBOARD_EVENTS || []).forEach(ev => {
+        if (ev.date) {
+            window.EVENT_DATE_SET.add(ev.date);
+        } else if (ev.start && ev.end) {
+            let cur = new Date(ev.start);
+            const end = new Date(ev.end);
+            while (cur <= end) {
+                window.EVENT_DATE_SET.add(cur.toISOString().split('T')[0]);
+                cur.setDate(cur.getDate() + 1);
+            }
+        }
+    });
 
     fetch('/api/auth/me')
         .then(res => res.json())
@@ -269,21 +283,6 @@ function buildCalendar() {
 
     headTitle.textContent = calRef.toLocaleString(undefined, { month: 'long', year: 'numeric' });
 
-    // Pre-compute dates that have events for quick lookup
-    const eventDates = new Set();
-    (window.DASHBOARD_EVENTS || []).forEach(ev => {
-        if (ev.date) {
-            eventDates.add(ev.date);
-        } else if (ev.start && ev.end) {
-            let cur = new Date(ev.start);
-            const end = new Date(ev.end);
-            while (cur <= end) {
-                eventDates.add(cur.toISOString().split('T')[0]);
-                cur.setDate(cur.getDate() + 1);
-            }
-        }
-    });
-
     const first = new Date(calRef.getFullYear(), calRef.getMonth(), 1);
     const last = new Date(calRef.getFullYear(), calRef.getMonth() + 1, 0);
     const startIdx = first.getDay();
@@ -300,7 +299,7 @@ function buildCalendar() {
     grid.innerHTML = cells.map(c => {
         const today = c.date && isSame(c.date, new Date());
         const iso = c.date ? `${c.date.getFullYear()}-${fmt2(c.date.getMonth() + 1)}-${fmt2(c.date.getDate())}` : '';
-        const hasEvent = iso && eventDates.has(iso);
+        const hasEvent = iso && window.EVENT_DATE_SET && window.EVENT_DATE_SET.has(iso);
         return `<div class="day${c.muted ? ' muted' : ''}${today ? ' today' : ''}${hasEvent ? ' has-event' : ''}" data-date="${iso}">${c.text}</div>`;
     }).join('');
 


### PR DESCRIPTION
## Summary
- limit dashboard events to upcoming dates
- precompute event date set and highlight dates with a red dot on the calendar
- style calendar items to show red indicator for event days

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ccd18fd1c832c9418593913ff2056