### PR TITLE
Fix student coordinator search

### DIFF
--- a/emt/tests.py
+++ b/emt/tests.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
 
-from emt.models import ApprovalStep, EventProposal
+from emt.models import ApprovalStep, EventProposal, Student
 from emt.utils import (
     build_approval_chain,
     auto_approve_non_optional_duplicates,
@@ -125,6 +125,45 @@ class FacultyAPITests(TestCase):
         self.assertIn(self.user1.id, ids)
         self.assertIn(self.user2.id, ids)
         self.assertNotIn(other_user.id, ids)
+
+
+class StudentAPITests(TestCase):
+    def setUp(self):
+        self.ot = OrganizationType.objects.create(name="Dept")
+        self.org = Organization.objects.create(name="Science", org_type=self.ot)
+        self.other_org = Organization.objects.create(name="Arts", org_type=self.ot)
+        self.user = User.objects.create(
+            username="s1", first_name="Alice", email="alice@example.com"
+        )
+        Student.objects.create(user=self.user)
+        OrganizationMembership.objects.create(
+            user=self.user,
+            organization=self.org,
+            academic_year="2024-2025",
+            role="student",
+        )
+        self.other_user = User.objects.create(
+            username="s2", first_name="Bob", email="bob@example.com"
+        )
+        Student.objects.create(user=self.other_user)
+        OrganizationMembership.objects.create(
+            user=self.other_user,
+            organization=self.other_org,
+            academic_year="2024-2025",
+            role="student",
+        )
+        self.client.force_login(self.user)
+
+    def test_api_students_filters_by_org_membership(self):
+        resp = self.client.get(
+            reverse("emt:api_students"),
+            {"q": "Alice", "org_id": self.org.id},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(self.user.id, ids)
+        self.assertNotIn(self.other_user.id, ids)
 
 
 class OutcomesAPITests(TestCase):

--- a/emt/views.py
+++ b/emt/views.py
@@ -1098,7 +1098,10 @@ def api_students(request):
 
     students = Student.objects.select_related("user")
     if org_id:
-        students = students.filter(classes__organization_id=org_id)
+        students = students.filter(
+            Q(classes__organization_id=org_id)
+            | Q(user__org_memberships__organization_id=org_id)
+        )
 
     if q:
         students = students.filter(


### PR DESCRIPTION
## Summary
- include organization membership in student coordinator search API
- test student API returns members of selected organization

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689cca8ed358832cb7e20367de00b34e