### PR TITLE
Move proposal submission button to CDL support step

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1622,17 +1622,6 @@ function getWhyThisEventForm() {
                         Add all income sources for your event
                     </div>
                 </div>
-
-                <div class="form-row full-width">
-                    <div class="submit-section">
-                        <button type="submit" name="final_submit" class="btn-submit" id="submit-proposal-btn" disabled>
-                            Submit Proposal
-                        </button>
-                        <div class="submit-help-text">
-                            Review all sections before submitting
-                        </div>
-                    </div>
-                </div>
             </div>
         `;
     }
@@ -2023,11 +2012,13 @@ function getWhyThisEventForm() {
     }
 
     function updateSubmitButton() {
+        const btn = $('#submit-proposal-btn');
+        if (!btn.length) return;
         const requiredSections = Object.keys(sectionProgress).filter(section => !optionalSections.includes(section));
         const completedSections = requiredSections.filter(section => sectionProgress[section] === true).length;
 
         if (completedSections === requiredSections.length) {
-            $('#submit-proposal-btn').prop('disabled', false);
+            btn.prop('disabled', false);
             $('.submit-section').addClass('ready');
         }
     }

--- a/emt/templates/emt/cdl_support.html
+++ b/emt/templates/emt/cdl_support.html
@@ -75,7 +75,7 @@
         </div>
       </div>
       <div class="input-group">
-        <button type="submit" class="btn">Submit</button>
+        <button type="submit" class="btn btn-submit" id="submit-proposal-btn">Submit Proposal</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- remove submit proposal control from income section
- add final submit proposal button to CDL support step
- guard updateSubmitButton against missing submit button

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689fa3a07794832cbe0a5104a9c253e2