### PR TITLE
Handle missing EventProposal table in migration

### DIFF
--- a/core/migrations/0021_alter_roleassignment_organization_impersonationlog_and_more.py
+++ b/core/migrations/0021_alter_roleassignment_organization_impersonationlog_and_more.py
@@ -33,7 +33,19 @@ class Migration(migrations.Migration):
                 'ordering': ['-started_at'],
             },
         ),
-        migrations.DeleteModel(
-            name='EventProposal',
+        # `EventProposal` was removed previously. On some databases the
+        # table may already be absent, which would cause `DeleteModel` to
+        # fail. Dropping it conditionally keeps the migration idempotent
+        # and lets it run even if the table doesn't exist.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    "DROP TABLE IF EXISTS core_eventproposal",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+            state_operations=[
+                migrations.DeleteModel(name='EventProposal'),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary
- Make migration 0021 idempotent by conditionally dropping the legacy `core_eventproposal` table and removing it from migration state.

## Testing
- `python manage.py test core.tests.test_impersonation --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_68a2365e8d74832c8cb604532e6f1e40