### PR TITLE
Fix activities display in event report

### DIFF
--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -1,0 +1,45 @@
+from datetime import date
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.db.models.signals import post_save
+from django.contrib.auth.signals import user_logged_in
+
+from core.signals import create_or_update_user_profile, assign_role_on_login
+
+from emt.models import EventProposal, EventActivity
+
+
+class SubmitEventReportViewTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client.force_login(self.user)
+        self.proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Sample Event",
+            num_activities=1,
+        )
+        EventActivity.objects.create(
+            proposal=self.proposal,
+            name="Orientation",
+            date=date(2024, 1, 1),
+        )
+
+    def test_activities_rendered_in_report_form(self):
+        resp = self.client.get(
+            reverse("emt:submit_event_report", args=[self.proposal.id])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("Orientation", resp.content.decode())

--- a/emt/views.py
+++ b/emt/views.py
@@ -1508,9 +1508,9 @@ def submit_event_report(request, proposal_id):
         formset = AttachmentFormSet(queryset=report.attachments.all())
 
     # Fetch activities from the proposal for reference in the report form
-    activities = list(
-        EventActivity.objects.filter(proposal=proposal).order_by("date", "id")
-    )
+    # Using the reverse relation ensures we leverage any prefetched data and
+    # avoids missing activities due to incorrect filtering.
+    activities = list(proposal.activities.all().order_by("date", "id"))
 
     # Pre-fill context with proposal info for readonly/preview display
     context = {


### PR DESCRIPTION
## Summary
- ensure `submit_event_report` view uses proposal's reverse relation to load activities
- add regression test covering activity rendering in the event report form

## Testing
- `python manage.py test`
- `python manage.py test emt.tests.test_event_report_view -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a1ac241b44832c9f1b4f88ea7c0ee6