### PR TITLE
Improve autosave validation feedback

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -97,7 +97,9 @@ window.AutosaveManager = (function() {
             return Promise.reject(data);
         })
         .catch(err => {
-            console.error('Autosave error:', err);
+            if (!err || !err.errors) {
+                console.error('Autosave error:', err);
+            }
             document.dispatchEvent(new CustomEvent('autosave:error', {detail: err}));
             return Promise.reject(err);
         });


### PR DESCRIPTION
## Summary
- highlight invalid fields and scroll to first error when autosave fails
- surface server-side validation errors in save section flow and autosave indicator
- suppress noisy console errors for expected validation issues

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689d6007d618832caa7f9b63cb2f4455