### PR TITLE
Ensure sidebar permissions handle missing data

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -54,15 +54,17 @@ def active_academic_year(request):
 def sidebar_permissions(request):
     """Provide allowed sidebar items for the current user or role."""
     if not request.user.is_authenticated:
-        return {"allowed_nav_items": None}
-    items = None
+        return {"allowed_nav_items": []}
+
+    items = []
     perm = SidebarPermission.objects.filter(user=request.user).first()
-    if perm:
+    if perm and isinstance(perm.items, list):
         items = perm.items
     else:
         role = request.session.get("role")
         if role:
             perm = SidebarPermission.objects.filter(role=role).first()
-            if perm:
+            if perm and isinstance(perm.items, list):
                 items = perm.items
+
     return {"allowed_nav_items": items}

--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -1,0 +1,34 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User, AnonymousUser
+
+from core.context_processors import sidebar_permissions
+from core.models import SidebarPermission
+
+
+class SidebarPermissionsTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user("u", email="u@example.com", password="pass")
+
+    def _request(self, user=None, session=None):
+        request = self.factory.get("/")
+        request.user = user or self.user
+        request.session = session or {}
+        return request
+
+    def test_returns_empty_list_when_not_authenticated(self):
+        request = self._request(user=AnonymousUser())
+        ctx = sidebar_permissions(request)
+        self.assertEqual(ctx["allowed_nav_items"], [])
+
+    def test_user_specific_permission(self):
+        SidebarPermission.objects.create(user=self.user, items=["dashboard"])
+        request = self._request()
+        ctx = sidebar_permissions(request)
+        self.assertEqual(ctx["allowed_nav_items"], ["dashboard"])
+
+    def test_role_based_permission(self):
+        SidebarPermission.objects.create(role="student", items=["dashboard"])
+        request = self._request(session={"role": "student"})
+        ctx = sidebar_permissions(request)
+        self.assertEqual(ctx["allowed_nav_items"], ["dashboard"])


### PR DESCRIPTION
## Summary
- Avoid None from sidebar_permissions context processor by always returning a list
- Add regression tests for user and role-based sidebar permissions

## Testing
- ⚠️ `python manage.py test core.tests.test_sidebar_permissions -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e4a13ba4832cb173e8fb86203704