### PR TITLE
feat: revamp target audience selector

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2233,6 +2233,28 @@
     font-weight: 500;
 }
 
+#audienceModal .dual-list {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+#audienceModal .dual-list select {
+    width: 200px;
+    min-height: 200px;
+}
+
+#audienceModal .dual-list-controls {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+#audienceModal .dual-list-controls button {
+    padding: 0.25rem 0.5rem;
+}
+
 /* ===========================================
    SUBMIT EVENT REPORT PAGE INLINE STYLES
    Moved from submit_event_report.html template

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -337,13 +337,7 @@
 <div id="audienceModal" class="outcome-modal">
     <div class="modal-content">
         <h3>Select Target Audience</h3>
-        <div id="audienceOptions">
-            <div class="audience-type-selector">
-                <button type="button" data-type="students">Students</button>
-                <button type="button" data-type="faculty">Faculty</button>
-            </div>
-            <div id="audienceList">Select an option above.</div>
-        </div>
+        <div id="audienceOptions"></div>
         <div class="modal-actions">
             <button type="button" id="audienceCancel" class="btn-cancel">Cancel</button>
             <button type="button" id="audienceSave" class="btn-save">Add</button>


### PR DESCRIPTION
## Summary
- redesign target audience selector with dual list interface
- add styles for dual list modal
- simplify modal template for dynamic content

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fba15d20832cb17e997c2260dfbf