### PR TITLE
feat: add AI backend fallback

### DIFF
--- a/emt/tests/test_ai_generation.py
+++ b/emt/tests/test_ai_generation.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from suite import ai_client
 
 
 class AIGenerationTests(TestCase):
@@ -10,12 +11,9 @@ class AIGenerationTests(TestCase):
         self.user = User.objects.create_user('u', 'u@example.com', 'p')
         self.client.force_login(self.user)
 
-    @patch('emt.views.requests.post')
-    def test_generate_need_analysis(self, mock_post):
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {
-            'choices': [{'message': {'content': 'need text'}}]
-        }
+    @patch('suite.ai_client.chat')
+    def test_generate_need_analysis(self, mock_chat):
+        mock_chat.return_value = 'need text'
         resp = self.client.post(reverse('emt:generate_need_analysis'), {
             'title': 'T',
             'audience': 'Students'
@@ -25,12 +23,9 @@ class AIGenerationTests(TestCase):
         self.assertTrue(data['ok'])
         self.assertEqual(data['text'], 'need text')
 
-    @patch('emt.views.requests.post')
-    def test_generate_objectives(self, mock_post):
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {
-            'choices': [{'message': {'content': 'obj text'}}]
-        }
+    @patch('suite.ai_client.chat')
+    def test_generate_objectives(self, mock_chat):
+        mock_chat.return_value = 'obj text'
         resp = self.client.post(reverse('emt:generate_objectives'), {
             'title': 'T',
             'audience': 'Students'
@@ -39,6 +34,18 @@ class AIGenerationTests(TestCase):
         data = resp.json()
         self.assertTrue(data['ok'])
         self.assertEqual(data['text'], 'obj text')
+
+    @patch('suite.ai_client.chat')
+    def test_generate_need_analysis_error(self, mock_chat):
+        mock_chat.side_effect = ai_client.AIError('All AI backends failed: OLLAMA: down')
+        resp = self.client.post(reverse('emt:generate_need_analysis'), {
+            'title': 'T',
+            'audience': 'Students'
+        })
+        self.assertEqual(resp.status_code, 503)
+        data = resp.json()
+        self.assertFalse(data['ok'])
+        self.assertIn('All AI backends failed', data['error'])
 
     @patch('emt.views.requests.post')
     def test_generate_expected_outcomes(self, mock_post):

--- a/emt/views.py
+++ b/emt/views.py
@@ -7,6 +7,7 @@ import json
 import re
 from urllib.parse import urlparse
 import requests
+from suite import ai_client
 import time
 from bs4 import BeautifulSoup
 from django.db.models import Q
@@ -1771,11 +1772,11 @@ def generate_need_analysis(request):
     if not ctx:
         return JsonResponse({"ok": False, "error": "No context"}, status=400)
     try:
-        text = _ollama_chat(GEN_MODEL, NEED_PROMPT, ctx, max_tokens=220, temp=0.4)
+        text = ai_client.chat([{ "role": "user", "content": ctx }], system=NEED_PROMPT)
         return JsonResponse({"ok": True, "text": text})
-    except Exception as exc:
+    except ai_client.AIError as exc:
         logger.error("Need analysis generation failed: %s", exc)
-        return JsonResponse({"ok": False, "error": "AI service unavailable"}, status=503)
+        return JsonResponse({"ok": False, "error": str(exc)}, status=503)
 
 
 @login_required
@@ -1785,11 +1786,11 @@ def generate_objectives(request):
     if not ctx:
         return JsonResponse({"ok": False, "error": "No context"}, status=400)
     try:
-        text = _ollama_chat(GEN_MODEL, OBJ_PROMPT, ctx, max_tokens=200, temp=0.4)
+        text = ai_client.chat([{ "role": "user", "content": ctx }], system=OBJ_PROMPT)
         return JsonResponse({"ok": True, "text": text})
-    except Exception as exc:
+    except ai_client.AIError as exc:
         logger.error("Objectives generation failed: %s", exc)
-        return JsonResponse({"ok": False, "error": "AI service unavailable"}, status=503)
+        return JsonResponse({"ok": False, "error": str(exc)}, status=503)
 
 
 @login_required

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -10,19 +10,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # ---------------------------------------------------------------------------
 # AI backend configuration
 # ---------------------------------------------------------------------------
-AI_BACKEND = os.getenv("AI_BACKEND", "OPENROUTER").upper()
+AI_BACKEND = os.getenv("AI_BACKEND", "OLLAMA").upper()  # OLLAMA | OPENROUTER
+OLLAMA_BASE = os.getenv("OLLAMA_BASE", "http://127.0.0.1:11434")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL")
-LOCAL_AI_BASE_URL = os.getenv("LOCAL_AI_BASE_URL")
-LOCAL_AI_MODEL = os.getenv("LOCAL_AI_MODEL")
+AI_HTTP_TIMEOUT = int(os.getenv("AI_HTTP_TIMEOUT", "60"))
 
 _logger = logging.getLogger(__name__)
-if AI_BACKEND == "OPENROUTER":
-    if not OPENROUTER_API_KEY or not OPENROUTER_MODEL:
-        _logger.warning("OpenRouter backend selected but OPENROUTER_API_KEY or OPENROUTER_MODEL is missing")
-elif AI_BACKEND == "LOCAL_HTTP":
-    if not LOCAL_AI_BASE_URL or not LOCAL_AI_MODEL:
-        _logger.warning("LOCAL_HTTP backend selected but LOCAL_AI_BASE_URL or LOCAL_AI_MODEL is missing")
+if AI_BACKEND == "OPENROUTER" and not OPENROUTER_API_KEY:
+    _logger.warning("OpenRouter backend selected but OPENROUTER_API_KEY is missing")
 
 # SECRET_KEY loaded from environment with a development fallback
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-…')

--- a/suite/ai_client.py
+++ b/suite/ai_client.py
@@ -1,0 +1,83 @@
+import logging
+from typing import List, Dict, Optional
+import requests
+from django.conf import settings as django_settings
+
+logger = logging.getLogger(__name__)
+
+class AIError(Exception):
+    """Raised when all AI backends are unavailable."""
+    pass
+
+
+def _ollama_available(base: str) -> bool:
+    try:
+        resp = requests.get(f"{base}/v1/models", timeout=2)
+        resp.raise_for_status()
+        return True
+    except Exception as exc:  # pragma: no cover - health check failure
+        logger.warning("Ollama health check failed: %s", exc)
+        return False
+
+
+def _post_chat(url: str, headers: Dict[str, str], body: Dict, timeout: int) -> str:
+    resp = requests.post(url, headers=headers, json=body, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["choices"][0]["message"]["content"].strip()
+
+
+def chat(messages: List[Dict[str, str]], system: Optional[str] = None,
+         model: Optional[str] = None, settings=None) -> str:
+    """Send a chat completion request with automatic backend fallback."""
+    settings = settings or django_settings
+    full_messages = []
+    if system:
+        full_messages.append({"role": "system", "content": system})
+    full_messages.extend(messages)
+
+    preferred = settings.AI_BACKEND.upper()
+    order = [preferred, "OPENROUTER" if preferred == "OLLAMA" else "OLLAMA"]
+
+    errors = []
+    for backend in order:
+        try:
+            if backend == "OLLAMA":
+                base = getattr(settings, "OLLAMA_BASE", None)
+                if not base:
+                    raise AIError("Ollama base URL not configured")
+                if not _ollama_available(base):
+                    raise AIError("Ollama backend unreachable")
+                model_name = model or getattr(settings, "OLLAMA_GEN_MODEL", None)
+                if not model_name:
+                    raise AIError("Ollama model not configured")
+                body = {
+                    "model": model_name,
+                    "messages": full_messages,
+                    "temperature": 0.2,
+                }
+                return _post_chat(f"{base}/v1/chat/completions",
+                                  {"Content-Type": "application/json"},
+                                  body, settings.AI_HTTP_TIMEOUT)
+            else:  # OPENROUTER
+                api_key = getattr(settings, "OPENROUTER_API_KEY", None)
+                if not api_key:
+                    raise AIError("OpenRouter API key missing")
+                model_name = getattr(settings, "OPENROUTER_MODEL", None)
+                if not model_name:
+                    raise AIError("OpenRouter model not configured")
+                headers = {
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                }
+                body = {
+                    "model": model_name,
+                    "messages": full_messages,
+                    "temperature": 0.2,
+                }
+                return _post_chat("https://openrouter.ai/api/v1/chat/completions",
+                                  headers, body, settings.AI_HTTP_TIMEOUT)
+        except Exception as exc:
+            logger.warning("%s backend failed: %s", backend, exc)
+            errors.append(f"{backend}: {exc}")
+            continue
+    raise AIError("All AI backends failed: " + "; ".join(errors))


### PR DESCRIPTION
## Summary
- add AI backend config for Ollama/OpenRouter
- introduce AI client with automatic Ollama/OpenRouter fallback
- use ai_client in need analysis/objectives views and extend tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ed0699d38832c9097d7881fc8ac3a