### PR TITLE
Add volunteer count field and unify attendance modal style

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2196,18 +2196,21 @@
 }
 
 /* Audience modal enhancements */
-#audienceModal .modal-content {
+#audienceModal .modal-content,
+#attendanceModal .modal-content {
     max-width: 800px;
     width: 95%;
 }
 
-#audienceModal .audience-type-selector {
+#audienceModal .audience-type-selector,
+#attendanceModal .audience-type-selector {
     display: flex;
     gap: 1rem;
     margin-bottom: 1rem;
 }
 
-#audienceModal .audience-type-selector button {
+#audienceModal .audience-type-selector button,
+#attendanceModal .audience-type-selector button {
     flex: 1;
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--border-color);
@@ -2216,18 +2219,21 @@
     cursor: pointer;
 }
 
-#audienceModal #audienceList {
+#audienceModal #audienceList,
+#attendanceModal #audienceList {
     max-height: 50vh;
     overflow-y: auto;
     margin-top: 1rem;
 }
 
-#audienceModal .audience-org-header {
+#audienceModal .audience-org-header,
+#attendanceModal .audience-org-header {
     font-weight: 600;
     margin-top: 1rem;
 }
 
-#audienceModal .btn-continue {
+#audienceModal .btn-continue,
+#attendanceModal .btn-continue {
     margin-top: 1rem;
     background: var(--primary-blue);
     color: #fff;
@@ -2237,63 +2243,74 @@
     cursor: pointer;
 }
 
-#audienceModal .btn-continue:hover {
+#audienceModal .btn-continue:hover,
+#attendanceModal .btn-continue:hover {
     background: var(--primary-blue-dark);
 }
 
-#audienceModal .audience-select-all {
+#audienceModal .audience-select-all,
+#attendanceModal .audience-select-all {
     display: block;
     margin-bottom: 0.5rem;
     font-weight: 500;
 }
 
-#audienceModal .dual-list {
+#audienceModal .dual-list,
+#attendanceModal .dual-list {
     display: flex;
     gap: 1rem;
     margin-top: 1rem;
     align-items: flex-start;
 }
 
-#audienceModal .dual-list-column {
+#audienceModal .dual-list-column,
+#attendanceModal .dual-list-column {
     display: flex;
     flex-direction: column;
 }
 
-#audienceModal .dual-list-column input[type="text"] {
+#audienceModal .dual-list-column input[type="text"],
+#attendanceModal .dual-list-column input[type="text"] {
     margin-bottom: 0.5rem;
     padding: 0.25rem 0.5rem;
 }
 
-#audienceModal .dual-list select {
+#audienceModal .dual-list select,
+#attendanceModal .dual-list select {
     width: 260px;
     min-height: 260px;
 }
 
-#audienceModal .dual-list-controls {
+#audienceModal .dual-list-controls,
+#attendanceModal .dual-list-controls {
     display: flex;
     flex-direction: column;
     justify-content: center;
     gap: 0.5rem;
 }
 
-#audienceModal .dual-list-controls button {
+#audienceModal .dual-list-controls button,
+#attendanceModal .dual-list-controls button {
     padding: 0.25rem 0.5rem;
     width: 2.5rem;
 }
 
-#audienceModal .audience-custom {
+#audienceModal .audience-custom,
+#attendanceModal .audience-custom {
     display: flex;
     gap: 0.5rem;
     margin-top: 1rem;
     align-items: center;
 }
 
-#audienceModal .audience-custom input {
+#audienceModal .audience-custom input,
+#attendanceModal .audience-custom input {
     flex: 1;
     padding: 0.5rem;
 }
 
-#audienceModal .audience-custom button {
+#audienceModal .audience-custom button,
+#attendanceModal .audience-custom button {
     padding: 0.5rem 1rem;
 }
 

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1871,7 +1871,8 @@ function setupAttendanceModal() {
             notesField.val(JSON.stringify(data)).trigger('change').trigger('input');
             attendanceField.val(data.map(d => d.name).join(', ')).trigger('change').trigger('input');
             participantInput.val(data.length).trigger('change').trigger('input');
-            volunteerInput.val(0).trigger('change').trigger('input');
+            const volunteers = parseInt(volunteerInput.val(), 10) || 0;
+            volunteerInput.val(volunteers).trigger('change').trigger('input');
             modal.removeClass('show');
         });
     }

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -224,10 +224,16 @@
                                 <label for="attendance-modern">Attendance *</label>
                                 <input type="text" id="attendance-modern" readonly placeholder="Select participants">
                                 <input type="hidden" id="num-participants-modern" name="num_participants" value="{{ form.num_participants.value|default:'' }}">
-                                <input type="hidden" id="num-volunteers-modern" name="num_student_volunteers" value="{{ form.num_student_volunteers.value|default:'' }}">
                                 <div class="help-text">Select attendees; counts update automatically</div>
                                 {% if form.num_participants.errors %}
                                     <div class="field-error">{{ form.num_participants.errors.0 }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="input-group">
+                                <label for="num-volunteers-modern">Number of student volunteers</label>
+                                <input type="number" id="num-volunteers-modern" name="num_student_volunteers" value="{{ form.num_student_volunteers.value|default:'' }}" min="0" placeholder="Enter number of volunteers">
+                                {% if form.num_student_volunteers.errors %}
+                                    <div class="field-error">{{ form.num_student_volunteers.errors.0 }}</div>
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Style the attendance modal with the same dual-list and button styles as the audience modal
- Expose `num_student_volunteers` as a numeric input alongside attendance
- Sync volunteer count in attendance modal save handler

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5578c3e08832c8d8f5dfa617d4a84