### PR TITLE
Enable submit proposal after navigation

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -144,8 +144,10 @@ $(document).ready(function() {
                         showNotification('Please complete all required fields in the current section first.', 'error');
                         return;
                     }
+                    // Mark current section as complete when moving to the next
+                    markSectionComplete(currentExpandedCard);
                 }
-                
+
                 $(this).removeClass('disabled');
                 activateSection(section);
             } else {


### PR DESCRIPTION
## Summary
- mark current section complete when user navigates forward in proposal dashboard

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f83a0afc8832c9ae8eb6913642000