### PR TITLE
style: align notification bell with theme colors

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -209,6 +209,7 @@ body.command-center-layout {
 
 .notification-btn i {
   font-size: 1.75rem;
+  color: var(--gold-accent);
 }
 
 .notification-dropdown {

--- a/static/core/css/user_dashboard.css
+++ b/static/core/css/user_dashboard.css
@@ -79,7 +79,7 @@ body {
     position: relative;
     cursor: pointer;
     font-size: 1.75rem;
-    color: var(--text-secondary);
+    color: var(--primary-color);
     width: 42px;
     height: 42px;
     display: grid;


### PR DESCRIPTION
## Summary
- style notification bell icon using theme accent in command center layout
- match user dashboard bell icon to primary theme color

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689ef474ff8c832ca77d9b9af263200c