### PR TITLE
Expose proposal activities for editing in report

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1407,32 +1407,46 @@ function setupDynamicActivities() {
     const container = document.getElementById('dynamic-activities-section');
     if (!numActivitiesInput || !container) return;
 
+    const existing = Array.isArray(window.EXISTING_ACTIVITIES)
+        ? window.EXISTING_ACTIVITIES
+        : [];
+
     function render(count) {
+        const current = Array.from(
+            container.querySelectorAll('.dynamic-activity-group')
+        ).map(group => ({
+            name: group.querySelector('input[name^="activity_name_"]').value,
+            date: group.querySelector('input[name^="activity_date_"]').value,
+        }));
+
         container.innerHTML = '';
         if (isNaN(count) || count <= 0) return;
+
         for (let i = 1; i <= Math.min(count, 50); i++) {
-            const existing = (window.EXISTING_ACTIVITIES || [])[i - 1] || {};
+            const data = current[i - 1] || existing[i - 1] || {};
             container.insertAdjacentHTML('beforeend', `
                 <div class="dynamic-activity-group">
                     <div class="input-group">
                         <label for="activity_name_${i}">Activity ${i} Name</label>
-                        <input type="text" id="activity_name_${i}" name="activity_name_${i}" value="${existing.name || ''}">
+                        <input type="text" id="activity_name_${i}" name="activity_name_${i}" value="${data.name || ''}">
                     </div>
                     <div class="input-group">
                         <label for="activity_date_${i}">Activity ${i} Date</label>
-                        <input type="date" id="activity_date_${i}" name="activity_date_${i}" value="${existing.date || ''}">
+                        <input type="date" id="activity_date_${i}" name="activity_date_${i}" value="${data.date || ''}">
                     </div>
                 </div>
             `);
         }
     }
 
-    numActivitiesInput.addEventListener('input', (e) => {
+    const initialCount = existing.length || parseInt(numActivitiesInput.value, 10) || 0;
+    numActivitiesInput.value = initialCount;
+    render(initialCount);
+
+    numActivitiesInput.addEventListener('input', e => {
         const count = parseInt(e.target.value, 10);
         render(count);
     });
-
-    render(parseInt(numActivitiesInput.value, 10));
 }
 
 // Initialize section-specific handlers when document is ready

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -316,7 +316,7 @@
         window.API_FACULTY = "#"; // TODO: Add API URLs
         window.API_OUTCOMES_BASE = "#"; // TODO: Add API URLs
         window.SDG_GOALS = {{ sdg_goals_list|default:'[]'|safe }};
-        window.EXISTING_ACTIVITIES = {{ activities_json|default:'[]'|safe }};
+        window.EXISTING_ACTIVITIES = {{ activities_json|safe }};
         window.EXISTING_SPEAKERS = {{ speakers_json|default:'[]'|safe }};
         window.PROPOSAL_DATA = {
             department: "{{ proposal.organization.name|default:'' }}",

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -36,12 +36,20 @@ class SubmitEventReportViewTests(TestCase):
             date=date(2024, 1, 1),
         )
 
-    def test_activity_name_rendered_in_report_form(self):
+    def test_activities_prefilled_in_report_form(self):
         response = self.client.get(
             reverse("emt:submit_event_report", args=[self.proposal.id])
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Orientation")
+        # Activity data should be exposed for client-side rendering
+        self.assertContains(response, 'Orientation')
+        self.assertContains(response, '2024-01-01')
+        # Number of activities should be pre-filled
+        self.assertContains(
+            response,
+            'id="num-activities-modern" name="num_activities" value="1"',
+            html=False,
+        )
 
     def test_can_update_activities_via_report_submission(self):
         url = reverse("emt:submit_event_report", args=[self.proposal.id])

--- a/emt/views.py
+++ b/emt/views.py
@@ -1512,8 +1512,8 @@ def submit_event_report(request, proposal_id):
 
     # Fetch activities for editing in the report form
     activities = [
-        {"name": a["name"], "date": a["date"].isoformat()}
-        for a in proposal.activities.values("name", "date")
+        {"name": a.name, "date": a.date.isoformat()}
+        for a in proposal.activities.all()
     ]
 
     # Pre-fill context with proposal info for readonly/preview display


### PR DESCRIPTION
## Summary
- Provide existing activities and JSON to submit_event_report view context
- Prefill activities count and expose activity JSON to the report form
- Initialize dynamic activity inputs from existing activities on the client and keep them editable
- Add regression tests for activity prefill and editing

## Testing
- `python manage.py test emt.tests.test_event_report_view -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a1b5930220832cb9a58e7767df772c