### PR TITLE
Add attendance modal to event report form

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2631,6 +2631,43 @@ textarea {
     margin-right: 10px;
 }
 
+/* Attendance Modal */
+.attendance-modal {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.attendance-modal.show {
+    display: flex;
+}
+
+.attendance-modal .modal-content {
+    background: #ffffff;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 24px;
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.attendance-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.attendance-row input[type="text"] {
+    flex: 1;
+}
+
 /* Navigation States */
 .nav-link.completed {
     background: linear-gradient(135deg, #10b981 0%, #059669 100%);

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1553,9 +1553,58 @@ function setupDynamicActivities() {
     render();
 }
 
+function setupAttendanceModal() {
+    const participantInput = document.getElementById('num-participants-modern');
+    const volunteerInput = document.getElementById('num-volunteers-modern');
+    const modal = document.getElementById('attendanceModal');
+    const listContainer = document.getElementById('participantsList');
+    const saveBtn = document.getElementById('attendanceSave');
+    const cancelBtn = document.getElementById('attendanceCancel');
+    const notesField = document.getElementById('attendance-data');
+
+    if (!participantInput || !volunteerInput || !modal || !listContainer) return;
+
+    function openModal() {
+        const count = parseInt(participantInput.value, 10) || 0;
+        listContainer.innerHTML = '';
+        for (let i = 0; i < count; i++) {
+            const row = document.createElement('div');
+            row.className = 'attendance-row';
+            row.innerHTML = `
+                <input type="text" class="attendee-name" placeholder="Participant ${i + 1}">
+                <label><input type="checkbox" class="attendee-present" checked> Present</label>
+                <label><input type="checkbox" class="attendee-volunteer"> Volunteer</label>
+            `;
+            listContainer.appendChild(row);
+        }
+        modal.classList.add('show');
+    }
+
+    participantInput.addEventListener('change', openModal);
+    volunteerInput.addEventListener('change', openModal);
+
+    cancelBtn.addEventListener('click', () => modal.classList.remove('show'));
+
+    saveBtn.addEventListener('click', () => {
+        const data = [];
+        let volunteerCount = 0;
+        listContainer.querySelectorAll('.attendance-row').forEach(row => {
+            const name = row.querySelector('.attendee-name').value.trim();
+            const present = row.querySelector('.attendee-present').checked;
+            const volunteer = row.querySelector('.attendee-volunteer').checked;
+            if (volunteer) volunteerCount++;
+            data.push({ name, present, volunteer });
+        });
+        notesField.value = JSON.stringify(data);
+        volunteerInput.value = volunteerCount;
+        modal.classList.remove('show');
+    });
+}
+
 // Initialize section-specific handlers when document is ready
 $(document).ready(function() {
     initializeSectionSpecificHandlers();
     setupDynamicActivities();
+    setupAttendanceModal();
 });
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -97,6 +97,7 @@
             <textarea name="event_summary" hidden>{{ event_summary.content|default_if_none:'' }}</textarea>
             <textarea name="event_outcomes" hidden>{{ event_outcomes.content|default_if_none:'' }}</textarea>
             <textarea name="analysis" hidden>{{ analysis.content|default_if_none:'' }}</textarea>
+            <textarea name="attendance_notes" id="attendance-data" hidden>{{ form.attendance_notes.value|default:'' }}</textarea>
 
             <div class="form-panel" id="form-panel">
                 <div class="form-panel-content" id="form-panel-content">
@@ -294,6 +295,18 @@
         <div class="modal-actions" style="margin-top: 20px; text-align: center;">
             <button type="button" id="sdgCancel" class="btn-draft-section" style="margin-right: 10px;">Cancel</button>
             <button type="button" id="sdgSave" class="btn-save-section">Save Selection</button>
+        </div>
+    </div>
+</div>
+
+<!-- Attendance Modal -->
+<div id="attendanceModal" class="attendance-modal">
+    <div class="modal-content">
+        <h3>Mark Attendance</h3>
+        <div id="participantsList" class="attendance-list"></div>
+        <div class="modal-actions" style="margin-top: 20px; text-align: center;">
+            <button type="button" id="attendanceCancel" class="btn-draft-section" style="margin-right: 10px;">Cancel</button>
+            <button type="button" id="attendanceSave" class="btn-save-section">Save Attendance</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add hidden attendance_notes field and modal markup for event report form
- add JavaScript to generate attendance inputs and save volunteer counts
- add styling for new attendance modal

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a54eaec5d4832c8d453121af7ba9ce