### PR TITLE
Add Ollama chat client and update AI views

### DIFF
--- a/emt/tests/test_ai_generation.py
+++ b/emt/tests/test_ai_generation.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
-from suite import ai_client
+from suite import ollama_client
 
 
 class AIGenerationTests(TestCase):
@@ -11,7 +11,7 @@ class AIGenerationTests(TestCase):
         self.user = User.objects.create_user('u', 'u@example.com', 'p')
         self.client.force_login(self.user)
 
-    @patch('suite.ai_client.chat')
+    @patch('suite.ollama_client.chat')
     def test_generate_need_analysis(self, mock_chat):
         mock_chat.return_value = 'need text'
         resp = self.client.post(reverse('emt:generate_need_analysis'), {
@@ -20,10 +20,9 @@ class AIGenerationTests(TestCase):
         })
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data['ok'])
         self.assertEqual(data['text'], 'need text')
 
-    @patch('suite.ai_client.chat')
+    @patch('suite.ollama_client.chat')
     def test_generate_objectives(self, mock_chat):
         mock_chat.return_value = 'obj text'
         resp = self.client.post(reverse('emt:generate_objectives'), {
@@ -32,20 +31,18 @@ class AIGenerationTests(TestCase):
         })
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data['ok'])
         self.assertEqual(data['text'], 'obj text')
 
-    @patch('suite.ai_client.chat')
+    @patch('suite.ollama_client.chat')
     def test_generate_need_analysis_error(self, mock_chat):
-        mock_chat.side_effect = ai_client.AIError('All AI backends failed: OLLAMA: down')
+        mock_chat.side_effect = ollama_client.AIError('Ollama request failed: down')
         resp = self.client.post(reverse('emt:generate_need_analysis'), {
             'title': 'T',
             'audience': 'Students'
         })
         self.assertEqual(resp.status_code, 503)
         data = resp.json()
-        self.assertFalse(data['ok'])
-        self.assertIn('All AI backends failed', data['error'])
+        self.assertIn('Ollama request failed', data['error'])
 
     @patch('emt.views.requests.post')
     def test_generate_expected_outcomes(self, mock_post):

--- a/emt/views.py
+++ b/emt/views.py
@@ -7,7 +7,7 @@ import json
 import re
 from urllib.parse import urlparse
 import requests
-from suite import ai_client
+from suite import ollama_client
 import time
 from bs4 import BeautifulSoup
 from django.db.models import Q
@@ -1770,13 +1770,15 @@ OUT_PROMPT = "List 3-5 expected learning outcomes for participants as bullet poi
 def generate_need_analysis(request):
     ctx = _basic_info_context(request.POST)
     if not ctx:
-        return JsonResponse({"ok": False, "error": "No context"}, status=400)
+        return JsonResponse({"error": "No context"}, status=400)
     try:
-        text = ai_client.chat([{ "role": "user", "content": ctx }], system=NEED_PROMPT)
-        return JsonResponse({"ok": True, "text": text})
-    except ai_client.AIError as exc:
+        text = ollama_client.chat([
+            {"role": "user", "content": ctx}
+        ], system=NEED_PROMPT)
+        return JsonResponse({"text": text})
+    except ollama_client.AIError as exc:
         logger.error("Need analysis generation failed: %s", exc)
-        return JsonResponse({"ok": False, "error": str(exc)}, status=503)
+        return JsonResponse({"error": str(exc)}, status=503)
 
 
 @login_required
@@ -1784,13 +1786,15 @@ def generate_need_analysis(request):
 def generate_objectives(request):
     ctx = _basic_info_context(request.POST)
     if not ctx:
-        return JsonResponse({"ok": False, "error": "No context"}, status=400)
+        return JsonResponse({"error": "No context"}, status=400)
     try:
-        text = ai_client.chat([{ "role": "user", "content": ctx }], system=OBJ_PROMPT)
-        return JsonResponse({"ok": True, "text": text})
-    except ai_client.AIError as exc:
+        text = ollama_client.chat([
+            {"role": "user", "content": ctx}
+        ], system=OBJ_PROMPT)
+        return JsonResponse({"text": text})
+    except ollama_client.AIError as exc:
         logger.error("Objectives generation failed: %s", exc)
-        return JsonResponse({"ok": False, "error": str(exc)}, status=503)
+        return JsonResponse({"error": str(exc)}, status=503)
 
 
 @login_required

--- a/suite/ollama_client.py
+++ b/suite/ollama_client.py
@@ -1,0 +1,44 @@
+import logging
+from typing import List, Dict, Optional
+
+import requests
+from django.conf import settings as django_settings
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class AIError(Exception):
+    """Raised when the Ollama backend fails."""
+    pass
+
+
+def chat(messages: List[Dict[str, str]], system: Optional[str] = None,
+         model: Optional[str] = None, settings=django_settings) -> str:
+    """Send a chat completion request to the configured Ollama backend."""
+    base = getattr(settings, "OLLAMA_BASE", os.getenv("OLLAMA_BASE"))
+    if not base:
+        raise AIError("OLLAMA_BASE not configured")
+    timeout = getattr(settings, "AI_HTTP_TIMEOUT", int(os.getenv("AI_HTTP_TIMEOUT", 30)))
+    model_name = model or getattr(settings, "OLLAMA_MODEL", os.getenv("OLLAMA_MODEL"))
+    if not model_name:
+        raise AIError("OLLAMA_MODEL not configured")
+    full_messages: List[Dict[str, str]] = []
+    if system:
+        full_messages.append({"role": "system", "content": system})
+    full_messages.extend(messages)
+    try:
+        resp = requests.post(
+            f"{base}/v1/chat/completions",
+            json={"model": model_name, "messages": full_messages},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+    except requests.RequestException as exc:
+        logger.error("Ollama request failed: %s", exc)
+        raise AIError(f"Ollama request failed: {exc}") from exc
+    except (KeyError, IndexError, ValueError) as exc:
+        logger.error("Invalid Ollama response: %s", exc)
+        raise AIError(f"Invalid Ollama response: {exc}") from exc


### PR DESCRIPTION
## Summary
- add standalone `ollama_client.chat` for calling local Ollama models
- wire Need Analysis and Objectives views to `ollama_client` and simplify JSON responses
- update AI generation tests for new client and response format

## Testing
- `python manage.py test`
- `AI_BACKEND=OLLAMA OLLAMA_BASE=http://127.0.0.1:11434 AI_HTTP_TIMEOUT=30 OLLAMA_MODEL=llama3 python manage.py shell -c "from suite import ollama_client; print(ollama_client.chat([{\"role\":\"user\",\"content\":\"Reply with OK only.\"}]))"` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ed306f2ec832c96691eb76715a62b