### PR TITLE
Bypass sidebar restrictions for admin users

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -55,6 +55,8 @@ def sidebar_permissions(request):
     """Provide allowed sidebar items for the current user or role."""
     if not request.user.is_authenticated:
         return {"allowed_nav_items": None}
+    if request.user.is_superuser or request.session.get("role") == "admin":
+        return {"allowed_nav_items": []}
     items = None
     perm = SidebarPermission.objects.filter(user=request.user).first()
     if perm:

--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from core.context_processors import sidebar_permissions
+from core.models import SidebarPermission
+
+
+class SidebarPermissionsTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _get_request(self, user):
+        request = self.factory.get("/")
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        request.user = user
+        return request
+
+    def test_superuser_bypasses_sidebar_permission(self):
+        """Superusers should ignore any stored sidebar permissions."""
+        user = User.objects.create_user("super", password="pass", is_superuser=True)
+        SidebarPermission.objects.create(user=user, items=["dashboard"])
+
+        request = self._get_request(user)
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], [])
+
+    def test_admin_role_bypasses_sidebar_permission(self):
+        """Users with admin role should bypass sidebar restrictions."""
+        user = User.objects.create_user("regular", password="pass")
+        SidebarPermission.objects.create(role="admin", items=["dashboard"])
+
+        request = self._get_request(user)
+        request.session["role"] = "admin"
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], [])


### PR DESCRIPTION
## Summary
- Allow superusers and admin-role sessions to bypass sidebar restrictions
- Add tests covering superuser and admin-role sidebar access

## Testing
- `DJANGO_SETTINGS_MODULE=test_settings python manage.py test core.tests.test_sidebar_permissions -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a5f2e966f0832c98f2084286a042c1