### PR TITLE
Log state-changing requests in activity history

### DIFF
--- a/core/tests/test_activity_log_middleware.py
+++ b/core/tests/test_activity_log_middleware.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+
+from core.middleware import ActivityLogMiddleware
+from core.models import ActivityLog
+
+
+class ActivityLogMiddlewareTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user('alice', 'alice@example.com', 'pass')
+        self.middleware = ActivityLogMiddleware(lambda request: HttpResponse("ok"))
+
+    def test_creates_log_for_post_request(self):
+        request = self.factory.post('/some/path', {})
+        request.user = self.user
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        log = ActivityLog.objects.get()
+        self.assertEqual(log.user, self.user)
+        self.assertEqual(log.action, 'POST /some/path')
+        self.assertEqual(log.ip_address, '127.0.0.1')
+
+    def test_skips_get_requests(self):
+        request = self.factory.get('/some/path')
+        request.user = self.user
+        request.META['REMOTE_ADDR'] = '127.0.0.1'
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(ActivityLog.objects.exists())

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -99,6 +99,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'core.middleware.ImpersonationMiddleware',
     'allauth.account.middleware.AccountMiddleware',  # ← allauth middleware
+    'core.middleware.ActivityLogMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
## Summary
- add ActivityLogMiddleware to capture non-GET requests for audit trail
- enable middleware in settings so admin history shows all actions
- cover middleware with tests

## Testing
- `python manage.py test core.tests.test_activity_log_middleware core.tests.test_admin_history -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689eee91b8b4832ca72e504b8faf9d64