### PR TITLE
fix: replace PO/PSO selections on save

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -594,13 +594,19 @@ $(document).ready(function() {
 
         $('#outcomeCancel').off('click').on('click', () => modal.removeClass('show'));
         $('#outcomeSave').off('click').on('click', () => {
-            const selected = modal.find('input[type=checkbox]:checked').map((_, cb) => cb.value).get();
-            const existing = posField.val().trim();
-            const value = existing ? existing + '\n' + selected.join('\n') : selected.join('\n');
+            const selected = modal
+                .find('input[type=checkbox]:checked')
+                .map((_, cb) => cb.value)
+                .get();
+
+            // Replace existing content with newly selected outcomes
+            const value = selected.join('\n');
             posField.val(value).trigger('input').trigger('change');
+
             if (djangoPosField.length) {
                 djangoPosField.val(value).trigger('input').trigger('change');
             }
+
             modal.removeClass('show');
         });
     }


### PR DESCRIPTION
## Summary
- ensure Submit Proposal PO/PSO field overwrites previous selections instead of appending

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f76e583a8832cbdb45c3d8abc6c95