### PR TITLE
feat: make income section optional

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2004,10 +2004,10 @@ function getWhyThisEventForm() {
     }
 
     function updateSubmitButton() {
-        const completedSections = Object.values(sectionProgress).filter(status => status === true).length;
-        const totalSections = Object.keys(sectionProgress).length;
-        
-        if (completedSections === totalSections) {
+        const requiredSections = Object.keys(sectionProgress).filter(section => section !== 'income');
+        const completedSections = requiredSections.filter(section => sectionProgress[section] === true).length;
+
+        if (completedSections === requiredSections.length) {
             $('#submit-proposal-btn').prop('disabled', false);
             $('.submit-section').addClass('ready');
         }
@@ -2287,10 +2287,11 @@ function getWhyThisEventForm() {
 
     // ===== PROGRESS BAR FUNCTION - PRESERVED =====
     function updateProgressBar() {
-        const completedSections = Object.values(sectionProgress).filter(status => status === true).length;
-        const totalSections = Object.keys(sectionProgress).length;
+        const sections = Object.keys(sectionProgress).filter(section => section !== 'income');
+        const completedSections = sections.filter(section => sectionProgress[section] === true).length;
+        const totalSections = sections.length;
         const progressPercent = Math.round((completedSections / totalSections) * 100);
-        
+
         // Update any progress indicators in new UI
         console.log(`Progress: ${progressPercent}% (${completedSections}/${totalSections} sections complete)`);
         


### PR DESCRIPTION
## Summary
- allow proposal submission without income details
- adjust progress bar and submit logic to ignore optional income section

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f7a0a84d0832cb39bc3761e8b54f4