### PR TITLE
Show past events on dashboard calendar

### DIFF
--- a/core/tests/test_user_dashboard_calendar.py
+++ b/core/tests/test_user_dashboard_calendar.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth.models import User
+from emt.models import EventProposal
+
+
+class UserDashboardCalendarTests(TestCase):
+    def test_past_and_future_events_included(self):
+        user = User.objects.create_user(username="user", password="pass")
+        past_date = timezone.now() - timezone.timedelta(days=5)
+        future_date = timezone.now() + timezone.timedelta(days=5)
+        EventProposal.objects.create(
+            submitted_by=user,
+            event_title="Past",
+            status=EventProposal.Status.APPROVED,
+            event_datetime=past_date,
+        )
+        EventProposal.objects.create(
+            submitted_by=user,
+            event_title="Future",
+            status=EventProposal.Status.APPROVED,
+            event_datetime=future_date,
+        )
+        self.client.force_login(user)
+        response = self.client.get(reverse("user_dashboard"))
+        self.assertEqual(response.status_code, 200)
+        events = response.context["calendar_events"]
+        dates = {e.get("date") for e in events}
+        self.assertIn(past_date.date().isoformat(), dates)
+        self.assertIn(future_date.date().isoformat(), dates)

--- a/templates/core/user_dashboard.html
+++ b/templates/core/user_dashboard.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+{% load static %}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -57,7 +58,7 @@
                 <i class="fas fa-user"></i>
                 <span>My Profile</span>
             </button>
-            {% if user.popso_assignments.filter(is_active=True).exists %}
+            {% if show_settings_tab %}
             <a href="{% url 'settings_pso_po_management' %}" class="nav-tab settings-tab">
                 <i class="fas fa-cog"></i>
                 <span>Settings</span>


### PR DESCRIPTION
## Summary
- Include events with any recorded date on the dashboard calendar, not just future ones
- Pass settings tab availability from view to template and load static files
- Add regression test verifying past and future events are shown

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689d6d4efd48832cbde43813439a4a14