### PR TITLE
Ensure blank activity row renders when none provided

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1414,6 +1414,11 @@ function setupDynamicActivities() {
         : [];
     let activities = [...initialActivities];
 
+    // Ensure at least one blank activity row exists on initial load
+    if (activities.length === 0) {
+        activities.push({ activity_name: '', activity_date: '' });
+    }
+
     function render() {
         container.innerHTML = '';
         activities.forEach((act, idx) => {


### PR DESCRIPTION
## Summary
- Default to a blank activity row when proposal has no activities
- Keep dynamic add/remove behavior intact for report activities

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a2590c2c20832c986425d5083cc5b5