### PR TITLE
Prevent duplicate organization memberships on bulk upload

### DIFF
--- a/core/tests/test_bulk_user_upload.py
+++ b/core/tests/test_bulk_user_upload.py
@@ -140,6 +140,38 @@ class BulkUserUploadTests(TestCase):
         self.assertEqual(ras.count(), 1)
         self.assertEqual(ras.first().role.name, 'student')
 
+    def test_bulk_upload_moves_user_between_orgs(self):
+        """Uploading the same user to a new organization should replace old membership."""
+        self.client.force_login(self.admin)
+
+        # Initial upload to first organization
+        self._upload()
+
+        org2 = Organization.objects.create(name='Commerce', org_type=self.org.org_type)
+
+        csv_content = (
+            "register_no,name,email,role\n"
+            "001,John Doe,john@example.com,student\n"
+        )
+        file = SimpleUploadedFile('users.csv', csv_content.encode('utf-8'), content_type='text/csv')
+        url = reverse('admin_org_users_upload_csv', args=[org2.id])
+        data = {
+            'class_name': 'B',
+            'academic_year': '2024-2025',
+            'csv_file': file,
+        }
+        referer = f'http://testserver/core-admin/org-users/{org2.id}/students/'
+        self.client.post(url, data, follow=True, HTTP_REFERER=referer)
+
+        user = User.objects.get(email='john@example.com')
+        self.assertEqual(OrganizationMembership.objects.filter(user=user).count(), 1)
+        mem = OrganizationMembership.objects.get(user=user)
+        self.assertEqual(mem.organization, org2)
+        self.assertEqual(mem.role, 'student')
+        ra = RoleAssignment.objects.get(user=user)
+        self.assertEqual(ra.organization, org2)
+        self.assertEqual(ra.role.name, 'student')
+
 
 class BulkFacultyUploadTests(TestCase):
     def setUp(self):

--- a/core/views_admin_org_users.py
+++ b/core/views_admin_org_users.py
@@ -312,6 +312,18 @@ def upload_csv(request, org_id):
                     profile.register_no = reg
                     profile.save(update_fields=["register_no"])
 
+            # Prevent duplicate memberships for the same role across organizations
+            OrganizationMembership.objects.filter(
+                user=user,
+                role=org_role.name,
+                academic_year=ay,
+            ).exclude(organization=org).delete()
+            RoleAssignment.objects.filter(
+                user=user,
+                role__name=org_role.name,
+                academic_year=ay,
+            ).exclude(organization=org).delete()
+
             mem, mem_created = OrganizationMembership.objects.get_or_create(
                 user=user,
                 organization=org,


### PR DESCRIPTION
## Summary
- ensure bulk uploader replaces existing memberships with same role in other departments
- add regression test for moving a user between organizations via bulk upload

## Testing
- `python manage.py test core.tests.test_bulk_user_upload.BulkUserUploadTests.test_bulk_upload_moves_user_between_orgs -v 2`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689f9f42e660832c9e9856b5ce04dcdb