### PR TITLE
Secure AI generation endpoints and expand tests

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1859,7 +1859,7 @@ function getWhyThisEventForm() {
                         body: fd
                     });
                     const data = await resp.json();
-                    if (resp.ok && data.ok) {
+                    if (data.ok) {
                         textarea.val(data.text);
                         textarea.trigger('input');
                     } else {


### PR DESCRIPTION
## Summary
- require authenticated POST requests for AI generation views and standardize success/error payloads
- centralize expected-outcomes AI calls through the shared `ai_client.chat` helper
- update proposal dashboard to trust the `ok` flag and extend tests for error handling and access control

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689eedeaefe0832cae1891424e3fd1f1