### PR TITLE
Add audience CSV export for attendance and volunteers

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -224,7 +224,7 @@
                                 <label for="attendance-modern">Attendance *</label>
                                 <input type="text" id="attendance-modern" readonly placeholder="Select participants">
                                 <input type="hidden" id="num-participants-modern" name="num_participants" value="{{ form.num_participants.value|default:'' }}">
-                                <div class="help-text">Select attendees; counts update automatically</div>
+                                <div class="help-text">Select attendees; counts update automatically. <a href="{% url 'emt:download_audience_csv' proposal.id %}">Download CSV</a></div>
                                 {% if form.num_participants.errors %}
                                     <div class="field-error">{{ form.num_participants.errors.0 }}</div>
                                 {% endif %}
@@ -232,6 +232,7 @@
                             <div class="input-group">
                                 <label for="num-volunteers-modern">Number of student volunteers</label>
                                 <input type="number" id="num-volunteers-modern" name="num_student_volunteers" value="{{ form.num_student_volunteers.value|default:'' }}" min="0" placeholder="Enter number of volunteers">
+                                <div class="help-text"><a href="{% url 'emt:download_audience_csv' proposal.id %}">Download CSV</a></div>
                                 {% if form.num_student_volunteers.errors %}
                                     <div class="field-error">{{ form.num_student_volunteers.errors.0 }}</div>
                                 {% endif %}

--- a/emt/tests/test_audience_csv.py
+++ b/emt/tests/test_audience_csv.py
@@ -1,0 +1,43 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.db.models.signals import post_save
+from django.contrib.auth.signals import user_logged_in
+
+from core.signals import create_or_update_user_profile, assign_role_on_login
+
+from emt.models import EventProposal
+
+
+class AudienceCSVViewTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client.force_login(self.user)
+        self.proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Sample Event",
+            target_audience="Bob, Carol",
+        )
+
+    def test_download_audience_csv(self):
+        url = reverse("emt:download_audience_csv", args=[self.proposal.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        content = response.content.decode()
+        self.assertIn("Name,Absent,Student Volunteer", content)
+        self.assertIn("Bob", content)
+        self.assertIn("Carol", content)
+

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('report-success/<int:proposal_id>/', views.report_success, name='report_success'),
     path('download/pdf/<int:proposal_id>/', views.download_pdf, name='download_pdf'),
     path('download/word/<int:proposal_id>/', views.download_word, name='download_word'),
+    path('download/audience-csv/<int:proposal_id>/', views.download_audience_csv, name='download_audience_csv'),
     path('generated-reports/', views.generated_reports, name='generated_reports'),
     path('view-report/<int:report_id>/', views.view_report, name='view_report'),
 


### PR DESCRIPTION
## Summary
- add endpoint to download proposal audience as CSV for marking absentees and student volunteers
- link CSV download from attendance and student volunteer fields
- test CSV export view

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5648c7a10832c91e59e93309cebda