### PR TITLE
Revamp sidebar permission management UI with dual list selection

### DIFF
--- a/static/core/css/admin_nav_permissions.css
+++ b/static/core/css/admin_nav_permissions.css
@@ -19,8 +19,24 @@
 .sp-field {
   flex: 1;
 }
-.sp-items {
-  display: grid;
-  grid-template-columns: repeat(auto-fill,minmax(200px,1fr));
+
+.dual-list {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.dual-list-column {
+  flex: 1;
+}
+
+.dual-list select {
+  width: 100%;
+  min-height: 250px;
+}
+
+.dual-list-buttons {
+  display: flex;
+  flex-direction: column;
   gap: 0.5rem;
 }

--- a/templates/core/admin_sidebar_permissions.html
+++ b/templates/core/admin_sidebar_permissions.html
@@ -1,12 +1,15 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block content %}
+{% block extra_css %}
 <link rel="stylesheet" href="{% static 'core/css/admin_nav_permissions.css' %}">
+{% endblock %}
+
+{% block content %}
 <div class="sidebar-permissions-bg">
   <div class="sidebar-permissions-container">
     <h1 class="mb-4">Sidebar Permissions</h1>
-    <form method="post">
+    <form method="post" id="sidebar-permission-form">
       {% csrf_token %}
       <div class="sp-selection-row">
         <div class="sp-field">
@@ -28,16 +31,94 @@
           </select>
         </div>
       </div>
-      <div class="sp-items">
-        {% for key,label in nav_items %}
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" value="{{ key }}" id="item_{{ key }}" name="items" {% if permission and key in permission.items %}checked{% endif %}>
-          <label class="form-check-label" for="item_{{ key }}">{{ label }}</label>
+
+      <div class="dual-list mt-4">
+        <div class="dual-list-column">
+          <label class="form-label" for="available">Available</label>
+          <input type="text" id="available_filter" class="form-control mb-2" placeholder="Filter">
+          <select id="available" class="form-select" multiple>
+            {% for key,label in nav_items %}
+            {% if not permission or key not in permission.items %}
+            <option value="{{ key }}">{{ label }}</option>
+            {% endif %}
+            {% endfor %}
+          </select>
         </div>
-        {% endfor %}
+
+        <div class="dual-list-buttons">
+          <button type="button" id="add_btn" class="btn btn-outline-primary mb-2" aria-label="Add selected">&gt;</button>
+          <button type="button" id="remove_btn" class="btn btn-outline-primary" aria-label="Remove selected">&lt;</button>
+        </div>
+
+        <div class="dual-list-column">
+          <label class="form-label" for="assigned">Assigned</label>
+          <input type="text" id="assigned_filter" class="form-control mb-2" placeholder="Filter">
+          <select id="assigned" name="items" class="form-select" multiple>
+            {% if permission %}
+            {% for key,label in nav_items %}
+              {% if key in permission.items %}
+              <option value="{{ key }}">{{ label }}</option>
+              {% endif %}
+            {% endfor %}
+            {% endif %}
+          </select>
+        </div>
       </div>
-      <button type="submit" class="btn btn-primary mt-3">Save</button>
+
+      <div class="text-end mt-3">
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
     </form>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts_extra %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  function moveOptions(from, to) {
+    Array.from(from.selectedOptions).forEach(function (opt) {
+      opt.selected = false;
+      to.add(opt);
+    });
+  }
+
+  const addBtn = document.getElementById('add_btn');
+  const removeBtn = document.getElementById('remove_btn');
+  const available = document.getElementById('available');
+  const assigned = document.getElementById('assigned');
+
+  addBtn.addEventListener('click', function () {
+    moveOptions(available, assigned);
+  });
+
+  removeBtn.addEventListener('click', function () {
+    moveOptions(assigned, available);
+  });
+
+  document.getElementById('sidebar-permission-form').addEventListener('submit', function () {
+    Array.from(assigned.options).forEach(function (opt) {
+      opt.selected = true;
+    });
+  });
+
+  function filterList(input, select) {
+    const term = input.value.toLowerCase();
+    Array.from(select.options).forEach(function (opt) {
+      const show = opt.text.toLowerCase().includes(term);
+      opt.style.display = show ? '' : 'none';
+    });
+  }
+
+  const availableFilter = document.getElementById('available_filter');
+  const assignedFilter = document.getElementById('assigned_filter');
+
+  availableFilter.addEventListener('keyup', function () {
+    filterList(availableFilter, available);
+  });
+  assignedFilter.addEventListener('keyup', function () {
+    filterList(assignedFilter, assigned);
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- modern dual-list interface for admin sidebar permission management
- streamline page-specific styling and scripts

## Testing
- `python manage.py test` (fails: NOT NULL constraint failed: core_profile.achievements_visible)


------
https://chatgpt.com/codex/tasks/task_e_68a0e380a56c832c8bea95a8aba2d926