### PR TITLE
Add admin history search and filters

### DIFF
--- a/core/tests/test_admin_history.py
+++ b/core/tests/test_admin_history.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.utils import timezone
+from datetime import timedelta
+from core.models import ActivityLog
+
+class AdminHistoryFilterTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser('admin', 'admin@example.com', 'pass')
+        self.client.login(username='admin', password='pass')
+        self.u1 = User.objects.create_user('alice')
+        self.u2 = User.objects.create_user('bob')
+        log1 = ActivityLog.objects.create(user=self.u1, action='login', description='first')
+        log1.timestamp = timezone.now() - timedelta(days=1)
+        log1.save()
+        self.log1 = log1
+        self.log2 = ActivityLog.objects.create(user=self.u2, action='logout', description='second')
+
+    def test_search_filters_results(self):
+        url = reverse('admin_history')
+        resp = self.client.get(url, {'q': 'logout'})
+        self.assertContains(resp, 'logout')
+        self.assertNotContains(resp, 'alice')
+
+    def test_date_range_filters_results(self):
+        url = reverse('admin_history')
+        today = timezone.now().date().strftime('%Y-%m-%d')
+        resp = self.client.get(url, {'start': today, 'end': today})
+        self.assertContains(resp, 'logout')
+        self.assertNotContains(resp, 'alice')

--- a/static/core/css/admin_history.css
+++ b/static/core/css/admin_history.css
@@ -39,3 +39,22 @@ body {
 .pagination .page-link {
     margin: 0 5px;
 }
+
+/* Filter form */
+.history-filter-form {
+    margin-bottom: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.history-filter-form input,
+.history-filter-form button {
+    padding: 8px 12px;
+}
+
+.history-filter-form .btn-reset {
+    padding: 8px 0;
+    color: #20508c;
+    text-decoration: underline;
+}

--- a/templates/core/admin_history.html
+++ b/templates/core/admin_history.html
@@ -5,6 +5,15 @@
 <link rel="stylesheet" href="{% static 'core/css/admin_history.css' %}">
 <div class="admin-history-container">
   <h1 class="history-title">Activity History</h1>
+  <form method="get" class="history-filter-form">
+    <input type="text" name="q" placeholder="Search..." value="{{ q }}">
+    <input type="date" name="start" value="{{ start }}">
+    <input type="date" name="end" value="{{ end }}">
+    <button type="submit">Filter</button>
+    {% if q or start or end %}
+      <a href="{% url 'admin_history' %}" class="btn-reset">Reset</a>
+    {% endif %}
+  </form>
   <div class="table-responsive">
     <table class="history-table">
       <thead>
@@ -13,6 +22,7 @@
           <th>User</th>
           <th>Action</th>
           <th>Description</th>
+          <th>IP</th>
         </tr>
       </thead>
       <tbody>
@@ -22,10 +32,11 @@
           <td>{{ log.user.get_full_name|default:log.user.username|default:"System" }}</td>
           <td><a href="{% url 'admin_history_detail' log.pk %}">{{ log.action }}</a></td>
           <td>{{ log.description|default:"-" }}</td>
+          <td>{{ log.ip_address|default:"-" }}</td>
         </tr>
         {% empty %}
         <tr>
-          <td colspan="4">No activity found.</td>
+          <td colspan="5">No activity found.</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -34,11 +45,11 @@
   {% if logs.has_other_pages %}
   <div class="pagination">
     {% if logs.has_previous %}
-      <a href="?page={{ logs.previous_page_number }}" class="page-link">&laquo;</a>
+      <a href="?q={{ q }}&start={{ start }}&end={{ end }}&page={{ logs.previous_page_number }}" class="page-link">&laquo;</a>
     {% endif %}
     <span class="page-current">Page {{ logs.number }} of {{ logs.paginator.num_pages }}</span>
     {% if logs.has_next %}
-      <a href="?page={{ logs.next_page_number }}" class="page-link">&raquo;</a>
+      <a href="?q={{ q }}&start={{ start }}&end={{ end }}&page={{ logs.next_page_number }}" class="page-link">&raquo;</a>
     {% endif %}
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- enable text search and date filtering on admin activity history
- show IP address column and style filter form
- add tests covering history search and date range filtering

## Testing
- `python manage.py test core.tests.test_admin_history`


------
https://chatgpt.com/codex/tasks/task_e_689d58bdf0ac832c9356c1e4a50829f1