### PR TITLE
Add save button and navigation fix for income section

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1622,6 +1622,13 @@ function getWhyThisEventForm() {
                         Add all income sources for your event
                     </div>
                 </div>
+
+                <div class="form-row full-width">
+                    <div class="save-section-container">
+                        <button type="button" class="btn-save-section">Save & Continue</button>
+                        <div class="save-help-text">Complete this section to unlock the next one</div>
+                    </div>
+                </div>
             </div>
         `;
     }
@@ -1765,9 +1772,15 @@ function getWhyThisEventForm() {
 
                         const nextSection = getNextSection(currentExpandedCard);
                         if (nextSection) {
-                            $(`.proposal-nav .nav-link[data-section="${nextSection}"]`).removeClass('disabled');
+                            const nextLink = $(`.proposal-nav .nav-link[data-section="${nextSection}"]`);
+                            nextLink.removeClass('disabled');
+                            const nextUrl = nextLink.data('url');
                             setTimeout(() => {
-                                openFormPanel(nextSection);
+                                if (nextUrl) {
+                                    window.location.href = nextUrl;
+                                } else {
+                                    openFormPanel(nextSection);
+                                }
                             }, 1000);
                         }
                     })


### PR DESCRIPTION
## Summary
- Add "Save & Continue" action to income section of proposal wizard
- Redirect to next section URL after saving when navigation target uses external page (e.g. CDL support)

## Testing
- `python manage.py test`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689ffc3f0b20832ca8cfb8dbdb86904c