### PR TITLE
Add Sidebar Permissions link to settings menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -302,6 +302,9 @@
           <a href="{% url 'admin_history' %}" class="nav-sublink {% if request.resolver_match.url_name == 'admin_history' or request.resolver_match.url_name == 'admin_history_detail' %}active{% endif %}">
             <i class="fas fa-history"></i> History
           </a>
+          <a href="{% url 'admin_sidebar_permissions' %}" class="nav-sublink {% if request.resolver_match.url_name == 'admin_sidebar_permissions' %}active{% endif %}">
+            <i class="fas fa-bars"></i> Sidebar Permissions
+          </a>
         </div>
       </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- add Sidebar Permissions link with icon in admin Settings submenu

## Testing
- `python manage.py test` *(fails: IntegrityError NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a0de2e3dfc832ca694555321351ef3