### PR TITLE
feat: configure AI field contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ emt.txt
 # Allow Node package manifests
 !package.json
 !package-lock.json
+# Include AI field configuration
+!suite/field_config/*.json
 
 media/
 

--- a/suite/field_config/learning_outcomes.json
+++ b/suite/field_config/learning_outcomes.json
@@ -1,0 +1,7 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "event_focus_type"
+  ]
+}

--- a/suite/field_config/need_analysis.json
+++ b/suite/field_config/need_analysis.json
@@ -1,0 +1,10 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "event_focus_type",
+    "location",
+    "start_date",
+    "end_date"
+  ]
+}

--- a/suite/field_config/objectives.json
+++ b/suite/field_config/objectives.json
@@ -1,0 +1,7 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "event_focus_type"
+  ]
+}

--- a/suite/field_config/why_event.json
+++ b/suite/field_config/why_event.json
@@ -1,0 +1,8 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "event_focus_type",
+    "location"
+  ]
+}


### PR DESCRIPTION
## Summary
- define per-field AI context in `suite/field_config` to minimize prompt size
- load field lists via `suite.facts.load_fields` and filter `collect_basic_facts`
- wire `suite.views` generation endpoints to use field-specific contexts
- cover field filtering with a new unit test

## Testing
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d5343a60832c9408cf6123f45738