### PR TITLE
Fix missing styling on CDL head dashboard

### DIFF
--- a/templates/cdl/cdl_head_dashboard.html
+++ b/templates/cdl/cdl_head_dashboard.html
@@ -1,5 +1,15 @@
 {% extends "base.html" %}
+{% load static %}
 {% block title %}CDL Head Dashboard{% endblock %}
+
+{% block head_extra %}
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<link rel="stylesheet" href="{% static 'core/css/dashboard.css' %}">
+<link rel="stylesheet" href="{% static 'core/css/cdl_head_dashboard.css' %}">
+{% endblock %}
+
 {% block content %}
 <h1>CDL Head Dashboard</h1>
 <div class="row text-center my-4">


### PR DESCRIPTION
## Summary
- include fonts and stylesheet links for CDL head dashboard

## Testing
- `python manage.py test core.tests.test_cdl` *(fails: IntegrityError: NOT NULL constraint failed: core_profile.achievements_visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a237d3f488832cbd7cecd3dc8a7cd1