### PR TITLE
Handle missing event description in user events data API

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2636,10 +2636,11 @@ def api_user_events_data(request):
     
     events_data = []
     for event in events.order_by('-created_at')[:10]:  # Latest 10 events
+        desc = getattr(event, 'description', '') or ''
         events_data.append({
             'id': event.id,
             'title': event.event_title,
-            'description': event.description[:100] + '...' if len(event.description) > 100 else event.description,
+            'description': desc[:100] + '...' if len(desc) > 100 else desc,
             'status': event.status,
             'created_at': event.created_at.strftime('%Y-%m-%d %H:%M'),
             'organization': event.organization.name if event.organization else 'N/A'


### PR DESCRIPTION
## Summary
- Avoid AttributeError when events lack a `description`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f1ab99b38832cab00a5adccc5c9c8