### PR TITLE
Add ok flag to AI generation endpoints

### DIFF
--- a/emt/tests/test_ai_generation.py
+++ b/emt/tests/test_ai_generation.py
@@ -21,6 +21,7 @@ class AIGenerationTests(TestCase):
         })
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
+        self.assertTrue(data['ok'])
         self.assertEqual(data['text'], 'need text')
 
     @patch('emt.views.chat')
@@ -32,6 +33,7 @@ class AIGenerationTests(TestCase):
         })
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
+        self.assertTrue(data['ok'])
         self.assertEqual(data['text'], 'obj text')
 
     @patch('emt.views.chat')
@@ -43,6 +45,7 @@ class AIGenerationTests(TestCase):
         })
         self.assertEqual(resp.status_code, 503)
         data = resp.json()
+        self.assertFalse(data['ok'])
         self.assertIn('Ollama request failed', data['error'])
 
     @patch('emt.views.requests.post')
@@ -70,4 +73,5 @@ class AIGenerationTests(TestCase):
         })
         self.assertEqual(resp.status_code, 503)
         data = resp.json()
+        self.assertFalse(data['ok'])
         self.assertIn('timed out', data['error'])

--- a/emt/views.py
+++ b/emt/views.py
@@ -1770,7 +1770,7 @@ OUT_PROMPT = "List 3-5 expected learning outcomes for participants as bullet poi
 def generate_need_analysis(request):
     ctx = _basic_info_context(request.POST)
     if not ctx:
-        return JsonResponse({"error": "No context"}, status=400)
+        return JsonResponse({"ok": False, "error": "No context"}, status=400)
     try:
         messages = [{"role": "user", "content": f"{NEED_PROMPT}\n\n{ctx}"}]
         timeout = getattr(settings, "AI_HTTP_TIMEOUT", 60)
@@ -1779,10 +1779,10 @@ def generate_need_analysis(request):
             system="You write crisp academic content for university event proposals.",
             timeout=timeout,
         )
-        return JsonResponse({"text": text})
+        return JsonResponse({"ok": True, "text": text})
     except AIError as exc:
         logger.error("Need analysis generation failed: %s", exc)
-        return JsonResponse({"error": str(exc)}, status=503)
+        return JsonResponse({"ok": False, "error": str(exc)}, status=503)
     except Exception as exc:
         logger.error("Need analysis generation unexpected error: %s", exc)
         return JsonResponse({"error": f"Unexpected error: {exc}"}, status=500)
@@ -1793,7 +1793,7 @@ def generate_need_analysis(request):
 def generate_objectives(request):
     ctx = _basic_info_context(request.POST)
     if not ctx:
-        return JsonResponse({"error": "No context"}, status=400)
+        return JsonResponse({"ok": False, "error": "No context"}, status=400)
     try:
         messages = [{"role": "user", "content": f"{OBJ_PROMPT}\n\n{ctx}"}]
         timeout = getattr(settings, "AI_HTTP_TIMEOUT", 60)
@@ -1802,13 +1802,13 @@ def generate_objectives(request):
             system="You write measurable, outcome-focused objectives aligned to higher-education events.",
             timeout=timeout,
         )
-        return JsonResponse({"text": text})
+        return JsonResponse({"ok": True, "text": text})
     except AIError as exc:
         logger.error("Objectives generation failed: %s", exc)
-        return JsonResponse({"error": str(exc)}, status=503)
+        return JsonResponse({"ok": False, "error": str(exc)}, status=503)
     except Exception as exc:
         logger.error("Objectives generation unexpected error: %s", exc)
-        return JsonResponse({"error": f"Unexpected error: {exc}"}, status=500)
+        return JsonResponse({"ok": False, "error": f"Unexpected error: {exc}"}, status=500)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- ensure generate_need_analysis and generate_objectives return an `ok` status flag
- update tests to cover new response structure

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ee8c35254832c83d21afdad265ed7