### PR TITLE
Allow autosaving income without participant or rate details

### DIFF
--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -268,6 +268,22 @@ class AutosaveProposalTests(TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn("Invalid JSON", resp.json().get("error", ""))
 
+    def test_autosave_income_optional_fields(self):
+        payload = self._payload()
+        payload.update({
+            "income_particulars_0": "Registration Fees",
+            "income_amount_0": "5000",
+        })
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data.get("success"))
+        self.assertNotIn("errors", data)
+
 
 class EventProposalOrganizationPrefillTests(TestCase):
     def setUp(self):

--- a/emt/views.py
+++ b/emt/views.py
@@ -485,13 +485,10 @@ def autosave_proposal(request):
         rate = data.get(f"income_rate_{in_idx}")
         amount = data.get(f"income_amount_{in_idx}")
         missing = {}
-        if particulars or participants or rate or amount:
+        # Only require particulars and amount; participants and rate are optional
+        if any([particulars, participants, rate, amount]):
             if not particulars:
                 missing["particulars"] = "This field is required."
-            if not participants:
-                missing["participants"] = "This field is required."
-            if not rate:
-                missing["rate"] = "This field is required."
             if not amount:
                 missing["amount"] = "This field is required."
         if missing:


### PR DESCRIPTION
## Summary
- Relax income validation in `autosave_proposal` so only particulars and amount are required
- Add regression test ensuring autosave succeeds when participant count and rate are omitted

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f74290668832ca59e2a947d410b7b