### PR TITLE
Improve local AI timeout handling

### DIFF
--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -33,11 +33,11 @@ def _env(key: str, default=None, cast=None):
 AI_BACKEND       = _env("AI_BACKEND", default="OLLAMA")  # OLLAMA | OPENROUTER
 OLLAMA_BASE      = _env("OLLAMA_BASE", default="http://127.0.0.1:11434")
 OLLAMA_MODEL     = _env("OLLAMA_MODEL", default="llama3")  # guarantees a default
-AI_HTTP_TIMEOUT  = _env("AI_HTTP_TIMEOUT", default="20")
+AI_HTTP_TIMEOUT  = _env("AI_HTTP_TIMEOUT", default="120")
 try:
     AI_HTTP_TIMEOUT = int(AI_HTTP_TIMEOUT)
 except Exception:
-    AI_HTTP_TIMEOUT = 20
+    AI_HTTP_TIMEOUT = 120
 
 # Optional: generator/critic models if used elsewhere in code
 OLLAMA_GEN_MODEL    = _env("OLLAMA_GEN_MODEL", default=OLLAMA_MODEL)


### PR DESCRIPTION
## Summary
- raise default AI_HTTP_TIMEOUT to 120s
- use separate connect/read timeouts and explicit messages in AI clients
- add regression test for timeout errors

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689ee43aca34832c98761ab22b4fe0ff