### PR TITLE
Improve sidebar permission management

### DIFF
--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, RequestFactory
 from django.contrib.auth.models import User
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import Client
+from django.urls import reverse
 
 from core.context_processors import sidebar_permissions
 from core.models import SidebarPermission
@@ -38,3 +40,52 @@ class SidebarPermissionsTests(TestCase):
         result = sidebar_permissions(request)
 
         self.assertEqual(result["allowed_nav_items"], [])
+
+    def test_user_permission_applied(self):
+        """Explicit user permissions should be returned."""
+        user = User.objects.create_user("alice", password="pass")
+        SidebarPermission.objects.create(user=user, items=["dashboard"])
+
+        request = self._get_request(user)
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], ["dashboard"])
+
+    def test_role_permission_applied(self):
+        """Role permissions should apply when user has none."""
+        user = User.objects.create_user("bob", password="pass")
+        SidebarPermission.objects.create(role="faculty", items=["events"])
+
+        request = self._get_request(user)
+        request.session["role"] = "faculty"
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], ["events"])
+
+    def test_user_permission_overrides_role(self):
+        """User-specific permissions override role permissions."""
+        user = User.objects.create_user("carol", password="pass")
+        SidebarPermission.objects.create(role="faculty", items=["events"])
+        SidebarPermission.objects.create(user=user, items=["dashboard"])
+
+        request = self._get_request(user)
+        request.session["role"] = "faculty"
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], ["dashboard"])
+
+
+class SidebarPermissionsViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.admin = User.objects.create_superuser("admin", "admin@example.com", "pass")
+        self.client.login(username="admin", password="pass")
+
+    def test_assign_permission_to_user(self):
+        target = User.objects.create_user("dave", password="pass")
+        url = reverse("admin_sidebar_permissions")
+        response = self.client.post(url, {"user": str(target.id), "items": ["dashboard", "events"]})
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(f"?user={target.id}", response["Location"])
+        perm = SidebarPermission.objects.get(user=target)
+        self.assertEqual(perm.items, ["dashboard", "events"])

--- a/core/views.py
+++ b/core/views.py
@@ -1482,7 +1482,12 @@ def admin_sidebar_permissions(request):
         permission.save()
         messages.success(request, "Sidebar permissions updated")
         logger.info("Sidebar permissions updated for user=%s role=%s", target_user, target_role)
-        return redirect("admin_sidebar_permissions")
+        redirect_url = reverse("admin_sidebar_permissions")
+        if target_user:
+            redirect_url += f"?user={target_user}"
+        elif target_role:
+            redirect_url += f"?role={target_role}"
+        return redirect(redirect_url)
 
     context = {
         "roles": roles,

--- a/templates/core/admin_sidebar_permissions.html
+++ b/templates/core/admin_sidebar_permissions.html
@@ -76,6 +76,26 @@
 {% block scripts_extra %}
 <script>
 document.addEventListener('DOMContentLoaded', function () {
+  const userSelect = document.getElementById('user_select');
+  const roleSelect = document.getElementById('role_select');
+
+  userSelect.addEventListener('change', function () {
+    if (this.value) {
+      roleSelect.value = '';
+      window.location = '?user=' + this.value;
+    } else {
+      window.location = window.location.pathname;
+    }
+  });
+
+  roleSelect.addEventListener('change', function () {
+    if (this.value) {
+      userSelect.value = '';
+      window.location = '?role=' + this.value;
+    } else {
+      window.location = window.location.pathname;
+    }
+  });
   function moveOptions(from, to) {
     Array.from(from.selectedOptions).forEach(function (opt) {
       opt.selected = false;


### PR DESCRIPTION
## Summary
- Keep user or role selection after saving sidebar permissions
- Auto-refresh sidebar permission page when selecting user or role
- Test sidebar permission application and view behavior

## Testing
- `DATABASE_URL=sqlite://:memory: python manage.py test core.tests.test_sidebar_permissions -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a5f7ac886c832c9662a5e49fbb91b2