### PR TITLE
Improve attendance CSV handling and UI parsing

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -361,5 +361,6 @@
             sdg_goals: "{{ proposal.sdg_goals|default:'' }}"
         };
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
     <script src="{% static 'emt/js/submit_event_report.js' %}"></script>
 {% endblock %}

--- a/emt/tests/test_audience_csv.py
+++ b/emt/tests/test_audience_csv.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.db.models.signals import post_save
 from django.contrib.auth.signals import user_logged_in
 import json
+import csv
 
 from core.signals import create_or_update_user_profile, assign_role_on_login
 from core.models import OrganizationType, Organization, OrganizationRole, RoleAssignment
@@ -38,13 +39,15 @@ class AudienceCSVViewTests(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/csv")
-        content = response.content.decode()
-        self.assertIn(
-            "Registration No,Full Name,Class,Absent,Student Volunteer",
-            content,
+        reader = csv.reader(response.content.decode().splitlines())
+        rows = list(reader)
+        self.assertEqual(
+            rows[0],
+            ["Registration No", "Full Name", "Class", "Absent", "Student Volunteer"],
         )
-        self.assertIn("Bob", content)
-        self.assertIn("Carol", content)
+        self.assertEqual(rows[1][1], "Bob")
+        self.assertEqual(rows[2][1], "Carol")
+        self.assertEqual(len(rows[1]), 5)
 
     def test_download_faculty_audience_csv(self):
         url = reverse("emt:download_audience_csv", args=[self.proposal.id]) + "?type=faculty"

--- a/emt/views.py
+++ b/emt/views.py
@@ -1607,7 +1607,7 @@ def download_audience_csv(request, proposal_id):
         ]
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
-    writer = csv.writer(response)
+    writer = csv.writer(response, quoting=csv.QUOTE_MINIMAL)
     writer.writerow(headers)
     for name in names:
         writer.writerow(["", name, "", "", ""])


### PR DESCRIPTION
## Summary
- Quote names minimally when generating attendance CSV templates
- Robustly parse uploaded CSVs, trim cells, and render checkboxes with fixed table layout
- Load PapaParse for reliable client-side CSV parsing and add tests for row structure

## Testing
- `node - <<'NODE' ... NODE`
- `python manage.py test` *(fails: connection to server at yamanote.proxy.rlwy.net failed; network is unreachable)*
- `DATABASE_URL=sqlite:///test.sqlite3 python manage.py test` *(fails: 'sslmode' is an invalid keyword argument for Connection)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a570df074c832c8726f116c0bc2267