### PR TITLE
Fix template conditionals causing admin dashboard crash

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -183,17 +183,20 @@
       {% endif %}
 
       <!-- Graduate Transcript - Standalone (Superuser only) -->
-      {% if user.is_superuser and ( not allowed_nav_items or 'transcript' in allowed_nav_items ) %}
+      {% if user.is_superuser %}
+        {% if not allowed_nav_items or 'transcript' in allowed_nav_items %}
       <div class="nav-item">
         <a href="/transcript/" class="nav-link {% if request.resolver_match.namespace == 'transcript' or 'transcript' in request.resolver_match.url_name or '/transcript/' in request.path %}active{% endif %}">
           <i class="fas fa-graduation-cap nav-icon"></i>
           <span class="nav-text">Graduate Transcript</span>
         </a>
       </div>
+        {% endif %}
       {% endif %}
 
       <!-- CDL - Expandable (Faculty and Superuser) -->
-      {% if ( user.is_superuser or request.session.role == 'faculty' or user|has_group:"Faculty" ) and ( not allowed_nav_items or 'cdl' in allowed_nav_items ) %}
+      {% if user.is_superuser or request.session.role == 'faculty' or user|has_group:"Faculty" %}
+        {% if not allowed_nav_items or 'cdl' in allowed_nav_items %}
       <div class="nav-section {% if 'cdl' in request.resolver_match.url_name or '/cdl/' in request.path %}expanded{% endif %}">
         <div class="nav-section-header">
           <i class="fas fa-photo-video nav-icon"></i>
@@ -209,20 +212,24 @@
           </a>
         </div>
       </div>
+        {% endif %}
       {% endif %}
 
       <!-- POs & PSOs Management (Visible to assigned managers; non-admin) -->
-      {% if request.user.is_authenticated and not user.is_superuser and request.session.role != 'admin' and ( not allowed_nav_items or 'pso_psos' in allowed_nav_items ) %}
+      {% if request.user.is_authenticated and not user.is_superuser and request.session.role != 'admin' %}
+        {% if not allowed_nav_items or 'pso_psos' in allowed_nav_items %}
       <div class="nav-item" id="popso-manager-nav" style="display:none;">
         <a href="{% url 'settings_pso_po_management' %}" class="nav-link {% if request.resolver_match.url_name == 'settings_pso_po_management' %}active{% endif %}">
           <i class="fas fa-clipboard-list nav-icon"></i>
           <span class="nav-text">POs & PSOs Management</span>
         </a>
       </div>
+        {% endif %}
       {% endif %}
 
       <!-- User Management - Expandable (Admin Only) -->
-      {% if ( user.is_superuser or request.session.role == 'admin' ) and ( not allowed_nav_items or 'user_management' in allowed_nav_items ) %}
+      {% if user.is_superuser or request.session.role == 'admin' %}
+        {% if not allowed_nav_items or 'user_management' in allowed_nav_items %}
       <div class="nav-section {% if 'users' in request.path or 'user-roles' in request.path or request.resolver_match.url_name == 'admin_user_management' or request.resolver_match.url_name == 'admin_role_management' or request.resolver_match.url_name == 'admin_user_panel' %}expanded{% endif %}">
         <div class="nav-section-header">
           <i class="fas fa-users nav-icon"></i>
@@ -238,9 +245,11 @@
           </a>
         </div>
       </div>
+        {% endif %}
       {% endif %}
 
-      {% if ( user.is_superuser or request.session.role == 'admin' ) and ( not allowed_nav_items or 'event_proposals' in allowed_nav_items ) %}
+      {% if user.is_superuser or request.session.role == 'admin' %}
+        {% if not allowed_nav_items or 'event_proposals' in allowed_nav_items %}
       <!-- Event Proposals - Standalone (Admin Only) -->
       <div class="nav-item">
         <a href="/core-admin/event-proposals/" class="nav-link {% if request.resolver_match.url_name == 'admin_event_proposals' %}active{% endif %}">
@@ -248,20 +257,24 @@
           <span class="nav-text">Event Proposals</span>
         </a>
       </div>
+        {% endif %}
       {% endif %}
 
       <!-- Reports - Standalone (Admin Only) -->
-      {% if ( user.is_superuser or request.session.role == 'admin' ) and ( not allowed_nav_items or 'reports' in allowed_nav_items ) %}
+      {% if user.is_superuser or request.session.role == 'admin' %}
+        {% if not allowed_nav_items or 'reports' in allowed_nav_items %}
       <div class="nav-item">
         <a href="/core-admin/reports/" class="nav-link {% if request.resolver_match.url_name == 'admin_reports' or request.resolver_match.url_name == 'admin_reports_view' %}active{% endif %}">
           <i class="fas fa-file-alt nav-icon"></i>
           <span class="nav-text">Reports</span>
         </a>
       </div>
+        {% endif %}
       {% endif %}
 
       <!-- Settings - Expandable (Admin Only) -->
-      {% if ( user.is_superuser or request.session.role == 'admin' ) and ( not allowed_nav_items or 'settings' in allowed_nav_items ) %}
+      {% if user.is_superuser or request.session.role == 'admin' %}
+        {% if not allowed_nav_items or 'settings' in allowed_nav_items %}
       <div class="nav-section {% if 'settings' in request.path or 'approval' in request.path or 'pso-po' in request.path or 'master-data' in request.path or 'outcomes' in request.path or 'sdg-goals' in request.path or 'history' in request.path or request.resolver_match.url_name == 'admin_settings' or request.resolver_match.url_name == 'admin_master_data' or request.resolver_match.url_name == 'admin_approval_flow' or request.resolver_match.url_name == 'admin_pso_po_management' or request.resolver_match.url_name == 'admin_outcome_dashboard' or request.resolver_match.url_name == 'admin_sdg_management' or request.resolver_match.url_name == 'admin_academic_year_settings' or request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}expanded{% endif %}">
         <div class="nav-section-header">
           <i class="fas fa-cog nav-icon"></i>
@@ -291,6 +304,7 @@
           </a>
         </div>
       </div>
+        {% endif %}
       {% endif %}
 
     </nav>


### PR DESCRIPTION
## Summary
- avoid parentheses in `base.html` conditionals to comply with Django's template parser

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a0da0ca9c4832cb3829ad948963fb9