### PR TITLE
Fix activity planner autosave

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -248,6 +248,10 @@ $(document).ready(function() {
             clearValidationErrors();
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
+                const actInput = document.getElementById('num-activities-modern');
+                if (actInput && actInput.value) {
+                    actInput.dispatchEvent(new Event('input'));
+                }
             }
             if (autoFillEnabled) {
                 autofillTestData(section);

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -221,7 +221,7 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="num-activities-modern">Number of Activities</label>
-                                <input type="number" id="num-activities-modern" min="1" max="50" placeholder="Enter number of activities">
+                                <input type="number" id="num-activities-modern" name="num_activities" min="1" max="50" placeholder="Enter number of activities">
                                 <div class="help-text">How many activities will your event include?</div>
                             </div>
                             <div class="input-group">


### PR DESCRIPTION
## Summary
- ensure number of activities field persists by giving it a name
- re-render dynamic activity inputs after restoring autosaved data

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689fa0cd2704832cb57cf7c8725b8887