### PR TITLE
feat: enhance admin history table

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2111,17 +2111,9 @@ def admin_history(request):
         )
     )
 
-    paginator = Paginator(logs, 50)
-    page = request.GET.get("page")
-    try:
-        logs_page = paginator.page(page)
-    except PageNotAnInteger:
-        logs_page = paginator.page(1)
-    except EmptyPage:
-        logs_page = paginator.page(paginator.num_pages)
-
+    logs = logs.order_by("-timestamp")
     context = {
-        "logs": logs_page,
+        "logs": logs,
         "q": query,
         "start": start_date,
         "end": end_date,

--- a/static/core/css/admin_history.css
+++ b/static/core/css/admin_history.css
@@ -1,6 +1,7 @@
 body {
     background: #e8f3fc;
 }
+
 .admin-history-container,
 .history-detail-container {
     background: #fff;
@@ -10,6 +11,7 @@ body {
     padding: 40px;
     box-shadow: 0 8px 40px rgba(34,116,203,0.10);
 }
+
 .history-title {
     font-size: 2.1rem;
     font-weight: 800;
@@ -17,28 +19,144 @@ body {
     margin-bottom: 22px;
     letter-spacing: -1px;
 }
-.history-table {
-    width: 100%;
+
+/* DataTable styling */
+.history-table.dataTable {
+    width: 100% !important;
     border-collapse: collapse;
+    border: 1px solid #dbeaff;
+    font-size: 0.95rem;
+    background: #fff;
 }
-.history-table th,
-.history-table td {
-    border-bottom: 1.5px solid #e3eefd;
-    padding: 12px 16px;
-    text-align: left;
-    user-select: text;
-}
-.history-table th {
-    background: #f4f8fc;
-    color: #20508c;
+
+.history-table thead th {
+    background: linear-gradient(to right, #2274cb, #185db4);
+    color: white;
+    padding: 12px 14px;
+    text-transform: uppercase;
     font-weight: 600;
+    font-size: 0.9rem;
 }
-.pagination {
-    margin-top: 20px;
-    text-align: center;
+
+.history-table thead th.sorting_disabled {
+    cursor: default !important;
 }
-.pagination .page-link {
-    margin: 0 5px;
+
+.history-table tbody tr:hover {
+    background: #f3f9ff;
+}
+
+.history-table td {
+    padding: 12px 14px;
+    vertical-align: middle;
+    color: #183a56;
+}
+
+.history-table tbody tr:nth-child(even) {
+    background: #f7fbff;
+}
+
+/* DataTables toolbar */
+.dataTables_wrapper .dt-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 1rem 0;
+    padding: 10px 0;
+}
+
+.dt-toolbar {
+    display: flex !important;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+}
+
+.dt-toolbar .dataTables_length {
+    order: 1;
+}
+
+.dt-toolbar .dt-buttons {
+    order: 2;
+    flex: 1;
+    justify-content: center;
+}
+
+.dt-toolbar .dataTables_filter {
+    order: 3;
+    margin-left: auto;
+}
+
+.dt-toolbar .dataTables_filter input[type="search"] {
+    max-width: 220px;
+}
+
+.dataTables_info {
+    color: #154d8b;
+    font-weight: 500;
+    margin-top: 15px;
+}
+
+.dataTables_paginate {
+    margin-top: 15px;
+}
+
+/* Entries dropdown */
+.dataTables_length label {
+    font-weight: 500;
+    color: #154d8b;
+}
+
+.dataTables_length select {
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    background: #ffffff;
+    font-size: 0.9rem;
+    color: #154d8b;
+}
+
+/* Buttons */
+.dt-buttons {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.dt-button {
+    background: #2274cb;
+    color: white !important;
+    border: none;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-weight: 500;
+    font-size: 0.9rem;
+}
+
+.dt-button:hover {
+    background: #154d8b !important;
+}
+
+/* Search bar */
+.dataTables_filter label {
+    font-weight: 500;
+    color: #154d8b;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.dataTables_filter input {
+    padding: 8px 14px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    height: 40px;
+    width: 220px;
+    box-sizing: border-box;
 }
 
 /* Filter form */
@@ -58,19 +176,4 @@ body {
     padding: 8px 0;
     color: #20508c;
     text-decoration: underline;
-}
-
-/* Select all button */
-.btn-select-all {
-    margin-bottom: 10px;
-    padding: 8px 12px;
-    background: #20508c;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-.btn-select-all:hover {
-    background: #163d6d;
 }

--- a/templates/core/admin_history.html
+++ b/templates/core/admin_history.html
@@ -1,8 +1,27 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block content %}
+{% block head_extra %}
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/dataTables.bootstrap5.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.5.0/css/responsive.bootstrap5.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.bootstrap5.min.css">
+<script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.7/js/dataTables.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js"></script>
+<script src="https://cdn.datatables.net/responsive/2.5.0/js/responsive.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.colVis.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
 <link rel="stylesheet" href="{% static 'core/css/admin_history.css' %}">
+{% endblock %}
+
+{% block content %}
 <div class="admin-history-container">
   <h1 class="history-title">Activity History</h1>
   <form method="get" class="history-filter-form">
@@ -19,9 +38,8 @@
       <a href="{% url 'admin_history' %}" class="btn-reset">Reset</a>
     {% endif %}
   </form>
-  <button type="button" class="btn-select-all" id="select-all-btn">Select All</button>
   <div class="table-responsive">
-    <table class="history-table">
+    <table class="history-table table table-striped table-bordered" id="historyTable">
       <thead>
         <tr>
           <th>Timestamp</th>
@@ -48,37 +66,19 @@
       </tbody>
     </table>
   </div>
-  {% if logs.has_other_pages %}
-  <div class="pagination">
-    {% if logs.has_previous %}
-      <a href="?q={{ q }}&start={{ start }}&end={{ end }}&page={{ logs.previous_page_number }}" class="page-link">&laquo;</a>
-    {% endif %}
-    <span class="page-current">Page {{ logs.number }} of {{ logs.paginator.num_pages }}</span>
-    {% if logs.has_next %}
-      <a href="?q={{ q }}&start={{ start }}&end={{ end }}&page={{ logs.next_page_number }}" class="page-link">&raquo;</a>
-    {% endif %}
-  </div>
-  {% endif %}
 </div>
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-  const searchInput = document.getElementById('history-search-input');
-  const rows = Array.from(document.querySelectorAll('.history-table tbody tr'));
-  searchInput.addEventListener('input', function() {
-    const term = this.value.toLowerCase();
-    rows.forEach(row => {
-      const text = row.textContent.toLowerCase();
-      row.style.display = text.includes(term) ? '' : 'none';
-    });
-  });
-  const selectAllBtn = document.getElementById('select-all-btn');
-  selectAllBtn.addEventListener('click', function() {
-    const table = document.querySelector('.history-table');
-    const range = document.createRange();
-    range.selectNodeContents(table);
-    const sel = window.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
+$(document).ready(function() {
+  $('#historyTable').DataTable({
+    responsive: true,
+    dom: '<"dt-toolbar d-flex justify-content-between align-items-center flex-wrap mb-3"lBf>rtip',
+    buttons: [
+      { extend: 'copy', className: 'btn btn-secondary' },
+      { extend: 'excel', className: 'btn btn-success' },
+      { extend: 'csv', className: 'btn btn-info' },
+      { extend: 'print', className: 'btn btn-primary' },
+      { extend: 'colvis', className: 'btn btn-secondary' }
+    ]
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- modernize admin history list with DataTables UI
- style history table to match dashboard and proposal review
- simplify admin history view and drop server pagination

## Testing
- `python manage.py test core.tests.test_admin_history -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689d60f720dc832c81008e660e16427e