### PR TITLE
Split audience CSV and attendance modal

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1562,347 +1562,114 @@ function setupAttendanceModal() {
 
     if (!attendanceField.length || !modal.length) return;
 
-    // Populate field from existing data
+    let participants = [];
+
     if (notesField.val()) {
         try {
-            const existing = JSON.parse(notesField.val());
-            attendanceField.val(existing.map(p => p.name).join(', '));
-            participantInput.val(existing.length);
-            const volunteerCount = existing.filter(p => {
-                const val = String(p.student_volunteer || "").toLowerCase();
-                return ["yes", "true", "1", "y"].includes(val);
-            }).length;
+            participants = JSON.parse(notesField.val());
+            const present = participants.filter(p => !p.absent);
+            attendanceField.val(present.map(p => p.name).join(', '));
+            participantInput.val(present.length);
+            const volunteerCount = present.filter(p => p.student_volunteer).length;
             volunteerInput.val(volunteerCount).trigger('change').trigger('input');
         } catch (e) {
-            // ignore
+            participants = [];
         }
     }
 
     attendanceField.prop('readonly', true).css('cursor', 'pointer');
-    $(document).off('click', '#attendance-modern').on('click', '#attendance-modern', openAttendanceModal);
+    $(document).off('click', '#attendance-modern').on('click', '#attendance-modern', () => {
+        renderList();
+        modal.addClass('show');
+    });
     $('#attendanceCancel').off('click').on('click', () => modal.removeClass('show'));
 
-    function openAttendanceModal() {
-        const container = $('#attendanceOptions');
-        modal.addClass('show');
-        $('#attendanceSave').hide();
-
-        let available = [];
-        let selected = [];
-        let userAvailable = [];
-        let userSelected = [];
-        let currentType = null;
-        let classStudentMap = {};
-        let departmentFacultyMap = {};
-
-        container.html(`
-            <div id="attendanceStep1">
-                <div class="audience-type-selector">
-                    <button type="button" data-type="students">Students</button>
-                    <button type="button" data-type="faculty">Faculty</button>
-                </div>
-                <div class="dual-list" id="attendanceGroupList" style="display:none;">
-                    <div class="dual-list-column">
-                        <input type="text" id="attendanceAvailableSearch" placeholder="Search available">
-                        <select id="attendanceAvailable" multiple></select>
-                    </div>
-                    <div class="dual-list-controls">
-                        <button type="button" id="attendanceAddAll">&raquo;</button>
-                        <button type="button" id="attendanceAdd">&gt;</button>
-                        <button type="button" id="attendanceRemove">&lt;</button>
-                        <button type="button" id="attendanceRemoveAll">&laquo;</button>
-                    </div>
-                    <div class="dual-list-column">
-                        <input type="text" id="attendanceSelectedSearch" placeholder="Search selected">
-                        <select id="attendanceSelected" multiple></select>
-                    </div>
-                </div>
-                <button type="button" id="attendanceContinue" class="btn-continue" style="display:none;">Continue</button>
-            </div>
-            <div id="attendanceStep2" style="display:none;">
-                <div class="dual-list user-list" id="attendeeUserList">
-                    <div class="dual-list-column">
-                        <input type="text" id="attendeeAvailableSearch" placeholder="Search available">
-                        <select id="attendeeAvailable" multiple></select>
-                    </div>
-                    <div class="dual-list-controls">
-                        <button type="button" id="attendeeAdd">&gt;</button>
-                        <button type="button" id="attendeeRemove">&lt;</button>
-                    </div>
-                    <div class="dual-list-column">
-                        <input type="text" id="attendeeSelectedSearch" placeholder="Search selected">
-                        <select id="attendeeSelected" multiple></select>
-                    </div>
-                </div>
-                <div class="audience-custom">
-                    <select id="attendanceCustomInput" placeholder="Add custom participant"></select>
-                </div>
-                <button type="button" id="attendanceBack" class="btn-continue">Back</button>
-            </div>
-        `);
-
-        const listContainer = container.find('#attendanceGroupList');
-        const availableSelect = container.find('#attendanceAvailable');
-        const selectedSelect = container.find('#attendanceSelected');
-        const userListContainer = container.find('#attendeeUserList');
-        const userAvailableSelect = container.find('#attendeeAvailable');
-        const userSelectedSelect = container.find('#attendeeSelected');
-        const step1 = container.find('#attendanceStep1');
-        const step2 = container.find('#attendanceStep2');
-        const continueBtn = container.find('#attendanceContinue');
-        const backBtn = container.find('#attendanceBack');
-
-        // Prepopulate available users from proposal's target audience
-        const initialAudience = (window.PROPOSAL_DATA && window.PROPOSAL_DATA.target_audience)
-            ? window.PROPOSAL_DATA.target_audience.split(',').map(n => n.trim()).filter(Boolean)
-            : [];
-        initialAudience.forEach((name, idx) => {
-            userAvailable.push({ id: `custom-pre-${idx}`, name });
-        });
-
-        function filterOptions(input, select) {
-            const term = input.val().toLowerCase();
-            select.find('option').each(function() {
-                const txt = $(this).text().toLowerCase();
-                $(this).toggle(txt.includes(term));
-            });
-        }
-
-        function renderLists() {
-            availableSelect.empty();
-            selectedSelect.empty();
-            available.forEach(item => {
-                availableSelect.append($('<option>').val(item.id).text(item.name));
-            });
-            selected.forEach(item => {
-                selectedSelect.append($('<option>').val(item.id).text(item.name));
-            });
-            filterOptions($('#attendanceSelectedSearch'), selectedSelect);
-        }
-
-        function renderUserLists() {
-            userAvailableSelect.empty();
-            userSelectedSelect.empty();
-            userAvailable.forEach(u => {
-                userAvailableSelect.append($('<option>').val(u.id).text(u.name));
-            });
-            userSelected.forEach(u => {
-                userSelectedSelect.append($('<option>').val(u.id).text(u.name));
-            });
-            filterOptions($('#attendeeSelectedSearch'), userSelectedSelect);
-        }
-
-        // Show step2 immediately if proposal has predefined audience
-        if (initialAudience.length) {
-            renderUserLists();
-            step1.hide();
-            step2.show();
-            continueBtn.hide();
-            $('#attendanceSave').show();
-        }
-
-        function updateUserLists() {
-            // Preserve custom entries (predefined audience or manually added)
-            userAvailable = userAvailable.filter(u => u.id.startsWith('custom-'));
-            if (currentType === 'students') {
-                selected.forEach(cls => {
-                    (classStudentMap[cls.id] || []).forEach(stu => {
-                        if (!userSelected.some(u => u.id === `stu-${stu.id}`) &&
-                            !userAvailable.some(u => u.id === `stu-${stu.id}`)) {
-                            userAvailable.push({ id: `stu-${stu.id}`, name: stu.name });
-                        }
-                    });
-                });
-            } else if (currentType === 'faculty') {
-                selected.forEach(dept => {
-                    (departmentFacultyMap[dept.id] || []).forEach(fac => {
-                        if (!userSelected.some(u => u.id === `fac-${fac.id}`) &&
-                            !userAvailable.some(u => u.id === `fac-${fac.id}`)) {
-                            userAvailable.push({ id: `fac-${fac.id}`, name: fac.name });
-                        }
-                    });
-                });
-            }
-            renderUserLists();
-        }
-
-        function loadAvailable(term = '') {
-            available = [];
-            const orgId = window.PROPOSAL_ORG_ID;
-            const orgName = window.PROPOSAL_ORG_NAME;
-            if (!orgId) {
-                availableSelect.html('<option>No organization</option>');
-                return;
-            }
-            if (currentType === 'students') {
-                classStudentMap = {};
-                fetch(`${window.API_CLASSES_BASE}${orgId}/?q=${encodeURIComponent(term)}`, { credentials: 'include' })
-                    .then(r => r.json())
-                    .then(data => {
-                        if (data.success && data.classes.length) {
-                            data.classes.forEach(cls => {
-                                classStudentMap[String(cls.id)] = cls.students || [];
-                                available.push({ id: String(cls.id), name: cls.name });
-                            });
-                            renderLists();
-                        } else {
-                            availableSelect.html('<option>No classes</option>');
-                        }
-                    })
-                    .catch(() => {
-                        availableSelect.html('<option>Error loading</option>');
-                    });
-            } else if (currentType === 'faculty') {
-                departmentFacultyMap = {};
-                fetch(`${window.API_FACULTY}?org_id=${orgId}&q=${encodeURIComponent(term)}`, { credentials: 'include' })
-                    .then(r => r.json())
-                    .then(data => {
-                        data.forEach(f => {
-                            const dept = f.department || 'General';
-                            if (!departmentFacultyMap[dept]) departmentFacultyMap[dept] = [];
-                            departmentFacultyMap[dept].push({ id: f.id, name: f.name });
-                        });
-                        available = Object.keys(departmentFacultyMap).map(dept => ({ id: dept, name: dept }));
-                        available.sort((a, b) => a.name.localeCompare(b.name));
-                        renderLists();
-                    })
-                    .catch(() => {
-                        availableSelect.html('<option>Error loading</option>');
-                    });
-            }
-        }
-
-        container.find('button[data-type]').on('click', function() {
-            currentType = $(this).data('type');
-            available = [];
-            selected = [];
-            listContainer.show();
-            continueBtn.show();
-            step2.hide();
-            $('#attendanceSave').hide();
-            loadAvailable('');
-        });
-
-        container.on('click', '#attendanceAdd', function() {
-            const ids = availableSelect.val() || [];
-            ids.forEach(id => {
-                const idx = available.findIndex(it => it.id === id);
-                if (idx > -1) {
-                    selected.push(available[idx]);
-                    available.splice(idx, 1);
-                }
-            });
-            renderLists();
-        });
-
-        container.on('click', '#attendanceAddAll', function() {
-            selected = selected.concat(available);
-            available = [];
-            renderLists();
-        });
-
-        container.on('click', '#attendanceRemove', function() {
-            const ids = selectedSelect.val() || [];
-            ids.forEach(id => {
-                const idx = selected.findIndex(it => it.id === id);
-                if (idx > -1) {
-                    available.push(selected[idx]);
-                    selected.splice(idx, 1);
-                }
-            });
-            renderLists();
-        });
-
-        container.on('click', '#attendanceRemoveAll', function() {
-            available = available.concat(selected);
-            selected = [];
-            renderLists();
-        });
-
-        continueBtn.on('click', function() {
-            updateUserLists();
-            step1.hide();
-            step2.show();
-            continueBtn.hide();
-            $('#attendanceSave').show();
-        });
-
-        backBtn.on('click', function() {
-            step2.hide();
-            step1.show();
-            continueBtn.show();
-            $('#attendanceSave').hide();
-        });
-
-        const customTS = new TomSelect('#attendanceCustomInput', {
-            persist: false,
-            create: true,
-            onItemAdd(value, text) {
-                userSelected.push({ id: `custom-${Date.now()}`, name: text });
-                customTS.clear();
-                renderUserLists();
-            }
-        });
-
-        container.on('input', '#attendanceAvailableSearch', function() {
-            const term = $(this).val().trim();
-            if (currentType) loadAvailable(term);
-        });
-
-        container.on('input', '#attendanceSelectedSearch', function() {
-            filterOptions($(this), selectedSelect);
-        });
-
-        container.on('click', '#attendeeAdd', function() {
-            const ids = userAvailableSelect.val() || [];
-            ids.forEach(id => {
-                const idx = userAvailable.findIndex(u => u.id === id);
-                if (idx > -1) {
-                    userSelected.push(userAvailable[idx]);
-                    userAvailable.splice(idx, 1);
-                }
-            });
-            renderUserLists();
-        });
-
-        container.on('click', '#attendeeRemove', function() {
-            const ids = userSelectedSelect.val() || [];
-            ids.forEach(id => {
-                const idx = userSelected.findIndex(u => u.id === id);
-                if (idx > -1) {
-                    userAvailable.push(userSelected[idx]);
-                    userSelected.splice(idx, 1);
-                }
-            });
-            renderUserLists();
-        });
-
-        container.on('input', '#attendeeAvailableSearch', function() {
-            const term = $(this).val().toLowerCase();
-            userAvailableSelect.find('option').each(function() {
-                const txt = $(this).text().toLowerCase();
-                $(this).toggle(txt.includes(term));
-            });
-        });
-
-        container.on('input', '#attendeeSelectedSearch', function() {
-            filterOptions($(this), userSelectedSelect);
-        });
-
-        $('#attendanceSave').off('click').on('click', () => {
-            const data = userSelected.map(u => ({ name: u.name, student_volunteer: u.student_volunteer }));
-            notesField.val(JSON.stringify(data)).trigger('change').trigger('input');
-            attendanceField.val(data.map(d => d.name).join(', ')).trigger('change').trigger('input');
-            participantInput.val(data.length).trigger('change').trigger('input');
-            const volunteerCount = data.filter(d => {
-                const val = String(d.student_volunteer || "").toLowerCase();
-                return ["yes", "true", "1", "y"].includes(val);
-            }).length;
-            volunteerInput.val(volunteerCount).trigger('change').trigger('input');
-            modal.removeClass('show');
-        });
+    function toBool(val) {
+        const v = String(val || '').trim().toLowerCase();
+        return ['yes', 'true', '1', 'y'].includes(v);
     }
+
+    function parseCSV(text) {
+        return text.trim().split(/\r?\n/).slice(1).map(line => line.split(','));
+    }
+
+    function handleFile(file, type) {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = e => {
+            const rows = parseCSV(e.target.result);
+            rows.forEach(row => {
+                const obj = {
+                    number: row[0] || '',
+                    name: row[1] || '',
+                    class_or_dept: row[2] || '',
+                    absent: toBool(row[3]),
+                    student_volunteer: toBool(row[4]),
+                    type
+                };
+                participants.push(obj);
+                if (type === 'faculty' && !obj.class_or_dept && obj.number) {
+                    fetch(`${window.API_FACULTY}?org_id=${window.PROPOSAL_ORG_ID}&q=${encodeURIComponent(obj.number)}`, { credentials: 'include' })
+                        .then(r => r.json())
+                        .then(data => {
+                            if (data.length) {
+                                obj.class_or_dept = data[0].department || '';
+                                renderList();
+                            }
+                        })
+                        .catch(() => {});
+                }
+            });
+            renderList();
+        };
+        reader.readAsText(file);
+    }
+
+    $('#studentCsv').off('change').on('change', function() {
+        handleFile(this.files[0], 'student');
+        this.value = '';
+    });
+    $('#facultyCsv').off('change').on('change', function() {
+        handleFile(this.files[0], 'faculty');
+        this.value = '';
+    });
+
+    function renderList() {
+        const list = $('#attendanceList');
+        if (!participants.length) {
+            list.html('<p>No participants loaded.</p>');
+            return;
+        }
+        let html = '<table class="attendance-table"><thead><tr><th>Name</th><th>Reg/Emp No</th><th>Class/Dept</th><th>Absent</th><th>Student Volunteer</th></tr></thead><tbody>';
+        participants.forEach((p, i) => {
+            html += `<tr><td>${p.name}</td><td>${p.number || ''}</td><td>${p.class_or_dept || ''}</td>` +
+                    `<td><input type="checkbox" class="absent-toggle" data-index="${i}" ${p.absent ? 'checked' : ''}></td>` +
+                    `<td><input type="checkbox" class="volunteer-toggle" data-index="${i}" ${p.student_volunteer ? 'checked' : ''}></td></tr>`;
+        });
+        html += '</tbody></table>';
+        list.html(html);
+    }
+
+    $('#attendanceList').on('change', '.absent-toggle', function() {
+        const idx = $(this).data('index');
+        participants[idx].absent = this.checked;
+    });
+    $('#attendanceList').on('change', '.volunteer-toggle', function() {
+        const idx = $(this).data('index');
+        participants[idx].student_volunteer = this.checked;
+    });
+
+    $('#attendanceSave').off('click').on('click', () => {
+        notesField.val(JSON.stringify(participants)).trigger('change').trigger('input');
+        const present = participants.filter(p => !p.absent);
+        attendanceField.val(present.map(p => p.name).join(', ')).trigger('change').trigger('input');
+        participantInput.val(present.length).trigger('change').trigger('input');
+        const volunteerCount = present.filter(p => p.student_volunteer).length;
+        volunteerInput.val(volunteerCount).trigger('change').trigger('input');
+        modal.removeClass('show');
+    });
 }
+
 
 // Initialize section-specific handlers when document is ready
 $(document).ready(function() {

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -224,7 +224,7 @@
                                 <label for="attendance-modern">Attendance *</label>
                                 <input type="text" id="attendance-modern" readonly placeholder="Select participants">
                                 <input type="hidden" id="num-participants-modern" name="num_participants" value="{{ form.num_participants.value|default:'' }}">
-                                <div class="help-text">Select attendees; counts update automatically. <a href="{% url 'emt:download_audience_csv' proposal.id %}">Download CSV</a></div>
+                                <div class="help-text">Select attendees; counts update automatically. <a href="{% url 'emt:download_audience_csv' proposal.id %}?type=students">Student CSV</a> | <a href="{% url 'emt:download_audience_csv' proposal.id %}?type=faculty">Faculty CSV</a></div>
                                 {% if form.num_participants.errors %}
                                     <div class="field-error">{{ form.num_participants.errors.0 }}</div>
                                 {% endif %}
@@ -303,8 +303,12 @@
 <!-- Attendance Modal -->
 <div id="attendanceModal" class="attendance-modal">
     <div class="modal-content">
-        <h3>Select Participants</h3>
-        <div id="attendanceOptions" class="attendance-options"></div>
+        <h3>Upload Attendance</h3>
+        <div class="upload-row" style="margin-bottom: 15px;">
+            <label>Student CSV <input type="file" id="studentCsv" accept=".csv"></label>
+            <label style="margin-left:10px;">Faculty CSV <input type="file" id="facultyCsv" accept=".csv"></label>
+        </div>
+        <div id="attendanceList" class="attendance-options"></div>
         <div class="modal-actions" style="margin-top: 20px; text-align: center;">
             <button type="button" id="attendanceCancel" class="btn-draft-section" style="margin-right: 10px;">Cancel</button>
             <button type="button" id="attendanceSave" class="btn-save-section">Save Attendance</button>

--- a/emt/tests/test_audience_csv.py
+++ b/emt/tests/test_audience_csv.py
@@ -3,10 +3,12 @@ from django.test import TestCase
 from django.urls import reverse
 from django.db.models.signals import post_save
 from django.contrib.auth.signals import user_logged_in
+import json
 
 from core.signals import create_or_update_user_profile, assign_role_on_login
+from core.models import OrganizationType, Organization, OrganizationRole, RoleAssignment
 
-from emt.models import EventProposal
+from emt.models import EventProposal, EventReport
 
 
 class AudienceCSVViewTests(TestCase):
@@ -31,16 +33,78 @@ class AudienceCSVViewTests(TestCase):
             target_audience="Bob, Carol",
         )
 
-    def test_download_audience_csv(self):
-        url = reverse("emt:download_audience_csv", args=[self.proposal.id])
+    def test_download_student_audience_csv(self):
+        url = reverse("emt:download_audience_csv", args=[self.proposal.id]) + "?type=students"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
         content = response.content.decode()
         self.assertIn(
-            "Reg No/Emp No,Full Name,Class,Absent,Student Volunteer",
+            "Registration No,Full Name,Class,Absent,Student Volunteer",
             content,
         )
         self.assertIn("Bob", content)
         self.assertIn("Carol", content)
+
+    def test_download_faculty_audience_csv(self):
+        url = reverse("emt:download_audience_csv", args=[self.proposal.id]) + "?type=faculty"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn(
+            "Employee No,Full Name,Department,Absent,Student Volunteer",
+            content,
+        )
+
+    def test_api_faculty_returns_department(self):
+        dept_type = OrganizationType.objects.create(name="Department")
+        dept = Organization.objects.create(name="CSE", org_type=dept_type)
+        role = OrganizationRole.objects.create(organization=dept, name="Faculty")
+        faculty = User.objects.create_user(username="fac1", password="pass", first_name="John")
+        RoleAssignment.objects.create(user=faculty, role=role, organization=dept)
+        url = reverse("emt:api_faculty") + f"?org_id={dept.id}&q=fac1"
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data[0]["department"], "CSE")
+
+    def test_attendance_selection_saved(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        notes = [
+            {
+                "number": "R1",
+                "name": "Bob",
+                "class_or_dept": "CSE",
+                "absent": False,
+                "student_volunteer": True,
+            },
+            {
+                "number": "R2",
+                "name": "Carol",
+                "class_or_dept": "CSE",
+                "absent": True,
+                "student_volunteer": False,
+            },
+        ]
+        data = {
+            "actual_event_type": "Seminar",
+            "report_signed_date": "2024-01-10",
+            "num_activities": "0",
+            "num_participants": "1",
+            "num_student_volunteers": "1",
+            "attendance_notes": json.dumps(notes),
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        report = EventReport.objects.get(proposal=self.proposal)
+        saved = json.loads(report.attendance_notes)
+        self.assertEqual(len(saved), 2)
+        self.assertTrue(saved[0]["student_volunteer"])
+        self.assertTrue(saved[1]["absent"])
+        self.assertEqual(report.num_student_volunteers, 1)
+        self.assertEqual(report.num_participants, 1)
 

--- a/emt/views.py
+++ b/emt/views.py
@@ -1578,29 +1578,43 @@ def submit_event_report(request, proposal_id):
 
 @login_required
 def download_audience_csv(request, proposal_id):
-    """Provide a CSV template of proposal audience for marking attendance and volunteers."""
+    """Provide CSV templates for marking attendance separately for students and faculty."""
     proposal = get_object_or_404(
         EventProposal, id=proposal_id, submitted_by=request.user
     )
+
+    audience_type = request.GET.get("type", "students").lower()
     names = [n.strip() for n in proposal.target_audience.split(',') if n.strip()]
 
     response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = (
-        f'attachment; filename="audience_{proposal_id}.csv"'
-    )
+    if audience_type == "faculty":
+        filename = f"faculty_audience_{proposal_id}.csv"
+        headers = [
+            "Employee No",
+            "Full Name",
+            "Department",
+            "Absent",
+            "Student Volunteer",
+        ]
+    else:
+        filename = f"student_audience_{proposal_id}.csv"
+        headers = [
+            "Registration No",
+            "Full Name",
+            "Class",
+            "Absent",
+            "Student Volunteer",
+        ]
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
     writer = csv.writer(response)
-    writer.writerow([
-        "Reg No/Emp No",
-        "Full Name",
-        "Class",
-        "Absent",
-        "Student Volunteer",
-    ])
+    writer.writerow(headers)
     for name in names:
         writer.writerow(["", name, "", "", ""])
 
-    logger.info("Generated audience CSV for proposal %s", proposal_id)
+    logger.info(
+        "Generated %s audience CSV for proposal %s", audience_type, proposal_id
+    )
     return response
 
 @login_required


### PR DESCRIPTION
## Summary
- Support separate student and faculty audience CSV templates including department column
- Replace attendance modal with checkbox-driven upload parsing for student and faculty CSVs
- Cover split CSV generation and attendance handling in tests

## Testing
- `python manage.py test` *(failed: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a56c7f73b4832c8f3006aca07b45a4