### PR TITLE
refactor: rely solely on env DB URL

### DIFF
--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -1,9 +1,14 @@
+from pathlib import Path
+import os
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except Exception:
+    pass
 import logging
 import dj_database_url
 
 # ---- .env loader (django-environ if available, else os.getenv) ----
-import os
-from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent  # ensure BASE_DIR is defined
 
@@ -139,17 +144,15 @@ WSGI_APPLICATION = 'iqac_project.wsgi.application'
 # DATABASE
 # ──────────────────────────────────────────────────────────────────────────────
 
-
-DATABASE_URL = os.getenv("DATABASE_URL", "")
-if DATABASE_URL:
-    DATABASES = {"default": dj_database_url.config(default=DATABASE_URL, conn_max_age=600)}
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
-        }
-    }
+DATABASES = {
+    "default": dj_database_url.config(
+        env="DATABASE_URL",
+        conn_max_age=600,
+        ssl_require=True,
+    )
+}
+if "railway.internal" in DATABASES["default"].get("HOST", ""):
+    raise RuntimeError("Invalid DB host — still pointing to Railway.")
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- load dotenv at startup so `.env` variables are available
- configure DATABASES exclusively from `DATABASE_URL` and require SSL
- raise an error if the DB host still points to `railway.internal`

## Testing
- `python manage.py test` *(fails: connection to server at "hopper.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a404e53ad4832c999e04f4d91b8c0b