### PR TITLE
Improve AI suggestion display

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2542,7 +2542,10 @@ async function generateWhyEvent(){
     const body = new URLSearchParams(Object.entries(facts));
     const res = await fetch('/suite/generate-why-event/', {
       method:'POST',
-      headers:{'X-CSRFToken':getCookie('csrftoken')},
+      headers:{
+        'X-CSRFToken':getCookie('csrftoken'),
+        'Content-Type':'application/x-www-form-urlencoded'
+      },
       body
     });
     const data = await res.json();
@@ -2562,8 +2565,16 @@ function showCard(field, content){
   const card = document.querySelector(`#ai-${field}`);
   if (!card) return;
   if (Array.isArray(content)){
+    if (!content.length){
+      card.innerHTML = '';
+      return;
+    }
     card.innerHTML = '<ul>' + content.map(i=>`<li>${i}</li>`).join('') + '</ul>';
   } else {
+    if (!content){
+      card.textContent = '';
+      return;
+    }
     card.textContent = content;
   }
 }


### PR DESCRIPTION
## Summary
- ensure AI suggestion fetch posts form data with explicit content type
- hide AI suggestion cards when no content is returned to avoid blank UI

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f26089c4c832ca200a6bd5428abbf