### PR TITLE
Refine admin history filters UI

### DIFF
--- a/static/core/css/admin_history.css
+++ b/static/core/css/admin_history.css
@@ -162,18 +162,9 @@ body {
 /* Filter form */
 .history-filter-form {
     margin-bottom: 20px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-}
-
-.history-filter-form input,
-.history-filter-form button {
-    padding: 8px 12px;
 }
 
 .history-filter-form .btn-reset {
-    padding: 8px 0;
     color: #20508c;
     text-decoration: underline;
 }

--- a/templates/core/admin_history.html
+++ b/templates/core/admin_history.html
@@ -24,20 +24,45 @@
 {% block content %}
 <div class="admin-history-container">
   <h1 class="history-title">Activity History</h1>
-  <form method="get" class="history-filter-form">
-    <input type="text" id="history-search-input" name="q" placeholder="Search..." value="{{ q }}" list="history-suggestions">
-    <datalist id="history-suggestions">
-      {% for item in suggestions %}
-        <option value="{{ item }}">
-      {% endfor %}
-    </datalist>
-    <input type="date" name="start" value="{{ start }}">
-    <input type="date" name="end" value="{{ end }}">
-    <button type="submit">Filter</button>
+  <form method="get" class="history-filter-form row g-2 align-items-end">
+    <div class="col-md-4">
+      <label for="history-search-input" class="form-label">Search</label>
+      <input type="text" id="history-search-input" name="q" class="form-control" placeholder="Search..." value="{{ q }}" list="history-suggestions">
+      <datalist id="history-suggestions">
+        {% for item in suggestions %}
+          <option value="{{ item }}">
+        {% endfor %}
+      </datalist>
+    </div>
+    <div class="col-md-3">
+      <label for="start" class="form-label">Start date</label>
+      <input type="date" id="start" name="start" class="form-control" value="{{ start }}">
+    </div>
+    <div class="col-md-3">
+      <label for="end" class="form-label">End date</label>
+      <input type="date" id="end" name="end" class="form-control" value="{{ end }}">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary">Filter</button>
+    </div>
     {% if q or start or end %}
-      <a href="{% url 'admin_history' %}" class="btn-reset">Reset</a>
+    <div class="col-auto">
+      <a href="{% url 'admin_history' %}" class="btn btn-outline-secondary btn-reset">Reset</a>
+    </div>
     {% endif %}
   </form>
+  {% if q or start or end %}
+  <div class="alert alert-info py-2 small">
+    {% if q %}Search: <strong>{{ q }}</strong>{% endif %}
+    {% if start or end %}
+      {% if q %}<span class="mx-1">|</span>{% endif %}
+      Date:
+      {% if start %}from {{ start }}{% endif %}
+      {% if start and end %} to {% endif %}
+      {% if end %}{{ end }}{% endif %}
+    {% endif %}
+  </div>
+  {% endif %}
   <div class="table-responsive">
     <table class="history-table table table-striped table-bordered" id="historyTable">
       <thead>
@@ -71,7 +96,7 @@
 $(document).ready(function() {
   $('#historyTable').DataTable({
     responsive: true,
-    dom: '<"dt-toolbar d-flex justify-content-between align-items-center flex-wrap mb-3"lBf>rtip',
+    dom: '<"dt-toolbar d-flex justify-content-between align-items-center flex-wrap mb-3"lB>rtip',
     buttons: [
       { extend: 'copy', className: 'btn btn-secondary' },
       { extend: 'excel', className: 'btn btn-success' },


### PR DESCRIPTION
## Summary
- style admin history filters with bootstrap
- remove duplicate DataTables search and show applied filter summary

## Testing
- `python manage.py test core.tests.test_admin_history -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689d65ebbf3c832cafecb45a37d43a83