### PR TITLE
Show approved events on user dashboard calendar

### DIFF
--- a/core/tests/test_user_dashboard_calendar.py
+++ b/core/tests/test_user_dashboard_calendar.py
@@ -29,3 +29,19 @@ class UserDashboardCalendarTests(TestCase):
         dates = {e.get("date") for e in events}
         self.assertIn(past_date.date().isoformat(), dates)
         self.assertIn(future_date.date().isoformat(), dates)
+
+    def test_includes_events_from_other_users(self):
+        user = User.objects.create_user(username="user", password="pass")
+        other = User.objects.create_user(username="other", password="pass")
+        date = timezone.now()
+        EventProposal.objects.create(
+            submitted_by=other,
+            event_title="Other", 
+            status=EventProposal.Status.APPROVED,
+            event_datetime=date,
+        )
+        self.client.force_login(user)
+        response = self.client.get(reverse("user_dashboard"))
+        events = response.context["calendar_events"]
+        dates = {e.get("date") for e in events}
+        self.assertIn(date.date().isoformat(), dates)

--- a/core/views.py
+++ b/core/views.py
@@ -2249,28 +2249,13 @@ def api_student_achievements(request):
 def user_dashboard(request):
     """Render the simplified user dashboard with calendar events.
 
-    Events shown are related to the current user either directly (submitted
-    by or managed by them), through their organization assignments, or, if the
-    user is a student, through their participation in events.
+    Events shown include all approved events that have any associated date.
     """
 
     user = request.user
 
-    # Organizations the user is connected to via role assignments
-    user_org_ids = list(
-        RoleAssignment.objects.filter(user=user, organization_id__isnull=False)
-        .values_list("organization_id", flat=True)
-    )
-
     events = (
         EventProposal.objects.filter(status=EventProposal.Status.APPROVED)
-        .filter(
-            Q(submitted_by=user)
-            | Q(faculty_incharges=user)
-            | Q(organization_id__in=user_org_ids)
-            | Q(participants__user=user)
-        )
-        # Include events with any recorded date, past or future
         .filter(
             Q(event_datetime__isnull=False)
             | Q(event_start_date__isnull=False)


### PR DESCRIPTION
## Summary
- Display every approved event with a date on the user dashboard calendar
- Include tests confirming events from other users appear

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689d71c4b2c4832cbb18251e8ac63a62