### PR TITLE
Display planned activities in event report

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -1487,12 +1487,17 @@ def submit_event_report(request, proposal_id):
         form = EventReportForm(instance=report)
         formset = AttachmentFormSet(queryset=report.attachments.all())
 
+    # Fetch activities from the proposal for reference in the report form
+    activities = list(
+        EventActivity.objects.filter(proposal=proposal).order_by("date", "id")
+    )
+
     # Pre-fill context with proposal info for readonly/preview display
     context = {
         "proposal": proposal,
         "form": form,
         "formset": formset,
-        "activities": proposal.activities.all(),
+        "activities": activities,
     }
     return render(request, "emt/submit_event_report.html", context)
 


### PR DESCRIPTION
## Summary
- Load EventActivity records for proposals when rendering event report form
- Pass activities list to template so planned activities appear for reference

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a919c260832ca75f54db5a8a0624