### PR TITLE
Add Railway Postgres migration script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ OPENROUTER_API_KEY=__set_me__
 OPENROUTER_MODEL=qwen/qwen3-coder:free
 LOCAL_AI_BASE_URL=http://127.0.0.1:8000
 LOCAL_AI_MODEL=Qwen2.5-7B-Instruct-1M
+SOURCE_DATABASE_URL=postgres://username:password@old-host:5432/olddb
+TARGET_DATABASE_URL=postgres://username:password@new-host:5432/newdb

--- a/README.md
+++ b/README.md
@@ -345,3 +345,25 @@ py manage.py delete_academic_year 2025-2026
 ```
 
 Replace `2025-2026` with the year you want to delete.
+
+---
+
+## Railway PostgreSQL Migration
+
+Use the provided `migrate_railway_pg.sh` script to migrate data between two Railway-managed PostgreSQL databases.
+
+1. Copy the example environment file and fill in values from Railway's `DATABASE_URL` for both old and new databases:
+
+   ```bash
+   cp .env.example .env
+   # edit .env with your old + new DATABASE_URL
+   ```
+
+2. Run the migration:
+
+   ```bash
+   source .env
+   bash migrate_railway_pg.sh
+   ```
+
+Dependencies: `pg_dump`, `pg_restore`, `psql`.

--- a/migrate_railway_pg.sh
+++ b/migrate_railway_pg.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap 'echo "❌ Migration failed"; exit 1' ERR
+
+if [ ! -f .env ]; then
+  echo ".env file not found"
+  exit 1
+fi
+
+source .env
+
+: "${SOURCE_DATABASE_URL:?SOURCE_DATABASE_URL is required}"
+: "${TARGET_DATABASE_URL:?TARGET_DATABASE_URL is required}"
+
+echo "Dumping source database..."
+pg_dump "$SOURCE_DATABASE_URL" -Fc --no-owner --no-acl --if-exists -f backup.dump
+
+echo "Restoring into target database..."
+pg_restore -d "$TARGET_DATABASE_URL" --clean --if-exists --no-owner --no-acl backup.dump
+
+echo "✅ Migration successful"


### PR DESCRIPTION
## Summary
- add `migrate_railway_pg.sh` for migrating between Railway PostgreSQL databases
- document usage and placeholders for source/target DATABASE_URL in `.env.example`
- describe migration steps and dependencies in README

## Testing
- `bash -n migrate_railway_pg.sh`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a2b3b29a24832cbd8782f54bd12410