### PR TITLE
Improve robustness of AI JSON parsing for event generation

### DIFF
--- a/emt/tests/test_ai_generation.py
+++ b/emt/tests/test_ai_generation.py
@@ -106,6 +106,30 @@ class AIGenerationTests(TestCase):
         self.assertEqual(data['learning_outcomes'], ['l1'])
 
     @patch('suite.views.chat')
+    def test_generate_why_event_fenced_json(self, mock_chat):
+        mock_chat.return_value = (
+            "Here you go:\n```json\n"
+            '{"need_analysis": "need", "objectives": ["o1"], "learning_outcomes": ["l1"]}\n'
+            "```\nThanks"
+        )
+        resp = self.client.post(reverse('emt:generate_why_event'), {'title': 'T'})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['need_analysis'], 'need')
+        self.assertEqual(data['objectives'], ['o1'])
+        self.assertEqual(data['learning_outcomes'], ['l1'])
+
+    @patch('suite.views.chat')
+    def test_generate_why_event_empty_response(self, mock_chat):
+        mock_chat.return_value = ""
+        resp = self.client.post(reverse('emt:generate_why_event'), {'title': 'T'})
+        self.assertEqual(resp.status_code, 500)
+        data = resp.json()
+        self.assertFalse(data['ok'])
+        self.assertIn('Empty model response', data['error'])
+
+    @patch('suite.views.chat')
     def test_generate_why_event_error(self, mock_chat):
         mock_chat.side_effect = ai_client.AIError('down')
         resp = self.client.post(reverse('emt:generate_why_event'), {


### PR DESCRIPTION
## Summary
- make `parse_model_json` resilient to markdown fences, pre/post text, and empty responses
- cover fenced JSON and empty replies in Why Event generation tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689efc9ce638832c88840710f91422aa