### PR TITLE
feat: expand activity log details

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -122,12 +122,19 @@ class ActivityLogMiddleware:
                 params = {
                     k: v for k, v in params.items() if k.lower() != "csrfmiddlewaretoken"
                 }
-                description = "&".join(f"{k}={v}" for k, v in params.items())
+                params_str = ", ".join(f"{k}={v}" for k, v in params.items()) or "none"
+                ip = request.META.get("REMOTE_ADDR", "unknown")
+                ua = request.META.get("HTTP_USER_AGENT", "unknown")
+                status = getattr(response, "status_code", "unknown")
+                description = (
+                    f"User {request.user.username} performed {request.method} {request.path}. "
+                    f"Params: {params_str}. IP: {ip}. User-Agent: {ua}. Status: {status}"
+                )
                 ActivityLog.objects.create(
                     user=request.user,
                     action=f"{request.method} {request.path}",
-                    description=description or "",
-                    ip_address=request.META.get("REMOTE_ADDR"),
+                    description=description,
+                    ip_address=ip,
                     metadata=params or None,
                 )
         except Exception:  # pragma: no cover - logging should never break the request

--- a/core/tests/test_activity_log_middleware.py
+++ b/core/tests/test_activity_log_middleware.py
@@ -1,21 +1,28 @@
 from django.test import TestCase, RequestFactory
 from django.contrib.auth.models import User
+from django.db.models.signals import post_save
 from django.http import HttpResponse
 
 from core.middleware import ActivityLogMiddleware
 from core.models import ActivityLog
+from core import signals
 
 
 class ActivityLogMiddlewareTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
+        post_save.disconnect(signals.create_or_update_user_profile, sender=User)
         self.user = User.objects.create_user('alice', 'alice@example.com', 'pass')
         self.middleware = ActivityLogMiddleware(lambda request: HttpResponse("ok"))
+
+    def tearDown(self):
+        post_save.connect(signals.create_or_update_user_profile, sender=User)
 
     def test_creates_log_for_post_request(self):
         request = self.factory.post('/some/path', {'foo': 'bar', 'csrfmiddlewaretoken': 'token'})
         request.user = self.user
         request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_USER_AGENT'] = 'TestAgent/1.0'
 
         response = self.middleware(request)
 
@@ -25,12 +32,17 @@ class ActivityLogMiddlewareTests(TestCase):
         self.assertEqual(log.action, 'POST /some/path')
         self.assertEqual(log.ip_address, '127.0.0.1')
         self.assertEqual(log.metadata, {'foo': 'bar'})
-        self.assertEqual(log.description, 'foo=bar')
+        self.assertEqual(
+            log.description,
+            'User alice performed POST /some/path. Params: foo=bar. IP: 127.0.0.1. '
+            'User-Agent: TestAgent/1.0. Status: 200'
+        )
 
     def test_creates_log_for_get_request(self):
         request = self.factory.get('/some/path', {'q': 'test'})
         request.user = self.user
         request.META['REMOTE_ADDR'] = '127.0.0.1'
+        request.META['HTTP_USER_AGENT'] = 'TestAgent/1.0'
 
         response = self.middleware(request)
 
@@ -40,4 +52,8 @@ class ActivityLogMiddlewareTests(TestCase):
         self.assertEqual(log.action, 'GET /some/path')
         self.assertEqual(log.ip_address, '127.0.0.1')
         self.assertEqual(log.metadata, {'q': 'test'})
-        self.assertEqual(log.description, 'q=test')
+        self.assertEqual(
+            log.description,
+            'User alice performed GET /some/path. Params: q=test. IP: 127.0.0.1. '
+            'User-Agent: TestAgent/1.0. Status: 200'
+        )


### PR DESCRIPTION
## Summary
- add rich descriptions to activity logs (method, params, IP, user agent, status)
- cover admin history and middleware logging with tests

## Testing
- `python manage.py test core.tests.test_admin_history core.tests.test_activity_log_middleware -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a1ac604fe0832c8a4efad538a15594