### PR TITLE
feat(report): allow editing proposal activities

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1405,48 +1405,76 @@ function initializeSectionSpecificHandlers() {
 function setupDynamicActivities() {
     const numActivitiesInput = document.getElementById('num-activities-modern');
     const container = document.getElementById('dynamic-activities-section');
-    if (!numActivitiesInput || !container) return;
+    const addBtn = document.getElementById('add-activity-btn');
+    if (!numActivitiesInput || !container || !addBtn) return;
 
     const existing = Array.isArray(window.EXISTING_ACTIVITIES)
         ? window.EXISTING_ACTIVITIES
-        : [];
+        : Array.isArray(window.PROPOSAL_DATA?.activities)
+            ? window.PROPOSAL_DATA.activities
+            : [];
 
-    function render(count) {
-        const current = Array.from(
+    function collectValues() {
+        return Array.from(
             container.querySelectorAll('.dynamic-activity-group')
         ).map(group => ({
             name: group.querySelector('input[name^="activity_name_"]').value,
             date: group.querySelector('input[name^="activity_date_"]').value,
         }));
+    }
 
+    function render(count, values) {
         container.innerHTML = '';
-        if (isNaN(count) || count <= 0) return;
-
-        for (let i = 1; i <= Math.min(count, 50); i++) {
-            const data = current[i - 1] || existing[i - 1] || {};
+        for (let i = 1; i <= count; i++) {
+            const data = values[i - 1] || existing[i - 1] || {};
             container.insertAdjacentHTML('beforeend', `
                 <div class="dynamic-activity-group">
                     <div class="input-group">
-                        <label for="activity_name_${i}">Activity ${i} Name</label>
+                        <label for="activity_name_${i}" class="activity-label">Activity ${i} Name</label>
                         <input type="text" id="activity_name_${i}" name="activity_name_${i}" value="${data.name || ''}">
                     </div>
                     <div class="input-group">
-                        <label for="activity_date_${i}">Activity ${i} Date</label>
+                        <label for="activity_date_${i}" class="date-label">Activity ${i} Date</label>
                         <input type="date" id="activity_date_${i}" name="activity_date_${i}" value="${data.date || ''}">
                     </div>
+                    <button type="button" class="remove-activity" data-index="${i}">Remove</button>
                 </div>
             `);
         }
+        numActivitiesInput.value = count;
     }
 
-    const initialCount = existing.length || parseInt(numActivitiesInput.value, 10) || 0;
-    numActivitiesInput.value = initialCount;
-    render(initialCount);
+    container.addEventListener('click', e => {
+        if (e.target.classList.contains('remove-activity')) {
+            const index = parseInt(e.target.dataset.index, 10);
+            const values = collectValues();
+            values.splice(index - 1, 1);
+            render(values.length, values);
+        }
+    });
+
+    addBtn.addEventListener('click', () => {
+        const values = collectValues();
+        values.push({ name: '', date: '' });
+        render(values.length, values);
+    });
 
     numActivitiesInput.addEventListener('input', e => {
-        const count = parseInt(e.target.value, 10);
-        render(count);
+        let count = parseInt(e.target.value, 10);
+        if (isNaN(count) || count < 0) count = 0;
+        const values = collectValues();
+        if (values.length > count) {
+            values.splice(count);
+        } else {
+            while (values.length < count) {
+                values.push({ name: '', date: '' });
+            }
+        }
+        render(count, values);
     });
+
+    const initialCount = existing.length || parseInt(numActivitiesInput.value, 10) || 0;
+    render(initialCount, existing);
 }
 
 // Initialize section-specific handlers when document is ready

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -247,6 +247,7 @@
 
                         <!-- Dynamic activities section -->
                         <div id="dynamic-activities-section" class="full-width"></div>
+                        <button type="button" id="add-activity-btn" class="btn btn-secondary mt-2">Add Activity</button>
 
                         <!-- Save Section -->
                         <div class="form-row full-width">

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -50,6 +50,8 @@ class SubmitEventReportViewTests(TestCase):
             'id="num-activities-modern" name="num_activities" value="1"',
             html=False,
         )
+        # Add activity button for dynamic editing
+        self.assertContains(response, 'id="add-activity-btn"')
 
     def test_can_update_activities_via_report_submission(self):
         url = reverse("emt:submit_event_report", args=[self.proposal.id])


### PR DESCRIPTION
## Summary
- allow activities from proposals to be edited when submitting reports
- add client-side controls to append or remove activity rows
- cover new add-activity button in report view tests

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b84db710832cb7155bdbe6810ea1