### PR TITLE
Ensure bulk upload overwrites existing role

### DIFF
--- a/core/views_admin_org_users.py
+++ b/core/views_admin_org_users.py
@@ -332,6 +332,9 @@ def upload_csv(request, org_id):
                     mem.save(update_fields=fields_to_update)
                     memberships_updated += 1
 
+            RoleAssignment.objects.filter(
+                user=user, organization=org
+            ).exclude(role=org_role).delete()
             RoleAssignment.objects.update_or_create(
                 user=user,
                 organization=org,


### PR DESCRIPTION
## Summary
- Remove existing conflicting role assignments for a user/org before adding new ones
- Add regression test ensuring bulk upload updates role assignment instead of duplicating it

## Testing
- `python manage.py test core.tests.test_bulk_user_upload.BulkUserUploadTests.test_bulk_upload_overrides_existing_role`


------
https://chatgpt.com/codex/tasks/task_e_689f9c861848832c8c6f82145e9531e5