### PR TITLE
Add robust AI client and env config

### DIFF
--- a/emt/tests/test_ai_generation.py
+++ b/emt/tests/test_ai_generation.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
-from suite import ollama_client
+from suite import ai_client
 
 
 class AIGenerationTests(TestCase):
@@ -11,7 +11,7 @@ class AIGenerationTests(TestCase):
         self.user = User.objects.create_user('u', 'u@example.com', 'p')
         self.client.force_login(self.user)
 
-    @patch('suite.ollama_client.chat')
+    @patch('emt.views.chat')
     def test_generate_need_analysis(self, mock_chat):
         mock_chat.return_value = 'need text'
         resp = self.client.post(reverse('emt:generate_need_analysis'), {
@@ -22,7 +22,7 @@ class AIGenerationTests(TestCase):
         data = resp.json()
         self.assertEqual(data['text'], 'need text')
 
-    @patch('suite.ollama_client.chat')
+    @patch('emt.views.chat')
     def test_generate_objectives(self, mock_chat):
         mock_chat.return_value = 'obj text'
         resp = self.client.post(reverse('emt:generate_objectives'), {
@@ -33,9 +33,9 @@ class AIGenerationTests(TestCase):
         data = resp.json()
         self.assertEqual(data['text'], 'obj text')
 
-    @patch('suite.ollama_client.chat')
+    @patch('emt.views.chat')
     def test_generate_need_analysis_error(self, mock_chat):
-        mock_chat.side_effect = ollama_client.AIError('Ollama request failed: down')
+        mock_chat.side_effect = ai_client.AIError('Ollama request failed: down')
         resp = self.client.post(reverse('emt:generate_need_analysis'), {
             'title': 'T',
             'audience': 'Students'

--- a/emt/views.py
+++ b/emt/views.py
@@ -7,7 +7,7 @@ import json
 import re
 from urllib.parse import urlparse
 import requests
-from suite import ollama_client
+from suite.ai_client import chat, AIError
 import time
 from bs4 import BeautifulSoup
 from django.db.models import Q
@@ -1772,13 +1772,15 @@ def generate_need_analysis(request):
     if not ctx:
         return JsonResponse({"error": "No context"}, status=400)
     try:
-        text = ollama_client.chat([
-            {"role": "user", "content": ctx}
-        ], system=NEED_PROMPT)
+        messages = [{"role": "user", "content": f"{NEED_PROMPT}\n\n{ctx}"}]
+        text = chat(messages, system="You write crisp academic content for university event proposals.")
         return JsonResponse({"text": text})
-    except ollama_client.AIError as exc:
+    except AIError as exc:
         logger.error("Need analysis generation failed: %s", exc)
         return JsonResponse({"error": str(exc)}, status=503)
+    except Exception as exc:
+        logger.error("Need analysis generation unexpected error: %s", exc)
+        return JsonResponse({"error": f"Unexpected error: {exc}"}, status=500)
 
 
 @login_required
@@ -1788,13 +1790,15 @@ def generate_objectives(request):
     if not ctx:
         return JsonResponse({"error": "No context"}, status=400)
     try:
-        text = ollama_client.chat([
-            {"role": "user", "content": ctx}
-        ], system=OBJ_PROMPT)
+        messages = [{"role": "user", "content": f"{OBJ_PROMPT}\n\n{ctx}"}]
+        text = chat(messages, system="You write measurable, outcome-focused objectives aligned to higher-education events.")
         return JsonResponse({"text": text})
-    except ollama_client.AIError as exc:
+    except AIError as exc:
         logger.error("Objectives generation failed: %s", exc)
         return JsonResponse({"error": str(exc)}, status=503)
+    except Exception as exc:
+        logger.error("Objectives generation unexpected error: %s", exc)
+        return JsonResponse({"error": f"Unexpected error: {exc}"}, status=500)
 
 
 @login_required

--- a/suite/ai_client.py
+++ b/suite/ai_client.py
@@ -1,83 +1,104 @@
-import logging
-from typing import List, Dict, Optional
+import os
 import requests
-from django.conf import settings as django_settings
+from django.conf import settings
 
-logger = logging.getLogger(__name__)
 
 class AIError(Exception):
-    """Raised when all AI backends are unavailable."""
     pass
 
 
-def _ollama_available(base: str) -> bool:
+def _get(name: str, default=None):
+    """Read from Django settings first, then OS env, then default."""
+    return getattr(settings, name, os.getenv(name, default))
+
+
+def _ollama_available(base: str, timeout: int = 2) -> bool:
     try:
-        resp = requests.get(f"{base}/v1/models", timeout=2)
-        resp.raise_for_status()
-        return True
-    except Exception as exc:  # pragma: no cover - health check failure
-        logger.warning("Ollama health check failed: %s", exc)
+        r = requests.get(f"{base}/v1/models", timeout=timeout)
+        return r.ok
+    except requests.RequestException:
         return False
 
 
-def _post_chat(url: str, headers: Dict[str, str], body: Dict, timeout: int) -> str:
-    resp = requests.post(url, headers=headers, json=body, timeout=timeout)
-    resp.raise_for_status()
-    return resp.json()["choices"][0]["message"]["content"].strip()
+def _ollama_chat(messages, system=None, model=None, temperature=0.2, timeout=None, base=None):
+    base = base or _get("OLLAMA_BASE", "http://127.0.0.1:11434")
+    model = model or _get("OLLAMA_MODEL", "llama3")
+    timeout = timeout or int(_get("AI_HTTP_TIMEOUT", "20"))
+
+    payload = {
+        "model": model,
+        "messages": ([{"role": "system", "content": system}] if system else []) + messages,
+        "temperature": temperature,
+    }
+    r = requests.post(f"{base}/v1/chat/completions", json=payload, timeout=timeout)
+    r.raise_for_status()
+    try:
+        return r.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        raise AIError(f"Ollama unexpected response: {r.text[:400]} ({e})")
 
 
-def chat(messages: List[Dict[str, str]], system: Optional[str] = None,
-         model: Optional[str] = None, settings=None) -> str:
-    """Send a chat completion request with automatic backend fallback."""
-    settings = settings or django_settings
-    full_messages = []
-    if system:
-        full_messages.append({"role": "system", "content": system})
-    full_messages.extend(messages)
+def _openrouter_chat(messages, system=None, model=None, temperature=0.2, timeout=None, api_key=None):
+    api_key = api_key or _get("OPENROUTER_API_KEY", "")
+    if not api_key:
+        # no key -> skip gracefully
+        raise AIError("OpenRouter API key missing")
 
-    preferred = settings.AI_BACKEND.upper()
-    order = [preferred, "OPENROUTER" if preferred == "OLLAMA" else "OLLAMA"]
+    or_model = model or _get("OPENROUTER_MODEL", "qwen/qwen3.5:free")
+    timeout = timeout or int(_get("AI_HTTP_TIMEOUT", "20"))
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "HTTP-Referer": "https://iqac.local",
+        "X-Title": "IQAC-Suite",
+    }
+    payload = {
+        "model": or_model,
+        "messages": ([{"role": "system", "content": system}] if system else []) + messages,
+        "temperature": temperature,
+    }
+    r = requests.post("https://openrouter.ai/api/v1/chat/completions", json=payload, headers=headers, timeout=timeout)
+    r.raise_for_status()
+    try:
+        return r.json()["choices"][0]["message"]["content"]
+    except Exception as e:
+        raise AIError(f"OpenRouter unexpected response: {r.text[:400]} ({e})")
 
-    errors = []
-    for backend in order:
+
+def chat(messages, system=None, model=None, temperature=0.2, timeout=None):
+    """
+    Main entry point:
+    - Honors AI_BACKEND (default OLLAMA)
+    - Uses OpenRouter only if AI_BACKEND='OPENROUTER' OR OPENROUTER_API_KEY is present
+    - Provides clear failure reasons
+    """
+    backend = _get("AI_BACKEND", "OLLAMA").upper()
+    ollama_base = _get("OLLAMA_BASE", "http://127.0.0.1:11434")
+    or_key = _get("OPENROUTER_API_KEY", "")
+
+    order = []
+    if backend == "OPENROUTER":
+        order = ["OPENROUTER", "OLLAMA"]
+    elif backend == "OLLAMA":
+        # Only add OpenRouter as soft fallback if a key exists
+        order = ["OLLAMA"] + (["OPENROUTER"] if or_key else [])
+    else:
+        # unknown backend -> try safest path
+        order = ["OLLAMA"] + (["OPENROUTER"] if or_key else [])
+
+    last_err = None
+    for b in order:
         try:
-            if backend == "OLLAMA":
-                base = getattr(settings, "OLLAMA_BASE", None)
-                if not base:
-                    raise AIError("Ollama base URL not configured")
-                if not _ollama_available(base):
-                    raise AIError("Ollama backend unreachable")
-                model_name = model or getattr(settings, "OLLAMA_GEN_MODEL", None)
-                if not model_name:
-                    raise AIError("Ollama model not configured")
-                body = {
-                    "model": model_name,
-                    "messages": full_messages,
-                    "temperature": 0.2,
-                }
-                return _post_chat(f"{base}/v1/chat/completions",
-                                  {"Content-Type": "application/json"},
-                                  body, settings.AI_HTTP_TIMEOUT)
-            else:  # OPENROUTER
-                api_key = getattr(settings, "OPENROUTER_API_KEY", None)
-                if not api_key:
-                    raise AIError("OpenRouter API key missing")
-                model_name = getattr(settings, "OPENROUTER_MODEL", None)
-                if not model_name:
-                    raise AIError("OpenRouter model not configured")
-                headers = {
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                }
-                body = {
-                    "model": model_name,
-                    "messages": full_messages,
-                    "temperature": 0.2,
-                }
-                return _post_chat("https://openrouter.ai/api/v1/chat/completions",
-                                  headers, body, settings.AI_HTTP_TIMEOUT)
-        except Exception as exc:
-            logger.warning("%s backend failed: %s", backend, exc)
-            errors.append(f"{backend}: {exc}")
+            if b == "OLLAMA":
+                if not _ollama_available(ollama_base, timeout=2):
+                    raise AIError(f"Ollama not reachable at {ollama_base}")
+                return _ollama_chat(messages, system=system, model=model, temperature=temperature, timeout=timeout, base=ollama_base)
+
+            if b == "OPENROUTER":
+                return _openrouter_chat(messages, system=system, model=model, temperature=temperature, timeout=timeout, api_key=or_key)
+
+        except Exception as e:
+            last_err = e
             continue
-    raise AIError("All AI backends failed: " + "; ".join(errors))
+
+    raise AIError(f"All AI backends failed: {last_err}")
+


### PR DESCRIPTION
## Summary
- load `.env` with unified helper and define AI settings with safe defaults
- add robust `suite.ai_client` with Ollama default and OpenRouter fallback
- update generator views to use new client with clear error handling
- adjust tests to mock new client

## Testing
- `python manage.py test`
- `python manage.py shell -c "from django.conf import settings;print(settings.AI_BACKEND);print(settings.OLLAMA_BASE);print(settings.OLLAMA_MODEL);print(settings.AI_HTTP_TIMEOUT)"`
- `python manage.py shell -c "from suite.ai_client import chat;print(chat([{'role':'user','content':'Reply with OK only.'}], system='Be brief.'))"` *(fails: All AI backends failed: Ollama not reachable at http://127.0.0.1:11434)*

------
https://chatgpt.com/codex/tasks/task_e_689ed587202c832cbbaade6f0630ddc0