### PR TITLE
Show all users in admin history log

### DIFF
--- a/core/tests/test_admin_history.py
+++ b/core/tests/test_admin_history.py
@@ -31,10 +31,18 @@ class AdminHistoryFilterTests(TestCase):
         self.assertNotContains(resp, 'alice')
 
     def test_shows_activity_for_all_users(self):
-        """Ensure history lists actions performed by all users, not only admins."""
+        """The admin page should expose actions for every user on the system."""
+
+        # Add an explicit log entry for the admin to prove we don't filter on
+        # the logged-in user.
+        ActivityLog.objects.create(user=self.admin, action='reset', description='admin-only')
+
         url = reverse('admin_history')
         resp = self.client.get(url)
-        # Both users' actions should be visible in the table
+
+        # Admin, alice and bob should all appear in the table.
+        self.assertContains(resp, 'admin')
+        self.assertContains(resp, 'reset')
         self.assertContains(resp, 'alice')
         self.assertContains(resp, 'login')
         self.assertContains(resp, 'bob')

--- a/core/views.py
+++ b/core/views.py
@@ -2131,11 +2131,17 @@ def admin_reports_view(request):
 @login_required
 @admin_required
 def admin_history(request):
-    """List activity log entries for administrators with search and filtering."""
+    """List activity log entries for administrators.
 
-    # Fetch activity from all users so administrators can audit
-    # actions across the entire system, not just their own.
-    logs = ActivityLog.objects.select_related("user").all()
+    The history table is intended as an audit log for the whole site, so it
+    must display actions performed by **all** users rather than only the
+    requesting administrator. We therefore start with a queryset containing
+    every :class:`ActivityLog` record and then apply any filtering based on
+    the request parameters.
+    """
+
+    # Begin with activity from every user.
+    logs = ActivityLog.objects.select_related("user")
 
     # Text search across user name, username, action and description
     query = request.GET.get("q", "").strip()


### PR DESCRIPTION
## Summary
- Ensure admin history view lists actions from every user
- Add regression test covering multi-user activity display

## Testing
- `python manage.py test core.tests.test_admin_history -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689eeb0e0520832ca1869b70332e2c89