### PR TITLE
Prefill proposal activities in event report form

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1061,6 +1061,20 @@
     margin-bottom: 0;
 }
 
+/* Proposal activity editor */
+.activity-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 1rem;
+    align-items: flex-end;
+    margin-bottom: 0.5rem;
+}
+
+.activity-row .remove-activity {
+    align-self: center;
+    padding: 0.25rem 0.5rem;
+}
+
 /* Save Section Styling */
 .save-section-container {
     display: flex;

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1403,78 +1403,50 @@ function initializeSectionSpecificHandlers() {
 }
 
 function setupDynamicActivities() {
-    const numActivitiesInput = document.getElementById('num-activities-modern');
-    const container = document.getElementById('dynamic-activities-section');
+    const numInput = document.getElementById('num-activities-modern');
+    const container = document.getElementById('proposal-activities');
     const addBtn = document.getElementById('add-activity-btn');
-    if (!numActivitiesInput || !container || !addBtn) return;
+    if (!numInput || !container || !addBtn) return;
 
-    const existing = Array.isArray(window.EXISTING_ACTIVITIES)
-        ? window.EXISTING_ACTIVITIES
-        : Array.isArray(window.PROPOSAL_DATA?.activities)
-            ? window.PROPOSAL_DATA.activities
-            : [];
+    let activities = Array.isArray(window.PROPOSAL_ACTIVITIES)
+        ? window.PROPOSAL_ACTIVITIES
+        : [];
 
-    function collectValues() {
-        return Array.from(
-            container.querySelectorAll('.dynamic-activity-group')
-        ).map(group => ({
-            name: group.querySelector('input[name^="activity_name_"]').value,
-            date: group.querySelector('input[name^="activity_date_"]').value,
-        }));
-    }
-
-    function render(count, values) {
+    function render() {
         container.innerHTML = '';
-        for (let i = 1; i <= count; i++) {
-            const data = values[i - 1] || existing[i - 1] || {};
-            container.insertAdjacentHTML('beforeend', `
-                <div class="dynamic-activity-group">
-                    <div class="input-group">
-                        <label for="activity_name_${i}" class="activity-label">Activity ${i} Name</label>
-                        <input type="text" id="activity_name_${i}" name="activity_name_${i}" value="${data.name || ''}">
-                    </div>
-                    <div class="input-group">
-                        <label for="activity_date_${i}" class="date-label">Activity ${i} Date</label>
-                        <input type="date" id="activity_date_${i}" name="activity_date_${i}" value="${data.date || ''}">
-                    </div>
-                    <button type="button" class="remove-activity" data-index="${i}">Remove</button>
+        activities.forEach((act, idx) => {
+            const row = document.createElement('div');
+            row.className = 'activity-row';
+            row.innerHTML = `
+                <div class="input-group">
+                    <label for="activity_name_${idx + 1}" class="activity-label">Activity ${idx + 1} Name</label>
+                    <input type="text" id="activity_name_${idx + 1}" name="activity_name_${idx + 1}" value="${act.activity_name || ''}">
                 </div>
-            `);
-        }
-        numActivitiesInput.value = count;
+                <div class="input-group">
+                    <label for="activity_date_${idx + 1}" class="date-label">Activity ${idx + 1} Date</label>
+                    <input type="date" id="activity_date_${idx + 1}" name="activity_date_${idx + 1}" value="${act.activity_date || ''}">
+                </div>
+                <button type="button" class="remove-activity" data-index="${idx}">Remove</button>
+            `;
+            container.appendChild(row);
+        });
+        numInput.value = activities.length;
     }
 
-    container.addEventListener('click', e => {
+    container.addEventListener('click', (e) => {
         if (e.target.classList.contains('remove-activity')) {
             const index = parseInt(e.target.dataset.index, 10);
-            const values = collectValues();
-            values.splice(index - 1, 1);
-            render(values.length, values);
+            activities.splice(index, 1);
+            render();
         }
     });
 
     addBtn.addEventListener('click', () => {
-        const values = collectValues();
-        values.push({ name: '', date: '' });
-        render(values.length, values);
+        activities.push({ activity_name: '', activity_date: '' });
+        render();
     });
 
-    numActivitiesInput.addEventListener('input', e => {
-        let count = parseInt(e.target.value, 10);
-        if (isNaN(count) || count < 0) count = 0;
-        const values = collectValues();
-        if (values.length > count) {
-            values.splice(count);
-        } else {
-            while (values.length < count) {
-                values.push({ name: '', date: '' });
-            }
-        }
-        render(count, values);
-    });
-
-    const initialCount = existing.length || parseInt(numActivitiesInput.value, 10) || 0;
-    render(initialCount, existing);
+    render();
 }
 
 // Initialize section-specific handlers when document is ready

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -132,12 +132,8 @@
                             </div>
                         </div>
 
+                        <input type="hidden" id="num-activities-modern" name="num_activities" value="{{ proposal_activities|length }}">
                         <div class="form-row">
-                            <div class="input-group">
-                                <label for="num-activities-modern">Number of Activities</label>
-                                <input type="number" id="num-activities-modern" name="num_activities" value="{{ activities|length }}">
-                                <div class="help-text">Total activities from proposal (editable)</div>
-                            </div>
                             <div class="input-group">
                                 <label for="venue-modern">Venue *</label>
                                 <input type="text" id="venue-modern" name="venue_detail" value="{{ proposal.venue|default:'' }}">
@@ -246,7 +242,21 @@
                         </div>
 
                         <!-- Dynamic activities section -->
-                        <div id="dynamic-activities-section" class="full-width"></div>
+                        <div id="proposal-activities" class="full-width">
+                            {% for act in proposal_activities %}
+                            <div class="activity-row">
+                                <div class="input-group">
+                                    <label for="activity_name_{{ forloop.counter }}" class="activity-label">Activity {{ forloop.counter }} Name</label>
+                                    <input type="text" id="activity_name_{{ forloop.counter }}" name="activity_name_{{ forloop.counter }}" value="{{ act.activity_name }}">
+                                </div>
+                                <div class="input-group">
+                                    <label for="activity_date_{{ forloop.counter }}" class="date-label">Activity {{ forloop.counter }} Date</label>
+                                    <input type="date" id="activity_date_{{ forloop.counter }}" name="activity_date_{{ forloop.counter }}" value="{{ act.activity_date }}">
+                                </div>
+                                <button type="button" class="remove-activity" data-index="{{ forloop.counter0 }}">Remove</button>
+                            </div>
+                            {% endfor %}
+                        </div>
                         <button type="button" id="add-activity-btn" class="btn btn-secondary mt-2">Add Activity</button>
 
                         <!-- Save Section -->
@@ -317,7 +327,7 @@
         window.API_FACULTY = "#"; // TODO: Add API URLs
         window.API_OUTCOMES_BASE = "#"; // TODO: Add API URLs
         window.SDG_GOALS = {{ sdg_goals_list|default:'[]'|safe }};
-        window.EXISTING_ACTIVITIES = {{ activities_json|safe }};
+        window.PROPOSAL_ACTIVITIES = {{ proposal_activities_json|safe }};
         window.EXISTING_SPEAKERS = {{ speakers_json|default:'[]'|safe }};
         window.PROPOSAL_DATA = {
             department: "{{ proposal.organization.name|default:'' }}",
@@ -327,10 +337,10 @@
             event_focus_type: "{{ proposal.event_focus_type|default:'' }}",
             student_coordinators: "{{ proposal.student_coordinators|default:'' }}",
             academic_year: "{{ proposal.academic_year|default:'2024-2025' }}",
-            num_activities: "{{ activities|length }}",
+            num_activities: "{{ proposal_activities|length }}",
             event_start_date: "{% if proposal.event_start_date %}{{ proposal.event_start_date|date:'Y-m-d' }}{% elif proposal.event_datetime %}{{ proposal.event_datetime|date:'Y-m-d' }}{% endif %}",
             event_end_date: "{% if proposal.event_end_date %}{{ proposal.event_end_date|date:'Y-m-d' }}{% elif proposal.event_datetime %}{{ proposal.event_datetime|date:'Y-m-d' }}{% endif %}",
-            activities: {{ activities_json|default:'[]'|safe }},
+            activities: {{ proposal_activities_json|default:'[]'|safe }},
             speakers: {{ speakers_json|default:'[]'|safe }},
             pos_pso: "{{ proposal.pos_pso|default:'' }}",
             sdg_goals: "{{ proposal.sdg_goals|default:'' }}"

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -41,17 +41,26 @@ class SubmitEventReportViewTests(TestCase):
             reverse("emt:submit_event_report", args=[self.proposal.id])
         )
         self.assertEqual(response.status_code, 200)
-        # Activity data should be exposed for client-side rendering
-        self.assertContains(response, 'Orientation')
-        self.assertContains(response, '2024-01-01')
-        # Number of activities should be pre-filled
+        # Activity row should be pre-filled
+        self.assertContains(
+            response,
+            'name="activity_name_1" value="Orientation"',
+            html=False,
+        )
+        self.assertContains(
+            response,
+            'name="activity_date_1" value="2024-01-01"',
+            html=False,
+        )
+        # Hidden count of activities
         self.assertContains(
             response,
             'id="num-activities-modern" name="num_activities" value="1"',
             html=False,
         )
-        # Add activity button for dynamic editing
+        # Add and remove buttons for dynamic editing
         self.assertContains(response, 'id="add-activity-btn"')
+        self.assertContains(response, 'class="remove-activity"')
 
     def test_can_update_activities_via_report_submission(self):
         url = reverse("emt:submit_event_report", args=[self.proposal.id])

--- a/emt/views.py
+++ b/emt/views.py
@@ -1511,8 +1511,8 @@ def submit_event_report(request, proposal_id):
         formset = AttachmentFormSet(queryset=report.attachments.all())
 
     # Fetch activities for editing in the report form
-    activities = [
-        {"name": a.name, "date": a.date.isoformat()}
+    proposal_activities = [
+        {"activity_name": a.name, "activity_date": a.date.isoformat()}
         for a in proposal.activities.all()
     ]
 
@@ -1521,8 +1521,8 @@ def submit_event_report(request, proposal_id):
         "proposal": proposal,
         "form": form,
         "formset": formset,
-        "activities": activities,
-        "activities_json": json.dumps(activities),
+        "proposal_activities": proposal_activities,
+        "proposal_activities_json": json.dumps(proposal_activities),
     }
     return render(request, "emt/submit_event_report.html", context)
 


### PR DESCRIPTION
## Summary
- populate event report form with proposal activities on load
- render and manage activity rows dynamically with add/remove controls
- style activity editor grid for consistent layout and add tests for pre-filled activities

## Testing
- `python manage.py test emt.tests.test_event_report_view -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a23664ff58832ca6ca6a6f3759120b