### PR TITLE
Enhance attendance CSV with registration details

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1568,6 +1568,11 @@ function setupAttendanceModal() {
             const existing = JSON.parse(notesField.val());
             attendanceField.val(existing.map(p => p.name).join(', '));
             participantInput.val(existing.length);
+            const volunteerCount = existing.filter(p => {
+                const val = String(p.student_volunteer || "").toLowerCase();
+                return ["yes", "true", "1", "y"].includes(val);
+            }).length;
+            volunteerInput.val(volunteerCount).trigger('change').trigger('input');
         } catch (e) {
             // ignore
         }
@@ -1885,12 +1890,15 @@ function setupAttendanceModal() {
         });
 
         $('#attendanceSave').off('click').on('click', () => {
-            const data = userSelected.map(u => ({ name: u.name }));
+            const data = userSelected.map(u => ({ name: u.name, student_volunteer: u.student_volunteer }));
             notesField.val(JSON.stringify(data)).trigger('change').trigger('input');
             attendanceField.val(data.map(d => d.name).join(', ')).trigger('change').trigger('input');
             participantInput.val(data.length).trigger('change').trigger('input');
-            const volunteers = parseInt(volunteerInput.val(), 10) || 0;
-            volunteerInput.val(volunteers).trigger('change').trigger('input');
+            const volunteerCount = data.filter(d => {
+                const val = String(d.student_volunteer || "").toLowerCase();
+                return ["yes", "true", "1", "y"].includes(val);
+            }).length;
+            volunteerInput.val(volunteerCount).trigger('change').trigger('input');
             modal.removeClass('show');
         });
     }

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -232,7 +232,7 @@
                             <div class="input-group">
                                 <label for="num-volunteers-modern">Number of student volunteers</label>
                                 <input type="number" id="num-volunteers-modern" name="num_student_volunteers" value="{{ form.num_student_volunteers.value|default:'' }}" min="0" placeholder="Enter number of volunteers">
-                                <div class="help-text"><a href="{% url 'emt:download_audience_csv' proposal.id %}">Download CSV</a></div>
+                                <div class="help-text">Automatically calculated from attendance CSV</div>
                                 {% if form.num_student_volunteers.errors %}
                                     <div class="field-error">{{ form.num_student_volunteers.errors.0 }}</div>
                                 {% endif %}

--- a/emt/tests/test_audience_csv.py
+++ b/emt/tests/test_audience_csv.py
@@ -37,7 +37,10 @@ class AudienceCSVViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
         content = response.content.decode()
-        self.assertIn("Name,Absent,Student Volunteer", content)
+        self.assertIn(
+            "Reg No/Emp No,Full Name,Class,Absent,Student Volunteer",
+            content,
+        )
         self.assertIn("Bob", content)
         self.assertIn("Carol", content)
 

--- a/emt/views.py
+++ b/emt/views.py
@@ -1590,9 +1590,15 @@ def download_audience_csv(request, proposal_id):
     )
 
     writer = csv.writer(response)
-    writer.writerow(["Name", "Absent", "Student Volunteer"])
+    writer.writerow([
+        "Reg No/Emp No",
+        "Full Name",
+        "Class",
+        "Absent",
+        "Student Volunteer",
+    ])
     for name in names:
-        writer.writerow([name, "", ""])
+        writer.writerow(["", name, "", "", ""])
 
     logger.info("Generated audience CSV for proposal %s", proposal_id)
     return response


### PR DESCRIPTION
## Summary
- add registration, class, and volunteer columns to generated attendance CSV
- auto-fill volunteer count from uploaded attendance data
- update templates and tests accordingly

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a567074384832c8d2ef10def425761