### PR TITLE
fix: enlarge notification bell icon

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -175,8 +175,8 @@ body.command-center-layout {
 
 .notification-badge {
   position: absolute;
-  top: -0.25rem;
-  right: -0.25rem;
+  top: -0.4rem;
+  right: -0.4rem;
   background: #ef4444;
   color: var(--white);
   font-size: 0.75rem;
@@ -198,9 +198,9 @@ body.command-center-layout {
   justify-content: center;
   background: transparent;
   padding: 0;
-  border-radius: 0;
-  width: auto;
-  height: auto;
+  border-radius: var(--border-radius);
+  width: 32px;
+  height: 32px;
 }
 
 .notification-btn:hover {
@@ -208,7 +208,7 @@ body.command-center-layout {
 }
 
 .notification-btn i {
-  font-size: 1.5rem;
+  font-size: 1.75rem;
 }
 
 .notification-dropdown {

--- a/static/core/css/command-center.css
+++ b/static/core/css/command-center.css
@@ -468,9 +468,9 @@
     color: var(--gray-700) !important;
     transition: color 0.2s ease !important;
     padding: 0 !important;
-    border-radius: 0 !important;
-    width: auto !important;
-    height: auto !important;
+    border-radius: var(--border-radius) !important;
+    width: 32px !important;
+    height: 32px !important;
   }
 
   .notification-btn:hover {
@@ -478,13 +478,13 @@
   }
 
   .notification-btn i {
-    font-size: 1.5rem !important;
+    font-size: 1.75rem !important;
   }
 
   .notification-badge {
     position: absolute !important;
-    top: -0.25rem !important;
-    right: -0.25rem !important;
+    top: -0.4rem !important;
+    right: -0.4rem !important;
     background: #ef4444 !important;
     color: var(--white) !important;
     font-size: 0.75rem !important;

--- a/static/core/css/user_dashboard.css
+++ b/static/core/css/user_dashboard.css
@@ -78,14 +78,18 @@ body {
 .notification-btn {
     position: relative;
     cursor: pointer;
-    font-size: 1.5rem;
+    font-size: 1.75rem;
     color: var(--text-secondary);
+    width: 42px;
+    height: 42px;
+    display: grid;
+    place-items: center;
 }
 
 .notification-badge {
     position: absolute;
-    top: -5px;
-    right: -8px;
+    top: -6px;
+    right: -6px;
     background-color: #e74c3c;
     color: white;
     border-radius: 50%;


### PR DESCRIPTION
## Summary
- enlarge notification bell icon to match profile avatar
- reposition notification badge so it no longer covers the icon
- ensure consistent sizing across dashboards

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ef223d5f8832ca2856582ea9770d7