### PR TITLE
feat: limit student search to selected organizations

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -310,6 +310,13 @@ $(document).ready(function() {
         setupFacultyTomSelect();
         setupCommitteesTomSelect();
         setupStudentCoordinatorSelect();
+
+        const orgSelect = djangoBasicInfo.find('[name="organization"]');
+        const committeesIds = djangoBasicInfo.find('[name="committees_collaborations_ids"]');
+        orgSelect.off('change.studentCoordinator').on('change.studentCoordinator', setupStudentCoordinatorSelect);
+        if (committeesIds.length) {
+            committeesIds.off('change.studentCoordinator').on('change.studentCoordinator', setupStudentCoordinatorSelect);
+        }
     }
     
     // NEW FUNCTION to handle dynamic activities
@@ -489,6 +496,7 @@ $(document).ready(function() {
         const select = $('#student-coordinators-modern');
         const djangoField = $('#django-basic-info [name="student_coordinators"]');
         const orgSelect = $('#django-basic-info [name="organization"]');
+        const committeesField = $('#django-basic-info [name="committees_collaborations_ids"]');
         const list = $('#student-coordinators-list');
         if (!select.length || !djangoField.length) return;
 
@@ -504,8 +512,14 @@ $(document).ready(function() {
             create: false,
             placeholder: 'Type a student name…',
             load: function(query, callback) {
-                const orgId = orgSelect.val();
-                const url = `/suite/api/students/?q=${encodeURIComponent(query)}${orgId ? `&org_id=${orgId}` : ''}`;
+                const ids = [];
+                const main = orgSelect.val();
+                if (main) ids.push(main);
+                if (committeesField.length && committeesField.val()) {
+                    committeesField.val().split(',').map(id => id.trim()).filter(Boolean).forEach(id => ids.push(id));
+                }
+                const orgParam = ids.length ? `&org_ids=${encodeURIComponent(ids.join(','))}` : '';
+                const url = `/suite/api/students/?q=${encodeURIComponent(query)}${orgParam}`;
                 fetch(url)
                     .then(response => response.json())
                     .then(json => {

--- a/emt/tests.py
+++ b/emt/tests.py
@@ -165,6 +165,17 @@ class StudentAPITests(TestCase):
         self.assertIn(self.user.id, ids)
         self.assertNotIn(self.other_user.id, ids)
 
+    def test_api_students_supports_multiple_organizations(self):
+        resp = self.client.get(
+            reverse("emt:api_students"),
+            {"org_ids": f"{self.org.id},{self.other_org.id}"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ids = {item["id"] for item in data}
+        self.assertIn(self.user.id, ids)
+        self.assertIn(self.other_user.id, ids)
+
 
 class OutcomesAPITests(TestCase):
     def setUp(self):

--- a/emt/views.py
+++ b/emt/views.py
@@ -1095,9 +1095,14 @@ def api_students(request):
     """Return users with a student membership matching the search query."""
     q = request.GET.get("q", "").strip()
     org_id = request.GET.get("org_id")
+    org_ids = request.GET.get("org_ids")
 
     users = User.objects.filter(org_memberships__role="student")
-    if org_id:
+    if org_ids:
+        ids = [int(i) for i in org_ids.split(",") if i.strip().isdigit()]
+        if ids:
+            users = users.filter(org_memberships__organization_id__in=ids)
+    elif org_id:
         users = users.filter(org_memberships__organization_id=org_id)
 
     if q:


### PR DESCRIPTION
## Summary
- limit student lookup API to multiple selected organizations
- refresh student coordinator search when organization or committee selection changes
- test filtering by multiple organizations

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689d57a09f9c832cbe229097d17dc873