### PR TITLE
Allow admin roles to bypass sidebar restrictions

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -56,6 +56,9 @@ def sidebar_permissions(request):
     if not request.user.is_authenticated:
         return {"allowed_nav_items": []}
 
+    if request.user.is_superuser or request.session.get("role") == "admin":
+        return {"allowed_nav_items": []}
+
     items = []
     perm = SidebarPermission.objects.filter(user=request.user).first()
     if perm and isinstance(perm.items, list):

--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -32,3 +32,17 @@ class SidebarPermissionsTests(TestCase):
         request = self._request(session={"role": "student"})
         ctx = sidebar_permissions(request)
         self.assertEqual(ctx["allowed_nav_items"], ["dashboard"])
+
+    def test_superuser_bypasses_permissions(self):
+        self.user.is_superuser = True
+        self.user.save()
+        SidebarPermission.objects.create(user=self.user, items=["dashboard"])
+        request = self._request()
+        ctx = sidebar_permissions(request)
+        self.assertEqual(ctx["allowed_nav_items"], [])
+
+    def test_admin_role_bypasses_permissions(self):
+        SidebarPermission.objects.create(role="admin", items=["dashboard"])
+        request = self._request(session={"role": "admin"})
+        ctx = sidebar_permissions(request)
+        self.assertEqual(ctx["allowed_nav_items"], [])


### PR DESCRIPTION
## Summary
- Always show full sidebar to superusers and admin role users
- Test superuser and admin role bypass of `SidebarPermission`

## Testing
- `python manage.py test core.tests.test_sidebar_permissions -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*
- `DATABASE_URL=sqlite:///:memory: python manage.py test core.tests.test_sidebar_permissions -v 2` *(fails: `TypeError: 'sslmode' is an invalid keyword argument for Connection()`)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9351858832cae81f7fafce4a65d