### PR TITLE
Include view and referrer details in activity log

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -126,9 +126,15 @@ class ActivityLogMiddleware:
                 ip = request.META.get("REMOTE_ADDR", "unknown")
                 ua = request.META.get("HTTP_USER_AGENT", "unknown")
                 status = getattr(response, "status_code", "unknown")
+                referrer = request.META.get("HTTP_REFERER", "unknown")
+                view_name = (
+                    getattr(getattr(request, "resolver_match", None), "view_name", None)
+                    or request.path
+                )
                 description = (
                     f"User {request.user.username} performed {request.method} {request.path}. "
-                    f"Params: {params_str}. IP: {ip}. User-Agent: {ua}. Status: {status}"
+                    f"View: {view_name}. Params: {params_str}. IP: {ip}. "
+                    f"User-Agent: {ua}. Status: {status}. Referrer: {referrer}"
                 )
                 ActivityLog.objects.create(
                     user=request.user,

--- a/core/tests/test_activity_log_middleware.py
+++ b/core/tests/test_activity_log_middleware.py
@@ -34,8 +34,8 @@ class ActivityLogMiddlewareTests(TestCase):
         self.assertEqual(log.metadata, {'foo': 'bar'})
         self.assertEqual(
             log.description,
-            'User alice performed POST /some/path. Params: foo=bar. IP: 127.0.0.1. '
-            'User-Agent: TestAgent/1.0. Status: 200'
+            'User alice performed POST /some/path. View: /some/path. Params: foo=bar. '
+            'IP: 127.0.0.1. User-Agent: TestAgent/1.0. Status: 200. Referrer: unknown'
         )
 
     def test_creates_log_for_get_request(self):
@@ -54,6 +54,6 @@ class ActivityLogMiddlewareTests(TestCase):
         self.assertEqual(log.metadata, {'q': 'test'})
         self.assertEqual(
             log.description,
-            'User alice performed GET /some/path. Params: q=test. IP: 127.0.0.1. '
-            'User-Agent: TestAgent/1.0. Status: 200'
+            'User alice performed GET /some/path. View: /some/path. Params: q=test. '
+            'IP: 127.0.0.1. User-Agent: TestAgent/1.0. Status: 200. Referrer: unknown'
         )


### PR DESCRIPTION
## Summary
- add view name and referrer to activity log descriptions for more context
- adjust middleware tests for new logging details

## Testing
- `python manage.py test core.tests.test_activity_log_middleware`
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b2eee7e8832ca955dfd11dbb41ca