### PR TITLE
Refine AI field configs for event proposal sections

### DIFF
--- a/suite/field_config/learning_outcomes.json
+++ b/suite/field_config/learning_outcomes.json
@@ -2,6 +2,8 @@
   "fields": [
     "event_title",
     "target_audience",
-    "event_focus_type"
+    "pos_pso_management",
+    "sdg_goals",
+    "num_activities"
   ]
 }

--- a/suite/field_config/need_analysis.json
+++ b/suite/field_config/need_analysis.json
@@ -1,10 +1,9 @@
 {
   "fields": [
-    "event_title",
+    "organization_type",
+    "department",
     "target_audience",
     "event_focus_type",
-    "location",
-    "start_date",
-    "end_date"
+    "sdg_goals"
   ]
 }

--- a/suite/field_config/objectives.json
+++ b/suite/field_config/objectives.json
@@ -1,7 +1,8 @@
 {
   "fields": [
     "event_title",
-    "target_audience",
-    "event_focus_type"
+    "event_focus_type",
+    "committees_collaborations",
+    "pos_pso_management"
   ]
 }

--- a/suite/field_config/why_event.json
+++ b/suite/field_config/why_event.json
@@ -1,8 +1,13 @@
 {
   "fields": [
-    "event_title",
+    "organization_type",
+    "department",
     "target_audience",
     "event_focus_type",
-    "location"
+    "sdg_goals",
+    "event_title",
+    "committees_collaborations",
+    "pos_pso_management",
+    "num_activities"
   ]
 }


### PR DESCRIPTION
## Summary
- align need analysis config with organization, department, audience, focus type, and SDG goals
- include collaborations and POS/PSO in objectives field mapping
- expand learning outcomes and combined why-event configs with SDG goals and activities details

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ede9cea4832c9a2047dab9c3dfe5