### PR TITLE
Fix redirect after final event proposal submission

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -700,7 +700,7 @@ def submit_cdl_support(request, proposal_id):
             build_approval_chain(proposal)
 
             messages.success(request, "Your event proposal has been submitted for approval.")
-            return redirect("dashboard")
+            return redirect("emt:proposal_status_detail", proposal_id=proposal.id)
     else:
         initial = {}
         if instance:


### PR DESCRIPTION
## Summary
- After submitting CDL support, redirect to proposal status detail instead of the generic dashboard.

## Testing
- `python manage.py test` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0036_approvalflowtemplate_archived_at_and_more, 0036_cdlcommunicationthread_cdlmessage_cdlrequest_and_more, 0037_mark_existing_tables in core).)*

------
https://chatgpt.com/codex/tasks/task_e_68a0114f7474832c9b34a8a0bc50f3b6