### PR TITLE
Enhance audience selection UI with search and custom entries

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2239,6 +2239,16 @@
     margin-top: 1rem;
 }
 
+#audienceModal .dual-list-column {
+    display: flex;
+    flex-direction: column;
+}
+
+#audienceModal .dual-list-column input[type="text"] {
+    margin-bottom: 0.5rem;
+    padding: 0.25rem 0.5rem;
+}
+
 #audienceModal .dual-list select {
     width: 200px;
     min-height: 200px;
@@ -2253,6 +2263,22 @@
 
 #audienceModal .dual-list-controls button {
     padding: 0.25rem 0.5rem;
+    width: 2.5rem;
+}
+
+#audienceModal .audience-custom {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+#audienceModal .audience-custom input {
+    flex: 1;
+    padding: 0.5rem;
+}
+
+#audienceModal .audience-custom button {
+    padding: 0.5rem 1rem;
 }
 
 /* ===========================================


### PR DESCRIPTION
## Summary
- Improve target audience modal with search boxes, bulk add/remove controls, and custom audience creation/editing
- Style audience modal for a cleaner layout and input support

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a52ab9f0832caea079339124bd3a