### PR TITLE
Align event report activities container ID with JS

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1404,7 +1404,7 @@ function initializeSectionSpecificHandlers() {
 
 function setupDynamicActivities() {
     const numInput = document.getElementById('num-activities-modern');
-    const container = document.getElementById('proposal-activities');
+    const container = document.getElementById('report-activities');
     const addBtn = document.getElementById('add-activity-btn');
     if (!numInput || !container || !addBtn) return;
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -243,7 +243,7 @@
                         </div>
 
                         <!-- Pre-rendered activities from proposal -->
-                        <div id="proposal-activities" class="full-width">
+                        <div id="report-activities" class="full-width">
                             {% for act in proposal_activities %}
                             <div class="activity-row">
                                 <div class="input-group">


### PR DESCRIPTION
## Summary
- Use `report-activities` ID for the activities container in submit event report template.
- Update dynamic activities setup in JavaScript to query `report-activities` for proper initialization.

## Testing
- `python manage.py test emt`


------
https://chatgpt.com/codex/tasks/task_e_68a24ee0aba4832c8009988aec8859e3