### PR TITLE
feat: enhance attendance selection UI

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1554,51 +1554,327 @@ function setupDynamicActivities() {
 }
 
 function setupAttendanceModal() {
-    const participantInput = document.getElementById('num-participants-modern');
-    const volunteerInput = document.getElementById('num-volunteers-modern');
-    const modal = document.getElementById('attendanceModal');
-    const listContainer = document.getElementById('participantsList');
-    const saveBtn = document.getElementById('attendanceSave');
-    const cancelBtn = document.getElementById('attendanceCancel');
-    const notesField = document.getElementById('attendance-data');
+    const attendanceField = $('#attendance-modern');
+    const modal = $('#attendanceModal');
+    const notesField = $('#attendance-data');
+    const participantInput = $('#num-participants-modern');
+    const volunteerInput = $('#num-volunteers-modern');
 
-    if (!participantInput || !volunteerInput || !modal || !listContainer) return;
+    if (!attendanceField.length || !modal.length) return;
 
-    function openModal() {
-        const count = parseInt(participantInput.value, 10) || 0;
-        listContainer.innerHTML = '';
-        for (let i = 0; i < count; i++) {
-            const row = document.createElement('div');
-            row.className = 'attendance-row';
-            row.innerHTML = `
-                <input type="text" class="attendee-name" placeholder="Participant ${i + 1}">
-                <label><input type="checkbox" class="attendee-present" checked> Present</label>
-                <label><input type="checkbox" class="attendee-volunteer"> Volunteer</label>
-            `;
-            listContainer.appendChild(row);
+    // Populate field from existing data
+    if (notesField.val()) {
+        try {
+            const existing = JSON.parse(notesField.val());
+            attendanceField.val(existing.map(p => p.name).join(', '));
+            participantInput.val(existing.length);
+        } catch (e) {
+            // ignore
         }
-        modal.classList.add('show');
     }
 
-    participantInput.addEventListener('change', openModal);
-    volunteerInput.addEventListener('change', openModal);
+    attendanceField.prop('readonly', true).css('cursor', 'pointer');
+    $(document).off('click', '#attendance-modern').on('click', '#attendance-modern', openAttendanceModal);
+    $('#attendanceCancel').off('click').on('click', () => modal.removeClass('show'));
 
-    cancelBtn.addEventListener('click', () => modal.classList.remove('show'));
+    function openAttendanceModal() {
+        const container = $('#attendanceOptions');
+        modal.addClass('show');
+        $('#attendanceSave').hide();
 
-    saveBtn.addEventListener('click', () => {
-        const data = [];
-        let volunteerCount = 0;
-        listContainer.querySelectorAll('.attendance-row').forEach(row => {
-            const name = row.querySelector('.attendee-name').value.trim();
-            const present = row.querySelector('.attendee-present').checked;
-            const volunteer = row.querySelector('.attendee-volunteer').checked;
-            if (volunteer) volunteerCount++;
-            data.push({ name, present, volunteer });
+        let available = [];
+        let selected = [];
+        let userAvailable = [];
+        let userSelected = [];
+        let currentType = null;
+        let classStudentMap = {};
+        let departmentFacultyMap = {};
+
+        container.html(`
+            <div id="attendanceStep1">
+                <div class="audience-type-selector">
+                    <button type="button" data-type="students">Students</button>
+                    <button type="button" data-type="faculty">Faculty</button>
+                </div>
+                <div class="dual-list" id="attendanceGroupList" style="display:none;">
+                    <div class="dual-list-column">
+                        <input type="text" id="attendanceAvailableSearch" placeholder="Search available">
+                        <select id="attendanceAvailable" multiple></select>
+                    </div>
+                    <div class="dual-list-controls">
+                        <button type="button" id="attendanceAddAll">&raquo;</button>
+                        <button type="button" id="attendanceAdd">&gt;</button>
+                        <button type="button" id="attendanceRemove">&lt;</button>
+                        <button type="button" id="attendanceRemoveAll">&laquo;</button>
+                    </div>
+                    <div class="dual-list-column">
+                        <input type="text" id="attendanceSelectedSearch" placeholder="Search selected">
+                        <select id="attendanceSelected" multiple></select>
+                    </div>
+                </div>
+                <button type="button" id="attendanceContinue" class="btn-continue" style="display:none;">Continue</button>
+            </div>
+            <div id="attendanceStep2" style="display:none;">
+                <div class="dual-list user-list" id="attendeeUserList">
+                    <div class="dual-list-column">
+                        <input type="text" id="attendeeAvailableSearch" placeholder="Search available">
+                        <select id="attendeeAvailable" multiple></select>
+                    </div>
+                    <div class="dual-list-controls">
+                        <button type="button" id="attendeeAdd">&gt;</button>
+                        <button type="button" id="attendeeRemove">&lt;</button>
+                    </div>
+                    <div class="dual-list-column">
+                        <input type="text" id="attendeeSelectedSearch" placeholder="Search selected">
+                        <select id="attendeeSelected" multiple></select>
+                    </div>
+                </div>
+                <div class="audience-custom">
+                    <select id="attendanceCustomInput" placeholder="Add custom participant"></select>
+                </div>
+                <button type="button" id="attendanceBack" class="btn-continue">Back</button>
+            </div>
+        `);
+
+        const listContainer = container.find('#attendanceGroupList');
+        const availableSelect = container.find('#attendanceAvailable');
+        const selectedSelect = container.find('#attendanceSelected');
+        const userListContainer = container.find('#attendeeUserList');
+        const userAvailableSelect = container.find('#attendeeAvailable');
+        const userSelectedSelect = container.find('#attendeeSelected');
+        const step1 = container.find('#attendanceStep1');
+        const step2 = container.find('#attendanceStep2');
+        const continueBtn = container.find('#attendanceContinue');
+        const backBtn = container.find('#attendanceBack');
+
+        function filterOptions(input, select) {
+            const term = input.val().toLowerCase();
+            select.find('option').each(function() {
+                const txt = $(this).text().toLowerCase();
+                $(this).toggle(txt.includes(term));
+            });
+        }
+
+        function renderLists() {
+            availableSelect.empty();
+            selectedSelect.empty();
+            available.forEach(item => {
+                availableSelect.append($('<option>').val(item.id).text(item.name));
+            });
+            selected.forEach(item => {
+                selectedSelect.append($('<option>').val(item.id).text(item.name));
+            });
+            filterOptions($('#attendanceSelectedSearch'), selectedSelect);
+        }
+
+        function renderUserLists() {
+            userAvailableSelect.empty();
+            userSelectedSelect.empty();
+            userAvailable.forEach(u => {
+                userAvailableSelect.append($('<option>').val(u.id).text(u.name));
+            });
+            userSelected.forEach(u => {
+                userSelectedSelect.append($('<option>').val(u.id).text(u.name));
+            });
+            filterOptions($('#attendeeSelectedSearch'), userSelectedSelect);
+        }
+
+        function updateUserLists() {
+            userAvailable = [];
+            if (currentType === 'students') {
+                selected.forEach(cls => {
+                    (classStudentMap[cls.id] || []).forEach(stu => {
+                        if (!userSelected.some(u => u.id === `stu-${stu.id}`) &&
+                            !userAvailable.some(u => u.id === `stu-${stu.id}`)) {
+                            userAvailable.push({ id: `stu-${stu.id}`, name: stu.name });
+                        }
+                    });
+                });
+            } else if (currentType === 'faculty') {
+                selected.forEach(dept => {
+                    (departmentFacultyMap[dept.id] || []).forEach(fac => {
+                        if (!userSelected.some(u => u.id === `fac-${fac.id}`) &&
+                            !userAvailable.some(u => u.id === `fac-${fac.id}`)) {
+                            userAvailable.push({ id: `fac-${fac.id}`, name: fac.name });
+                        }
+                    });
+                });
+            }
+            renderUserLists();
+        }
+
+        function loadAvailable(term = '') {
+            available = [];
+            const orgId = window.PROPOSAL_ORG_ID;
+            const orgName = window.PROPOSAL_ORG_NAME;
+            if (!orgId) {
+                availableSelect.html('<option>No organization</option>');
+                return;
+            }
+            if (currentType === 'students') {
+                classStudentMap = {};
+                fetch(`${window.API_CLASSES_BASE}${orgId}/?q=${encodeURIComponent(term)}`, { credentials: 'include' })
+                    .then(r => r.json())
+                    .then(data => {
+                        if (data.success && data.classes.length) {
+                            data.classes.forEach(cls => {
+                                classStudentMap[String(cls.id)] = cls.students || [];
+                                available.push({ id: String(cls.id), name: cls.name });
+                            });
+                            renderLists();
+                        } else {
+                            availableSelect.html('<option>No classes</option>');
+                        }
+                    })
+                    .catch(() => {
+                        availableSelect.html('<option>Error loading</option>');
+                    });
+            } else if (currentType === 'faculty') {
+                departmentFacultyMap = {};
+                fetch(`${window.API_FACULTY}?org_id=${orgId}&q=${encodeURIComponent(term)}`, { credentials: 'include' })
+                    .then(r => r.json())
+                    .then(data => {
+                        data.forEach(f => {
+                            const dept = f.department || 'General';
+                            if (!departmentFacultyMap[dept]) departmentFacultyMap[dept] = [];
+                            departmentFacultyMap[dept].push({ id: f.id, name: f.name });
+                        });
+                        available = Object.keys(departmentFacultyMap).map(dept => ({ id: dept, name: dept }));
+                        available.sort((a, b) => a.name.localeCompare(b.name));
+                        renderLists();
+                    })
+                    .catch(() => {
+                        availableSelect.html('<option>Error loading</option>');
+                    });
+            }
+        }
+
+        container.find('button[data-type]').on('click', function() {
+            currentType = $(this).data('type');
+            available = [];
+            selected = [];
+            listContainer.show();
+            continueBtn.show();
+            step2.hide();
+            $('#attendanceSave').hide();
+            loadAvailable('');
         });
-        notesField.value = JSON.stringify(data);
-        volunteerInput.value = volunteerCount;
-        modal.classList.remove('show');
-    });
+
+        container.on('click', '#attendanceAdd', function() {
+            const ids = availableSelect.val() || [];
+            ids.forEach(id => {
+                const idx = available.findIndex(it => it.id === id);
+                if (idx > -1) {
+                    selected.push(available[idx]);
+                    available.splice(idx, 1);
+                }
+            });
+            renderLists();
+        });
+
+        container.on('click', '#attendanceAddAll', function() {
+            selected = selected.concat(available);
+            available = [];
+            renderLists();
+        });
+
+        container.on('click', '#attendanceRemove', function() {
+            const ids = selectedSelect.val() || [];
+            ids.forEach(id => {
+                const idx = selected.findIndex(it => it.id === id);
+                if (idx > -1) {
+                    available.push(selected[idx]);
+                    selected.splice(idx, 1);
+                }
+            });
+            renderLists();
+        });
+
+        container.on('click', '#attendanceRemoveAll', function() {
+            available = available.concat(selected);
+            selected = [];
+            renderLists();
+        });
+
+        continueBtn.on('click', function() {
+            updateUserLists();
+            step1.hide();
+            step2.show();
+            continueBtn.hide();
+            $('#attendanceSave').show();
+        });
+
+        backBtn.on('click', function() {
+            step2.hide();
+            step1.show();
+            continueBtn.show();
+            $('#attendanceSave').hide();
+        });
+
+        const customTS = new TomSelect('#attendanceCustomInput', {
+            persist: false,
+            create: true,
+            onItemAdd(value, text) {
+                userSelected.push({ id: `custom-${Date.now()}`, name: text });
+                customTS.clear();
+                renderUserLists();
+            }
+        });
+
+        container.on('input', '#attendanceAvailableSearch', function() {
+            const term = $(this).val().trim();
+            if (currentType) loadAvailable(term);
+        });
+
+        container.on('input', '#attendanceSelectedSearch', function() {
+            filterOptions($(this), selectedSelect);
+        });
+
+        container.on('click', '#attendeeAdd', function() {
+            const ids = userAvailableSelect.val() || [];
+            ids.forEach(id => {
+                const idx = userAvailable.findIndex(u => u.id === id);
+                if (idx > -1) {
+                    userSelected.push(userAvailable[idx]);
+                    userAvailable.splice(idx, 1);
+                }
+            });
+            renderUserLists();
+        });
+
+        container.on('click', '#attendeeRemove', function() {
+            const ids = userSelectedSelect.val() || [];
+            ids.forEach(id => {
+                const idx = userSelected.findIndex(u => u.id === id);
+                if (idx > -1) {
+                    userAvailable.push(userSelected[idx]);
+                    userSelected.splice(idx, 1);
+                }
+            });
+            renderUserLists();
+        });
+
+        container.on('input', '#attendeeAvailableSearch', function() {
+            const term = $(this).val().toLowerCase();
+            userAvailableSelect.find('option').each(function() {
+                const txt = $(this).text().toLowerCase();
+                $(this).toggle(txt.includes(term));
+            });
+        });
+
+        container.on('input', '#attendeeSelectedSearch', function() {
+            filterOptions($(this), userSelectedSelect);
+        });
+
+        $('#attendanceSave').off('click').on('click', () => {
+            const data = userSelected.map(u => ({ name: u.name }));
+            notesField.val(JSON.stringify(data)).trigger('change').trigger('input');
+            attendanceField.val(data.map(d => d.name).join(', ')).trigger('change').trigger('input');
+            participantInput.val(data.length).trigger('change').trigger('input');
+            volunteerInput.val(0).trigger('change').trigger('input');
+            modal.removeClass('show');
+        });
+    }
 }
 
 // Initialize section-specific handlers when document is ready

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -221,19 +221,13 @@
 
                         <div class="form-row">
                             <div class="input-group">
-                                <label for="num-participants-modern">Number of Participants</label>
-                                <input type="number" id="num-participants-modern" name="num_participants" value="{{ form.num_participants.value|default:'' }}" min="0" placeholder="Enter total participants">
-                                <div class="help-text">Total number of people who attended the event</div>
+                                <label for="attendance-modern">Attendance *</label>
+                                <input type="text" id="attendance-modern" readonly placeholder="Select participants">
+                                <input type="hidden" id="num-participants-modern" name="num_participants" value="{{ form.num_participants.value|default:'' }}">
+                                <input type="hidden" id="num-volunteers-modern" name="num_student_volunteers" value="{{ form.num_student_volunteers.value|default:'' }}">
+                                <div class="help-text">Select attendees; counts update automatically</div>
                                 {% if form.num_participants.errors %}
                                     <div class="field-error">{{ form.num_participants.errors.0 }}</div>
-                                {% endif %}
-                            </div>
-                            <div class="input-group">
-                                <label for="num-volunteers-modern">Number of Student Volunteers</label>
-                                <input type="number" id="num-volunteers-modern" name="num_student_volunteers" value="{{ form.num_student_volunteers.value|default:'' }}" min="0" placeholder="Enter volunteer count">
-                                <div class="help-text">Number of students who volunteered for the event</div>
-                                {% if form.num_student_volunteers.errors %}
-                                    <div class="field-error">{{ form.num_student_volunteers.errors.0 }}</div>
                                 {% endif %}
                             </div>
                         </div>
@@ -302,8 +296,8 @@
 <!-- Attendance Modal -->
 <div id="attendanceModal" class="attendance-modal">
     <div class="modal-content">
-        <h3>Mark Attendance</h3>
-        <div id="participantsList" class="attendance-list"></div>
+        <h3>Select Participants</h3>
+        <div id="attendanceOptions" class="attendance-options"></div>
         <div class="modal-actions" style="margin-top: 20px; text-align: center;">
             <button type="button" id="attendanceCancel" class="btn-draft-section" style="margin-right: 10px;">Cancel</button>
             <button type="button" id="attendanceSave" class="btn-save-section">Save Attendance</button>
@@ -331,7 +325,10 @@
         window.AUTOSAVE_URL = "#"; // TODO: Add autosave URL for reports
         window.AUTOSAVE_CSRF = "{{ csrf_token }}";
         window.API_ORGANIZATIONS = "#"; // TODO: Add API URLs
-        window.API_FACULTY = "#"; // TODO: Add API URLs
+        window.API_CLASSES_BASE = "{% url 'emt:api_classes' 0 %}".split('0/')[0];
+        window.API_FACULTY = "{% url 'emt:api_faculty' %}";
+        window.PROPOSAL_ORG_ID = "{{ proposal.organization.id|default:'' }}";
+        window.PROPOSAL_ORG_NAME = "{{ proposal.organization.name|default:'' }}";
         window.API_OUTCOMES_BASE = "#"; // TODO: Add API URLs
         window.SDG_GOALS = {{ sdg_goals_list|default:'[]'|safe }};
         window.PROPOSAL_ACTIVITIES = {{ proposal_activities_json|safe }};


### PR DESCRIPTION
## Summary
- replace participant and volunteer numeric inputs with interactive attendance selector
- add API config for event report and wire up dual-list participant modal
- implement attendee selection logic mirroring proposal target audience UI

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at yamanote.proxy.rlwy.net port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5530ea38c832ca90bdf32936a94a5