### PR TITLE
Gracefully handle proposal autosave errors

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -75,15 +75,14 @@ window.AutosaveManager = (function() {
             body: JSON.stringify(formData)
         })
         .then(async res => {
-            if (!res.ok) {
-                console.warn('autosave failed', res.status);
-                return Promise.reject(res.status);
-            }
             let data = null;
             try {
                 data = await res.json();
             } catch (e) {
                 // ignore JSON parse errors
+            }
+            if (!res.ok) {
+                return Promise.reject(data || res.status);
             }
             return data;
         })
@@ -94,11 +93,9 @@ window.AutosaveManager = (function() {
                 document.dispatchEvent(new Event('autosave:success'));
                 return data;
             }
-            document.dispatchEvent(new CustomEvent('autosave:error', {detail: data}));
             return Promise.reject(data);
         })
         .catch(err => {
-            console.warn('autosave exception', err);
             document.dispatchEvent(new CustomEvent('autosave:error', {detail: err}));
             return Promise.reject(err);
         });

--- a/emt/views.py
+++ b/emt/views.py
@@ -374,7 +374,7 @@ def autosave_proposal(request):
         
         # Don't autosave if proposal is already submitted
         if proposal and proposal.status != "draft":
-            return JsonResponse({"success": False, "error": "Cannot modify submitted proposal"}, status=400)
+            return JsonResponse({"success": False, "error": "Cannot modify submitted proposal"})
 
     form = EventProposalForm(data, instance=proposal, user=request.user)
     faculty_ids = data.get("faculty_incharges") or []
@@ -389,7 +389,7 @@ def autosave_proposal(request):
 
     if not form.is_valid():
         logger.debug("autosave_proposal form errors: %s", form.errors)
-        return JsonResponse({"success": False, "errors": form.errors}, status=400)
+        return JsonResponse({"success": False, "errors": form.errors})
 
     proposal = form.save(commit=False)
     proposal.submitted_by = request.user
@@ -496,7 +496,7 @@ def autosave_proposal(request):
 
     if errors:
         logger.debug("autosave_proposal dynamic errors: %s", errors)
-        return JsonResponse({"success": False, "errors": errors}, status=400)
+        return JsonResponse({"success": False, "errors": errors})
 
     _save_activities(proposal, data)
     _save_speakers(proposal, data, request.FILES)


### PR DESCRIPTION
## Summary
- Avoid 400 responses when autosaving proposals by returning success flags with HTTP 200
- Simplify autosave script to handle server errors without noisy console warnings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f5b323a88832cb9bd1c1c20a3e746