### PR TITLE
feat: add post-event CDL workflow

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -5,7 +5,7 @@ from .models import (
     EventProposal, EventNeedAnalysis, EventObjectives,
     EventExpectedOutcomes, TentativeFlow, SpeakerProfile,
     ExpenseDetail, EventReport, EventReportAttachment, CDLSupport,
-    CDLCertificateRecipient,
+    CDLCertificateRecipient, CDLMessage,
 )
 from core.models import (
     Organization,
@@ -355,3 +355,9 @@ class CertificateRecipientForm(forms.ModelForm):
     class Meta:
         model = CDLCertificateRecipient
         fields = ["name", "role", "certificate_type"]
+
+
+class CDLMessageForm(forms.ModelForm):
+    class Meta:
+        model = CDLMessage
+        fields = ["message", "file"]

--- a/emt/templates/emt/cdl_post_event.html
+++ b/emt/templates/emt/cdl_post_event.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}CDL Post-Event{% endblock %}
+
+{% block head_extra %}
+<link rel="stylesheet" href="{% static 'emt/css/styles.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="header">
+    <h1>Post-Event CDL Processing for "{{ proposal.event_title }}"</h1>
+  </div>
+  <div class="page-content">
+    <div class="section">
+      <h2>Certificate Recipients</h2>
+      <form method="post">
+        {% csrf_token %}
+        {{ recipient_form.as_p }}
+        <button type="submit" name="add_recipient" class="btn btn-submit">Add Recipient</button>
+      </form>
+      <ul>
+        {% for r in recipients %}
+          <li>{{ r.name }} — {{ r.get_certificate_type_display }} {% if r.ai_approved %}(Approved){% else %}(Pending){% endif %}</li>
+        {% empty %}
+          <li>No recipients added.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="section">
+      <h2>CDL Communication</h2>
+      <div class="messages">
+        {% for m in messages %}
+          <div class="message"><strong>{{ m.sender.get_full_name|default:m.sender.username }}</strong>: {{ m.message }} <span class="timestamp">{{ m.created_at|date:"M d, Y H:i" }}</span>{% if m.file %} <a href="{{ m.file.url }}">File</a>{% endif %}</div>
+        {% empty %}
+          <p>No messages yet.</p>
+        {% endfor %}
+      </div>
+      <form method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ message_form.as_p }}
+        <button type="submit" name="send_message" class="btn btn-submit">Send</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/emt/templates/emt/cdl_support.html
+++ b/emt/templates/emt/cdl_support.html
@@ -44,6 +44,7 @@
               <div class="input-group">{{ form.poster_event_title.label_tag }} {{ form.poster_event_title }}</div>
               <div class="input-group">{{ form.poster_summary.label_tag }} {{ form.poster_summary }}</div>
               <div class="input-group">{{ form.poster_design_link.label_tag }} {{ form.poster_design_link }}</div>
+              <p class="help-text">If requesting both poster and certificate, provide a single design file with poster on page 1 and certificate on page 2.</p>
             </div>
           </details>
 
@@ -60,6 +61,7 @@
               <div id="certificate-help-details" style="display:none;">
                 <div class="input-group">{{ form.certificate_choice.label_tag }} {{ form.certificate_choice }}</div>
                 <div class="input-group">{{ form.certificate_design_link.label_tag }} {{ form.certificate_design_link }}</div>
+                <p class="help-text">Use the same design file as poster if both are requested (page 2 for certificate).</p>
               </div>
             </div>
           </details>

--- a/emt/templates/emt/proposal_status_detail.html
+++ b/emt/templates/emt/proposal_status_detail.html
@@ -162,6 +162,9 @@
     {% if proposal.status == 'rejected' %}
       <a href="{% url 'emt:submit_proposal_with_pk' proposal.id %}" class="edit-btn">Edit Proposal →</a>
     {% endif %}
+    {% if proposal.cdl_support and proposal.cdl_support.needs_support %}
+      <a href="{% url 'emt:cdl_post_event' proposal.id %}" class="edit-btn">CDL Post-Event →</a>
+    {% endif %}
     <a href="{% url 'dashboard' %}" class="back-btn">
       ← Back to Dashboard
     </a>

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path('speaker-profile/<int:proposal_id>/', views.submit_speaker_profile, name='submit_speaker_profile'),
     path('expense-details/<int:proposal_id>/', views.submit_expense_details, name='submit_expense_details'),
     path('cdl-support/<int:proposal_id>/', views.submit_cdl_support, name='submit_cdl_support'),
+    path('cdl/post-event/<int:proposal_id>/', views.cdl_post_event, name='cdl_post_event'),
     path('proposal-status/<int:proposal_id>/', views.proposal_status_detail, name='proposal_status_detail'),
     path('autosave-proposal/', views.autosave_proposal, name='autosave_proposal'),
     path('autosave-need-analysis/', views.autosave_need_analysis, name='autosave_need_analysis'),


### PR DESCRIPTION
## Summary
- add messaging and certificate recipient forms for post-event CDL support
- link post-event workflow from proposal status page
- document design file requirements for CDL support

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a0067242e8832cb6978389b1f64cbf