### PR TITLE
Expand CDL head dashboard template

### DIFF
--- a/templates/cdl/cdl_head_dashboard.html
+++ b/templates/cdl/cdl_head_dashboard.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
-{% block title %}CDL Head Dashboard{% endblock %}
+
+{% block title %}Centre for Digital Learning (CDL) — Head Dashboard{% endblock %}
 
 {% block head_extra %}
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -11,41 +12,188 @@
 {% endblock %}
 
 {% block content %}
-<h1>CDL Head Dashboard</h1>
-<div class="row text-center my-4">
-  <div class="col">
-    <div class="card"><div class="card-body">
-      <h5>Total Active Requests</h5><p>{{ metrics.active_requests|default:0 }}</p>
-    </div></div>
-  </div>
-  <div class="col">
-    <div class="card"><div class="card-body">
-      <h5>Assets Delivery Pending</h5><p>{{ metrics.assets_pending|default:0 }}</p>
-    </div></div>
-  </div>
-  <div class="col">
-    <div class="card"><div class="card-body">
-      <h5>Unassigned Tasks</h5><p>{{ metrics.unassigned|default:0 }}</p>
-    </div></div>
-  </div>
-  <div class="col">
-    <div class="card"><div class="card-body">
-      <h5>Total Events Supported</h5><p>{{ metrics.events_supported|default:0 }}</p>
-    </div></div>
-  </div>
+<div class="ems-dashboard">
+  <header class="topbar">
+    <div>
+      <h1>Centre for Digital Learning (CDL)</h1>
+      <span class="topbar-date">{% now "F j, Y · l" %}</span>
+    </div>
+  </header>
+
+  <!-- KPIs + Profile -->
+  <section class="kpi-row">
+    <button class="kpi-card" id="kpiActive">
+      <div class="kpi-icon bg-indigo"><i class="fa-solid fa-list-check"></i></div>
+      <div class="kpi-content">
+        <span class="kpi-title">Total Active Requests</span>
+        <span class="kpi-value" id="valActive">0</span>
+        <span class="kpi-bar" style="--pct:60%"></span>
+      </div>
+    </button>
+
+    <button class="kpi-card" id="kpiAssets">
+      <div class="kpi-icon bg-sky"><i class="fa-solid fa-folder-open"></i></div>
+      <div class="kpi-content">
+        <span class="kpi-title">Assets Delivery Pending</span>
+        <span class="kpi-value" id="valAssetsPending">0</span>
+        <span class="kpi-bar" style="--pct:45%"></span>
+      </div>
+    </button>
+
+    <button class="kpi-card" id="kpiUnassigned">
+      <div class="kpi-icon bg-orange"><i class="fa-solid fa-user-clock"></i></div>
+      <div class="kpi-content">
+        <span class="kpi-title">Unassigned Tasks</span>
+        <span class="kpi-value" id="valUnassigned">0</span>
+        <span class="kpi-bar" style="--pct:35%"></span>
+      </div>
+    </button>
+
+    <button class="kpi-card" id="kpiEvents">
+      <div class="kpi-icon bg-emerald"><i class="fa-solid fa-calendar-check"></i></div>
+      <div class="kpi-content">
+        <span class="kpi-title">Total Events Supported</span>
+        <span class="kpi-value" id="valEvents">0</span>
+        <span class="kpi-bar" style="--pct:70%"></span>
+      </div>
+    </button>
+
+    <!-- PROFILE (student layout, no switch) -->
+    <div class="profile-kpi">
+      <div class="pkp-avatar">
+        {% if user.profile and user.profile.photo %}
+          <img src="{{ user.profile.photo.url }}" alt="{{ user.get_full_name|default:user.username }}">
+        {% else %}
+          <span class="pkp-initials">
+            {% if user.first_name %}{{ user.first_name.0|upper }}{% if user.last_name %}{{ user.last_name.0|upper }}{% endif %}{% else %}{{ user.username.0|upper }}{% endif %}
+          </span>
+        {% endif %}
+      </div>
+      <div class="pkp-body">
+        <h1 class="pkp-name">{{ user.get_full_name|default:"Admin" }}</h1>
+        <p class="pkp-sub">{{ user.email|default:"admin@gmail.com" }}</p>
+        <div class="pkp-meta">
+          <span>Role: <strong>CDL Head</strong></span>
+          <span>Dept: <strong>Centre for Digital Learning</strong></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Row 2 -->
+  <main class="grid-3 grid-assign">
+    <section class="card eq" id="cardNotifications">
+      <div class="card-header">
+        <h3><i class="fa-regular fa-bell"></i> Notifications</h3>
+        <div class="header-actions">
+          <div class="seg">
+            <button class="seg-btn active" data-nf="all">All</button>
+            <button class="seg-btn" data-nf="posters">Posters</button>
+            <button class="seg-btn" data-nf="certificates">Certificates</button>
+            <button class="seg-btn" data-nf="coverage">Coverage</button>
+            <button class="seg-btn" data-nf="media">Media</button>
+          </div>
+        </div>
+      </div>
+      <div class="list" id="notifList"></div>
+      <div class="empty muted" id="notifEmpty" style="display:none;padding:12px;">No notifications</div>
+    </section>
+
+    <section class="card eq" id="cardTeam">
+      <div class="card-header">
+        <h3><i class="fa-solid fa-chart-line"></i> <span id="teamTitle">Workload Distribution</span></h3>
+        <div class="header-actions">
+          <div class="seg">
+            <button class="seg-btn active" data-view="workload">Workload</button>
+            <button class="seg-btn" data-view="ontime">On-time %</button>
+            <button class="seg-btn" data-view="firstpass">First-pass %</button>
+          </div>
+          <div class="seg">
+            <button class="seg-btn ghost" data-range="7">7d</button>
+            <button class="seg-btn ghost active" data-range="30">30d</button>
+            <button class="seg-btn ghost" data-range="90">90d</button>
+          </div>
+        </div>
+      </div>
+      <div class="chart-wrap">
+        <canvas id="teamChart" height="150"></canvas>
+      </div>
+    </section>
+
+    <section class="card eq" id="cardCalendar">
+      <div class="card-header">
+        <h3><i class="fa-regular fa-calendar"></i> Calendar</h3>
+        <div class="header-actions">
+          <select id="calFilter" class="select">
+            <option value="all">All</option>
+            <option value="coverage">Coverage</option>
+            <option value="approvals">Approvals</option>
+          </select>
+          <a href="#" class="chip-btn" id="addEventBtn"><i class="fa-solid fa-plus"></i> Add</a>
+        </div>
+      </div>
+      <div class="mini-cal" id="miniCalendar">
+        <div class="cal-head">
+          <button class="cal-nav" id="calPrev" aria-label="Prev"><i class="fa-solid fa-chevron-left"></i></button>
+          <div id="calTitle">Month YYYY</div>
+          <button class="cal-nav" id="calNext" aria-label="Next"><i class="fa-solid fa-chevron-right"></i></button>
+        </div>
+        <div class="cal-weekdays"><span>S</span><span>M</span><span>T</span><span>W</span><span>T</span><span>F</span><span>S</span></div>
+        <div class="cal-grid" id="calGrid"></div>
+      </div>
+      <div class="cal-legend">
+        <span class="dot blue"></span> Coverage
+        <span class="dot green"></span> Approval
+        <span class="dot red"></span> Conflict
+      </div>
+      <div id="upcomingWrap" class="upcoming"></div>
+    </section>
+  </main>
+
+  <!-- Row 3 -->
+  <section class="card" id="cardAssignAll">
+    <div class="card-header">
+      <h3><i class="fa-solid fa-users-gear"></i> Assignment Manager</h3>
+      <div class="header-actions">
+        <div class="seg">
+          <button class="seg-btn active" data-am="all">All</button>
+          <button class="seg-btn" data-am="unassigned">Unassigned</button>
+          <button class="seg-btn" data-am="urgent">Urgent</button>
+          <button class="seg-btn" data-am="due24">SLA ≤ 24h</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="table-wrap">
+      <table class="table compact" id="assignTable">
+        <thead>
+          <tr>
+            <th><input type="checkbox" id="amSelectAll"></th>
+            <th>Event</th>
+            <th>Type</th>
+            <th>Priority</th>
+            <th>Due</th>
+            <th>Assignee</th>
+            <th>Status</th>
+            <th>Rev</th>
+            <th class="ta-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="assignBody"></tbody>
+      </table>
+    </div>
+
+    <div class="table-actions">
+      <button class="btn xs" id="amBulkAssign"><i class="fa-solid fa-user-plus"></i> Assign</button>
+      <button class="btn xs success" id="amBulkApprove"><i class="fa-solid fa-check"></i> Approve</button>
+      <button class="btn xs warn" id="amBulkReturn"><i class="fa-solid fa-rotate-left"></i> Return</button>
+    </div>
+  </section>
+
+  {{ calendar_events|json_script:"calendarEventsJson" }}
 </div>
