### PR TITLE
Improve admin history search with typeahead and selection

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2099,6 +2099,18 @@ def admin_history(request):
         except ValueError:
             pass
 
+    # Build type-ahead suggestions from the currently filtered log data
+    action_suggestions = logs.values_list("action", flat=True).distinct()
+    user_suggestions = logs.values_list("user__username", flat=True).distinct()
+    suggestions = sorted(
+        set(
+            filter(
+                None,
+                list(action_suggestions) + list(user_suggestions),
+            )
+        )
+    )
+
     paginator = Paginator(logs, 50)
     page = request.GET.get("page")
     try:
@@ -2113,6 +2125,7 @@ def admin_history(request):
         "q": query,
         "start": start_date,
         "end": end_date,
+        "suggestions": suggestions,
     }
     return render(request, "core/admin_history.html", context)
 

--- a/static/core/css/admin_history.css
+++ b/static/core/css/admin_history.css
@@ -26,6 +26,7 @@ body {
     border-bottom: 1.5px solid #e3eefd;
     padding: 12px 16px;
     text-align: left;
+    user-select: text;
 }
 .history-table th {
     background: #f4f8fc;
@@ -57,4 +58,19 @@ body {
     padding: 8px 0;
     color: #20508c;
     text-decoration: underline;
+}
+
+/* Select all button */
+.btn-select-all {
+    margin-bottom: 10px;
+    padding: 8px 12px;
+    background: #20508c;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-select-all:hover {
+    background: #163d6d;
 }

--- a/templates/core/admin_history.html
+++ b/templates/core/admin_history.html
@@ -6,7 +6,12 @@
 <div class="admin-history-container">
   <h1 class="history-title">Activity History</h1>
   <form method="get" class="history-filter-form">
-    <input type="text" name="q" placeholder="Search..." value="{{ q }}">
+    <input type="text" id="history-search-input" name="q" placeholder="Search..." value="{{ q }}" list="history-suggestions">
+    <datalist id="history-suggestions">
+      {% for item in suggestions %}
+        <option value="{{ item }}">
+      {% endfor %}
+    </datalist>
     <input type="date" name="start" value="{{ start }}">
     <input type="date" name="end" value="{{ end }}">
     <button type="submit">Filter</button>
@@ -14,6 +19,7 @@
       <a href="{% url 'admin_history' %}" class="btn-reset">Reset</a>
     {% endif %}
   </form>
+  <button type="button" class="btn-select-all" id="select-all-btn">Select All</button>
   <div class="table-responsive">
     <table class="history-table">
       <thead>
@@ -54,4 +60,26 @@
   </div>
   {% endif %}
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const searchInput = document.getElementById('history-search-input');
+  const rows = Array.from(document.querySelectorAll('.history-table tbody tr'));
+  searchInput.addEventListener('input', function() {
+    const term = this.value.toLowerCase();
+    rows.forEach(row => {
+      const text = row.textContent.toLowerCase();
+      row.style.display = text.includes(term) ? '' : 'none';
+    });
+  });
+  const selectAllBtn = document.getElementById('select-all-btn');
+  selectAllBtn.addEventListener('click', function() {
+    const table = document.querySelector('.history-table');
+    const range = document.createRange();
+    range.selectNodeContents(table);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add typeahead datalist and instant filtering to admin history
- allow selecting/copying all history table data

## Testing
- `python manage.py test core.tests.test_admin_history -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689d5c230a4c832c9964276777d05387