### PR TITLE
Use DATABASE_URL for DB config and guard social logins

### DIFF
--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -137,11 +137,16 @@ WSGI_APPLICATION = 'iqac_project.wsgi.application'
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-DATABASES = {
-    'default': dj_database_url.config(
-        default=os.getenv('DATABASE_URL', 'sqlite:///db.sqlite3')
-    )
-}
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+if DATABASE_URL:
+    DATABASES = {"default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600)}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -153,7 +158,7 @@ AUTHENTICATION_BACKENDS = [
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
 
-SITE_ID = 1 # Must match ID in django_site table
+SITE_ID = int(os.getenv("SITE_ID", "2"))
 
 
 LOGIN_URL = '/accounts/login/'

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,5 +1,5 @@
 {% load static %}
-{% load socialaccount %}
+{% load socialaccount %}{% get_providers as socialaccount_providers %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -44,10 +44,13 @@
         Only use <strong>Christ Credentials</strong> to access this app
       </p>
 
-      <a href="{% provider_login_url 'google' method='oauth2' process='login' %}" class="google-login-btn">
-        <img src="https://developers.google.com/identity/images/g-logo.png" width="18" height="18" />
-        Continue With Google
-      </a>
+      {% if socialaccount_providers %}
+        {% providers_media_js %}
+        <a href="{% provider_login_url 'google' method='oauth2' process='login' %}" class="google-login-btn">
+          <img src="https://developers.google.com/identity/images/g-logo.png" width="18" height="18" />
+          Continue With Google
+        </a>
+      {% endif %}
 
       <div class="info-panel">
         <ul class="info-list">


### PR DESCRIPTION
## Summary
- Support DATABASE_URL with dj-database-url and fall back to sqlite
- Read SITE_ID from environment for flexible deployments
- Avoid login template crash when no social providers configured

## Testing
- `python manage.py test`
- `curl -I http://127.0.0.1:8000/accounts/login/`
- `DATABASE_URL='postgres://user:pass@localhost:5432/testdb' python manage.py shell <<'PY'
from django.conf import settings
print(settings.DATABASES["default"])
PY`

------
https://chatgpt.com/codex/tasks/task_e_689edb607950832c93422655ba809970