### PR TITLE
Fix activities info display on event report

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -249,9 +249,9 @@
                             <div class="input-group">
                                 <label>Activities from Original Proposal</label>
                                 <div class="activities-reference-card">
-                                    {% if proposal.activities.all %}
+                                    {% if activities %}
                                         <div class="activities-grid">
-                                            {% for activity in proposal.activities.all %}
+                                            {% for activity in activities %}
                                                 <div class="activity-reference-item">
                                                     <div class="activity-title">{{ activity.name }}</div>
                                                     <div class="activity-date">{{ activity.date|date:"M d, Y" }}</div>
@@ -260,7 +260,7 @@
                                         </div>
                                         <div class="activities-summary">
                                             <small class="text-muted">
-                                                Total: {{ proposal.activities.count }} activit{{ proposal.activities.count|pluralize:"y,ies" }} planned
+                                                Total: {{ activities|length }} activit{{ activities|length|pluralize:"y,ies" }} planned
                                             </small>
                                         </div>
                                     {% else %}

--- a/emt/views.py
+++ b/emt/views.py
@@ -1452,7 +1452,11 @@ def review_approval_step(request, step_id):
 
 @login_required
 def submit_event_report(request, proposal_id):
-    proposal = get_object_or_404(EventProposal, id=proposal_id, submitted_by=request.user)
+    proposal = get_object_or_404(
+        EventProposal.objects.prefetch_related("activities"),
+        id=proposal_id,
+        submitted_by=request.user,
+    )
 
     # Only allow if no report exists yet
     report, created = EventReport.objects.get_or_create(proposal=proposal)
@@ -1486,6 +1490,7 @@ def submit_event_report(request, proposal_id):
         "proposal": proposal,
         "form": form,
         "formset": formset,
+        "activities": proposal.activities.all(),
     }
     return render(request, "emt/submit_event_report.html", context)
 


### PR DESCRIPTION
## Summary
- prefetch event proposal activities and expose them to the report form context
- render activities list with a variable and count to show planned items

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fb157708832c84cadb067059d8cc