### PR TITLE
Add academic year dropdowns on bulk upload forms

### DIFF
--- a/core/templates/core_admin_org_users/user_management.html
+++ b/core/templates/core_admin_org_users/user_management.html
@@ -57,8 +57,13 @@
                 <input type="text" id="students-class-name" name="class_name" placeholder="BSc-A" required>
               </div>
               <div class="form-group">
-                <label for="students-academic-year">Academic Year</label>
-                <input type="text" id="students-academic-year" name="academic_year" placeholder="2025-2026" required>
+                <label for="students-start-year">Academic Year</label>
+                <div class="year-selects">
+                  <select id="students-start-year" required></select>
+                  <span class="year-separator">-</span>
+                  <select id="students-end-year" required></select>
+                </div>
+                <input type="hidden" id="students-academic-year" name="academic_year" required>
               </div>
             </div>
             
@@ -118,8 +123,13 @@
             
             <div class="form-row">
               <div class="form-group">
-                <label for="faculty-academic-year">Academic Year</label>
-                <input type="text" id="faculty-academic-year" name="academic_year" placeholder="2025-2026" required>
+                <label for="faculty-start-year">Academic Year</label>
+                <div class="year-selects">
+                  <select id="faculty-start-year" required></select>
+                  <span class="year-separator">-</span>
+                  <select id="faculty-end-year" required></select>
+                </div>
+                <input type="hidden" id="faculty-academic-year" name="academic_year" required>
               </div>
             </div>
             

--- a/static/core/css/admin_user_management.css
+++ b/static/core/css/admin_user_management.css
@@ -252,6 +252,23 @@
     box-shadow: 0 0 0 2px var(--primary-light);
 }
 
+/* Academic year selectors */
+.year-selects {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.year-selects select {
+    flex: 1;
+    width: auto;
+}
+
+.year-separator {
+    padding: 0 0.25rem;
+    font-weight: 600;
+}
+
 .upload-btn {
     width: 100%;
     background: var(--primary-color);

--- a/static/core/js/admin_user_management.js
+++ b/static/core/js/admin_user_management.js
@@ -24,7 +24,11 @@ function initializeUserManagement() {
     
     // Initialize tab functionality
     initializeTabs();
-    
+
+    // Setup academic year dropdowns
+    setupAcademicYearSelectors('students');
+    setupAcademicYearSelectors('faculty');
+
     // Initialize upload forms
     initializeUploadForms();
     
@@ -145,6 +149,38 @@ function updateResultsContent(tabName, content) {
 }
 
 // =============================================================================
+// ACADEMIC YEAR SELECTORS
+// =============================================================================
+
+function setupAcademicYearSelectors(prefix) {
+    const startSelect = document.getElementById(`${prefix}-start-year`);
+    const endSelect = document.getElementById(`${prefix}-end-year`);
+    const hiddenInput = document.getElementById(`${prefix}-academic-year`);
+    if (!startSelect || !endSelect || !hiddenInput) return;
+
+    const currentYear = new Date().getFullYear();
+
+    for (let y = currentYear - 5; y <= currentYear + 5; y++) {
+        startSelect.add(new Option(y, y));
+    }
+
+    for (let y = currentYear - 4; y <= currentYear + 6; y++) {
+        endSelect.add(new Option(y, y));
+    }
+
+    startSelect.value = currentYear;
+    endSelect.value = currentYear + 1;
+
+    function sync() {
+        hiddenInput.value = `${startSelect.value}-${endSelect.value}`;
+    }
+
+    startSelect.addEventListener('change', sync);
+    endSelect.addEventListener('change', sync);
+    sync();
+}
+
+// =============================================================================
 // UPLOAD FORMS
 // =============================================================================
 
@@ -169,6 +205,14 @@ function initializeUploadForms() {
 }
 
 function handleFormSubmit(form, type) {
+    // Ensure academic year is combined from dropdowns
+    const startYear = form.querySelector(`#${type}-start-year`);
+    const endYear = form.querySelector(`#${type}-end-year`);
+    const academicYear = form.querySelector(`#${type}-academic-year`);
+    if (startYear && endYear && academicYear) {
+        academicYear.value = `${startYear.value}-${endYear.value}`;
+    }
+
     const formData = new FormData(form);
     const submitBtn = form.querySelector('.upload-btn');
     const originalText = submitBtn.innerHTML;


### PR DESCRIPTION
## Summary
- Replace text inputs with start and end year dropdowns for academic year selection on student and faculty bulk upload forms
- Populate year options, sync hidden academic year field, and style the new selectors

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f67748700832c9da9b46cd7a057be