### PR TITLE
Allow editing and adding activities in event report

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1402,8 +1402,42 @@ function initializeSectionSpecificHandlers() {
     });
 }
 
+function setupDynamicActivities() {
+    const numActivitiesInput = document.getElementById('num-activities-modern');
+    const container = document.getElementById('dynamic-activities-section');
+    if (!numActivitiesInput || !container) return;
+
+    function render(count) {
+        container.innerHTML = '';
+        if (isNaN(count) || count <= 0) return;
+        for (let i = 1; i <= Math.min(count, 50); i++) {
+            const existing = (window.EXISTING_ACTIVITIES || [])[i - 1] || {};
+            container.insertAdjacentHTML('beforeend', `
+                <div class="dynamic-activity-group">
+                    <div class="input-group">
+                        <label for="activity_name_${i}">Activity ${i} Name</label>
+                        <input type="text" id="activity_name_${i}" name="activity_name_${i}" value="${existing.name || ''}">
+                    </div>
+                    <div class="input-group">
+                        <label for="activity_date_${i}">Activity ${i} Date</label>
+                        <input type="date" id="activity_date_${i}" name="activity_date_${i}" value="${existing.date || ''}">
+                    </div>
+                </div>
+            `);
+        }
+    }
+
+    numActivitiesInput.addEventListener('input', (e) => {
+        const count = parseInt(e.target.value, 10);
+        render(count);
+    });
+
+    render(parseInt(numActivitiesInput.value, 10));
+}
+
 // Initialize section-specific handlers when document is ready
 $(document).ready(function() {
     initializeSectionSpecificHandlers();
+    setupDynamicActivities();
 });
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -245,34 +245,8 @@
                             <h3>Activities Information</h3>
                         </div>
 
-                        <div class="form-row full-width">
-                            <div class="input-group">
-                                <label>Activities from Original Proposal</label>
-                                <div class="activities-reference-card">
-                                    {% if activities %}
-                                        <div class="activities-grid">
-                                            {% for activity in activities %}
-                                                <div class="activity-reference-item">
-                                                    <div class="activity-title">{{ activity.name }}</div>
-                                                    <div class="activity-date">{{ activity.date|date:"M d, Y" }}</div>
-                                                </div>
-                                            {% endfor %}
-                                        </div>
-                                        <div class="activities-summary">
-                                            <small class="text-muted">
-                                                Total: {{ activities|length }} activit{{ activities|length|pluralize:"y,ies" }} planned
-                                            </small>
-                                        </div>
-                                    {% else %}
-                                        <div class="no-activities-message">
-                                            <i class="info-icon"></i>
-                                            <span>No activities were defined in the original proposal</span>
-                                        </div>
-                                    {% endif %}
-                                </div>
-                                <div class="help-text">Reference: Activities planned in the original proposal</div>
-                            </div>
-                        </div>
+                        <!-- Dynamic activities section -->
+                        <div id="dynamic-activities-section" class="full-width"></div>
 
                         <!-- Save Section -->
                         <div class="form-row full-width">

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -43,3 +43,25 @@ class SubmitEventReportViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Orientation")
 
+    def test_can_update_activities_via_report_submission(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Seminar",
+            "report_signed_date": "2024-01-10",
+            "num_activities": "2",
+            "activity_name_1": "Session 1",
+            "activity_date_1": "2024-01-02",
+            "activity_name_2": "Session 2",
+            "activity_date_2": "2024-01-03",
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        activities = list(EventActivity.objects.filter(proposal=self.proposal).order_by("date"))
+        self.assertEqual(len(activities), 2)
+        self.assertEqual(activities[0].name, "Session 1")
+        self.assertEqual(activities[1].name, "Session 2")
+


### PR DESCRIPTION
## Summary
- enable users to edit and add activities when submitting event reports
- render dynamic activity fields driven by the activity count
- cover activity updates with tests

## Testing
- `python manage.py test emt.tests.test_event_report_view -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a1b2464be4832c80a4c776da76263a