### PR TITLE
feat: enhance target audience modal

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2237,7 +2237,7 @@
     display: flex;
     gap: 1rem;
     margin-top: 1rem;
-    align-items: center;
+    align-items: flex-start;
 }
 
 #audienceModal .dual-list-column {


### PR DESCRIPTION
## Summary
- allow selecting individual students or faculty after choosing classes/departments
- use TomSelect for custom audience entries with typeahead
- fix dual-list alignment in audience modal

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab8909ec832cb8c877aa8fe4a34c