-<div class="card mb-4">
-  <div class="card-header">Notifications</div>
-  <div class="card-body">
-    <ul class="list-group">
-      {% for n in notifications %}
-        <li class="list-group-item d-flex justify-content-between align-items-center">{{ n }}<span><button class="btn btn-sm btn-success">Approve</button> <button class="btn btn-sm btn-danger">Decline</button></span></li>
-      {% empty %}<li class="list-group-item text-muted">No notifications</li>{% endfor %}
-    </ul>
-  </div>
-</div>
-<div class="card">
-  <div class="card-header">Calendar</div>
-  <div class="card-body">Calendar placeholder</div>
-</div>
+{% endblock %}
+
+{% block scripts_extra %}
+<script src="{% static 'core/js/cdl_head_dashboard.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace minimal CDL head dashboard with full core layout including KPI cards, profile block, notifications, charts, calendar, and assignment manager.
- Ensure template keeps base extension, static loading, and styling links for `dashboard.css` and `cdl_head_dashboard.css`.

## Testing
- `python manage.py test`
- `python manage.py shell -c "from django.contrib.auth.models import User;from django.test import Client;from django.conf import settings;settings.ALLOWED_HOSTS.append('testserver');User.objects.get_or_create(username='admin', defaults={'email':'admin@example.com','is_superuser':True,'is_staff':True});u=User.objects.get(username='admin');u.set_password('pass');u.save();c=Client();c.login(username='admin',password='pass');resp=c.get('/cdl/head/');print(resp.status_code);print('kpi-card' in resp.content.decode());print('cdl_head_dashboard.css' in resp.content.decode())"`

------
https://chatgpt.com/codex/tasks/task_e_68a23ad04a24832c9aadf61e2a7b0232