### PR TITLE
fix: retain basic info for AI generation

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1822,11 +1822,16 @@ function getWhyThisEventForm() {
     }
 
     function collectBasicInfo() {
+        const getVal = (modernSelector, djangoName) => {
+            const modern = $(modernSelector);
+            if (modern.length && modern.val()) return modern.val();
+            return $(`#django-basic-info [name="${djangoName}"]`).val() || '';
+        };
         return {
-            title: $('#event-title-modern').val() || '',
-            audience: $('#target-audience-modern').val() || '',
-            focus: $('#event-focus-type-modern').val() || '',
-            venue: $('#venue-modern').val() || ''
+            title: getVal('#event-title-modern', 'event_title'),
+            audience: getVal('#target-audience-modern', 'target_audience'),
+            focus: getVal('#event-focus-type-modern', 'event_focus_type'),
+            venue: getVal('#venue-modern', 'venue')
         };
     }
 


### PR DESCRIPTION
## Summary
- ensure basic info values persist for AI generation when modern fields are absent
- include previously entered values when generating "Why This Event?" AI text

## Testing
- `node test_ai.js`
- `npx playwright install` *(fails: chromium download incomplete)*
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689e522c18f4832c8b039fe5477e1a2e