### PR TITLE
Enhance audience selection modal

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2183,8 +2183,8 @@
 
 /* Audience modal enhancements */
 #audienceModal .modal-content {
-    max-width: 650px;
-    width: 90%;
+    max-width: 800px;
+    width: 95%;
 }
 
 #audienceModal .audience-type-selector {
@@ -2237,6 +2237,7 @@
     display: flex;
     gap: 1rem;
     margin-top: 1rem;
+    align-items: center;
 }
 
 #audienceModal .dual-list-column {
@@ -2250,8 +2251,8 @@
 }
 
 #audienceModal .dual-list select {
-    width: 200px;
-    min-height: 200px;
+    width: 260px;
+    min-height: 260px;
 }
 
 #audienceModal .dual-list-controls {
@@ -2270,6 +2271,7 @@
     display: flex;
     gap: 0.5rem;
     margin-top: 1rem;
+    align-items: center;
 }
 
 #audienceModal .audience-custom input {

--- a/emt/views.py
+++ b/emt/views.py
@@ -1134,18 +1134,34 @@ def api_faculty(request):
 
     users = (
         users
+        .prefetch_related("role_assignments__organization")
         .filter(
             Q(first_name__icontains=q)
             | Q(last_name__icontains=q)
             | Q(email__icontains=q)
         )
         .distinct()
-        .order_by("first_name")[:20]
+        .order_by("role_assignments__organization__name", "first_name")[:20]
     )
-    return JsonResponse(
-        [{"id": u.id, "text": f"{u.get_full_name() or u.username} ({u.email})"} for u in users],
-        safe=False
-    )
+
+    data = []
+    for u in users:
+        assignment = (
+            u.role_assignments
+            .filter(role__name__icontains="faculty", organization__isnull=False)
+            .select_related("organization")
+            .first()
+        )
+        dept = assignment.organization.name if assignment else ""
+        full_name = u.get_full_name() or u.username
+        data.append({
+            "id": u.id,
+            "name": full_name,
+            "department": dept,
+            "text": f"{full_name} ({u.email})",
+        })
+
+    return JsonResponse(data, safe=False)
 
 
 @login_required
@@ -1183,6 +1199,8 @@ def api_students(request):
 @require_http_methods(["GET"])
 def api_classes(request, org_id):
     """Return classes and their students for an organization."""
+    q = request.GET.get("q", "").strip()
+
     try:
         classes = (
             Class.objects
@@ -1190,6 +1208,8 @@ def api_classes(request, org_id):
             .prefetch_related('students__user')
             .order_by('name')
         )
+        if q:
+            classes = classes.filter(name__icontains=q)
         data = []
         for cls in classes:
             students = [


### PR DESCRIPTION
## Summary
- fetch faculty with department info and searchable classes
- load available audiences from backend when searching
- enlarge and realign target audience modal for better visibility

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a87a578c832c95df450f899f40ee