### PR TITLE
Handle trailing commas in AI JSON

### DIFF
--- a/emt/tests/test_ai_generation.py
+++ b/emt/tests/test_ai_generation.py
@@ -121,6 +121,20 @@ class AIGenerationTests(TestCase):
         self.assertEqual(data['learning_outcomes'], ['l1'])
 
     @patch('suite.views.chat')
+    def test_generate_why_event_trailing_commas(self, mock_chat):
+        mock_chat.return_value = (
+            '{"need_analysis": "need", "objectives": ["o1",], '
+            '"learning_outcomes": ["l1"],}'
+        )
+        resp = self.client.post(reverse('emt:generate_why_event'), {'title': 'T'})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['need_analysis'], 'need')
+        self.assertEqual(data['objectives'], ['o1'])
+        self.assertEqual(data['learning_outcomes'], ['l1'])
+
+    @patch('suite.views.chat')
     def test_generate_why_event_empty_response(self, mock_chat):
         mock_chat.return_value = ""
         resp = self.client.post(reverse('emt:generate_why_event'), {'title': 'T'})

--- a/suite/ai_safety.py
+++ b/suite/ai_safety.py
@@ -1,4 +1,6 @@
-import re, json
+import re, json, logging
+
+logger = logging.getLogger(__name__)
 
 BAD_PHRASES = [
     r"\baccording to\b",
@@ -54,4 +56,8 @@ def parse_model_json(s: str) -> dict:
     if not match:
         raise ValueError("No JSON object found in model response")
 
-    return json.loads(match.group(0))
+    json_str = match.group(0)
+    cleaned = re.sub(r",\s*(?=[}\]])", "", json_str)
+    if cleaned != json_str:
+        logger.debug("Removed trailing commas from model JSON")
+    return json.loads(cleaned)


### PR DESCRIPTION
## Summary
- Prevent JSON parse errors by stripping trailing commas before parsing AI output
- Log a debug message when cleanup occurs
- Add regression test ensuring AI-generated JSON with stray commas is accepted

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f2a87e574832ca99c7ba78eba1b3f