### PR TITLE
Persist POS/PSO data in proposal submission form

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -567,6 +567,7 @@ $(document).ready(function() {
         const djangoOrgSelect = $('#django-basic-info [name="organization"]');
         const modal = $('#outcomeModal');
         const optionsContainer = $('#outcomeOptions');
+        const djangoPosField = $('#django-basic-info [name="pos_pso"]');
 
         if (!posField.length || !djangoOrgSelect.length || !modal.length) return;
 
@@ -592,7 +593,10 @@ $(document).ready(function() {
             const selected = modal.find('input[type=checkbox]:checked').map((_, cb) => cb.value).get();
             const existing = posField.val().trim();
             const value = existing ? existing + '\n' + selected.join('\n') : selected.join('\n');
-            posField.val(value).trigger('change');
+            posField.val(value).trigger('input').trigger('change');
+            if (djangoPosField.length) {
+                djangoPosField.val(value).trigger('input').trigger('change');
+            }
             modal.removeClass('show');
         });
     }
@@ -1075,7 +1079,7 @@ $(document).ready(function() {
                     </div>
                     <div class="input-group">
                         <label for="pos-pso-modern">POS & PSO Management</label>
-                        <input type="text" id="pos-pso-modern" placeholder="e.g., PO1, PSO2">
+                        <input type="text" id="pos-pso-modern" name="pos_pso" placeholder="e.g., PO1, PSO2">
                         <div class="help-text">Program outcomes and specific outcomes addressed</div>
                     </div>
                 </div>

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -186,7 +186,7 @@
                             </div>
                             <div class="input-group">
                                 <label for="pos-pso-modern">POS & PSO Management</label>
-                                <input type="text" id="pos-pso-modern" placeholder="e.g., PO1, PSO2">
+                                <input type="text" id="pos-pso-modern" name="pos_pso" placeholder="e.g., PO1, PSO2">
                                 <div class="help-text">Program outcomes and specific outcomes addressed</div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Ensure POS/PSO selections persist by naming the visible field and syncing it to the hidden Django field
- Trigger input/change events so autosave captures POS/PSO values

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689d64cd4bfc832cb9abaac152c80536