### PR TITLE
Add CDL work dashboard view and URL

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -285,6 +285,7 @@ urlpatterns = [
      # CDL Work dashboard (you already have these two)
     path("cdl/head/", views.cdl_head_dashboard, name="cdl_head_dashboard"),
     path("cdl/member/", views.cdl_member_dashboard, name="cdl_member_dashboard"),
+    path("cdl/work/", views.cdl_work_dashboard, name="cdl_work_dashboard"),
 
     # NEW: make the template links resolve
     path("cdl/availability/new/", views.cdl_create_availability, name="create_availability"),

--- a/core/views.py
+++ b/core/views.py
@@ -4784,6 +4784,12 @@ def cdl_member_dashboard(request):
     }
     return render(request, "cdl/cdl_member_dashboard.html", ctx)
 
+@login_required
+def cdl_work_dashboard(request):
+    if not (request.user.is_superuser or request.user.groups.filter(name="CDL_MEMBER").exists()):
+        return HttpResponseForbidden()
+    return render(request, "core/cdl_work_dashboard.html")
+
 def cdl_create_availability(request):
     return HttpResponse("Create Availability (stub)")
 


### PR DESCRIPTION
## Summary
- add `cdl_work_dashboard` view with basic access checks
- register `cdl/work/` URL pattern for team dashboard

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dbc8cdf0832c989685dd33519d39