### PR TITLE
Handle invalid JSON in autosave

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -176,15 +176,30 @@ window.AutosaveManager = (function() {
 // Simple autosave helper used by AI generation
 async function autosave() {
     try {
+        const form = document.querySelector('form');
+        const formData = new FormData(form);
+        const payload = {};
+        formData.forEach((value, key) => {
+            if (payload[key] !== undefined) {
+                if (!Array.isArray(payload[key])) {
+                    payload[key] = [payload[key]];
+                }
+                payload[key].push(value);
+            } else {
+                payload[key] = value;
+            }
+        });
         const res = await fetch('/suite/autosave-proposal/', {
             method: 'POST',
-            body: new FormData(document.querySelector('form'))
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': window.AUTOSAVE_CSRF,
+            },
+            body: JSON.stringify(payload),
         });
         if (!res.ok) {
             console.warn('autosave failed', res.status);
-            return;
         }
-        // const data = await res.json(); // optional
     } catch (e) {
         console.warn('autosave exception', e);
     }

--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -259,6 +259,15 @@ class AutosaveProposalTests(TestCase):
         self.assertEqual(ids_after, {self.f1.id, self.f2.id})
         self.assertEqual(proposal.status, EventProposal.Status.SUBMITTED)
 
+    def test_autosave_proposal_invalid_json(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data="not json",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Invalid JSON", resp.json().get("error", ""))
+
 
 class EventProposalOrganizationPrefillTests(TestCase):
     def setUp(self):

--- a/emt/views.py
+++ b/emt/views.py
@@ -353,7 +353,13 @@ def autosave_proposal(request):
     if request.method != "POST":
         return JsonResponse({"error": "Invalid request"}, status=400)
 
-    data = json.loads(request.body.decode("utf-8"))
+    try:
+        raw = request.body.decode("utf-8")
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        logger.debug("autosave_proposal invalid json: %s", raw)
+        return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
+
     logger.debug("autosave_proposal payload: %s", data)
 
     # Replace department logic with generic organization


### PR DESCRIPTION
## Summary
- prevent autosave endpoint from crashing on missing or malformed JSON
- send proposal autosave requests as JSON with CSRF header
- cover invalid JSON case in autosave tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f5ea8f508832cb3f02bb64623727d