### PR TITLE
Ensure detailed activity log descriptions for all actions

### DIFF
--- a/core/tests/test_activity_log_auto_description.py
+++ b/core/tests/test_activity_log_auto_description.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from core.models import ActivityLog
+
+
+class ActivityLogAutoDescriptionTests(TestCase):
+    def test_generates_description_when_missing(self):
+        user = User.objects.create_user('charlie')
+        log = ActivityLog.objects.create(
+            user=user,
+            action='test_action',
+            ip_address='1.2.3.4',
+            metadata={'foo': 'bar'}
+        )
+        self.assertIn('User charlie performed test_action', log.description)
+        self.assertIn('Params: foo=bar', log.description)
+        self.assertIn('IP: 1.2.3.4', log.description)


### PR DESCRIPTION
## Summary
- Generate fallback descriptions for `ActivityLog` entries using user, action, parameters, IP and user agent
- Capture IP and user agent in login/logout and impersonation start/end logs for richer audit trails
- Add regression test for auto-generated activity log descriptions

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1afb3dca0832c8ee04701d33db29a