### PR TITLE
Show approved events on user dashboard calendar

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2265,7 +2265,7 @@ def user_dashboard(request):
     today = timezone.now().date()
 
     events = (
-        EventProposal.objects.filter(status="finalized")
+        EventProposal.objects.filter(status=EventProposal.Status.APPROVED)
         .filter(
             Q(submitted_by=user)
             | Q(faculty_incharges=user)

--- a/static/core/js/user_dashboard.js
+++ b/static/core/js/user_dashboard.js
@@ -319,7 +319,13 @@ function openDay(day) {
         return false;
     });
     list.innerHTML = items.length
-        ? items.map(e => `<div class="u-item"><div>${e.title}</div></div>`).join('')
+        ? items.map(e => {
+            const time = e.datetime
+                ? new Date(e.datetime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                : '';
+            const meta = [time, e.venue].filter(Boolean).join(' @ ');
+            return `<div class="u-item"><div>${e.title}${meta ? ' - ' + meta : ''}</div></div>`;
+        }).join('')
         : `<div class="empty">No events for ${day.toLocaleDateString()}</div>`;
 }
 

--- a/templates/core/user_dashboard.html
+++ b/templates/core/user_dashboard.html
@@ -149,6 +149,6 @@
 
     {{ calendar_events|json_script:"calendarEventsJson" }}
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-    <script src="{% static 'core/user_dashboard.js' %}"></script>
+    <script src="{% static 'core/js/user_dashboard.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Display only approved event proposals on the user dashboard calendar
- Load dashboard script correctly and show event time/venue when a date is opened

## Testing
- `pytest` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689d6b479578832cb7244661758a3d91