### PR TITLE
Propagate proposal id and update CDL link after autosave

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -94,8 +94,9 @@ window.AutosaveManager = (function() {
         .then(data => {
             if (data && data.success && data.proposal_id) {
                 proposalId = data.proposal_id;
+                window.PROPOSAL_ID = data.proposal_id;
                 saveLocal();
-                document.dispatchEvent(new Event('autosave:success'));
+                document.dispatchEvent(new CustomEvent('autosave:success', {detail: {proposalId: data.proposal_id}}));
                 return data;
             }
             return Promise.reject(data);

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -65,6 +65,14 @@ $(document).ready(function() {
 
     const getRandom = arr => arr[Math.floor(Math.random() * arr.length)];
 
+    function updateCdlNavLink(proposalId) {
+        if (!proposalId) return;
+        const link = $('.proposal-nav .nav-link[data-section="cdl-support"]');
+        const url = `/emt/cdl-support/${proposalId}/`;
+        link.data('url', url);
+        link.attr('data-url', url);
+    }
+
     initializeDashboard();
 
     function initializeDashboard() {
@@ -73,6 +81,9 @@ $(document).ready(function() {
         loadExistingData();
         checkForExistingErrors();
         enablePreviouslyVisitedSections();
+        if (window.PROPOSAL_ID) {
+            updateCdlNavLink(window.PROPOSAL_ID);
+        }
         $('#autofill-btn').on('click', () => autofillTestData(currentExpandedCard));
         if (!$('.form-errors-banner').length) {
             setTimeout(() => {
@@ -2544,7 +2555,12 @@ function getWhyThisEventForm() {
             indicator.find('.indicator-text').text('Saving...');
         });
 
-        $(document).on('autosave:success', function() {
+        $(document).on('autosave:success', function(e) {
+            const detail = e.originalEvent && e.originalEvent.detail;
+            if (detail && detail.proposalId) {
+                window.PROPOSAL_ID = detail.proposalId;
+                updateCdlNavLink(detail.proposalId);
+            }
             const indicator = $('#autosave-indicator');
             indicator.removeClass('saving error').addClass('saved');
             indicator.find('.indicator-text').text('Saved');


### PR DESCRIPTION
## Summary
- Dispatch `autosave:success` with proposal id and store it on the window
- Update proposal dashboard when autosave succeeds to wire the CDL Support tab
- Initialize CDL Support link when a proposal id already exists

## Testing
- `npm test` *(fails: playwright: not found)*
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a00f5c5a70832c9cbaba4ff96daa4e