### PR TITLE
Normalize sidebar role matching

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -55,16 +55,19 @@ def sidebar_permissions(request):
     """Provide allowed sidebar items for the current user or role."""
     if not request.user.is_authenticated:
         return {"allowed_nav_items": None}
-    if request.user.is_superuser or request.session.get("role") == "admin":
+
+    session_role = request.session.get("role")
+    if request.user.is_superuser or (
+        session_role and session_role.lower() == "admin"
+    ):
         return {"allowed_nav_items": []}
+
     items = None
     perm = SidebarPermission.objects.filter(user=request.user).first()
     if perm:
         items = perm.items
-    else:
-        role = request.session.get("role")
-        if role:
-            perm = SidebarPermission.objects.filter(role=role).first()
-            if perm:
-                items = perm.items
+    elif session_role:
+        perm = SidebarPermission.objects.filter(role__iexact=session_role).first()
+        if perm:
+            items = perm.items
     return {"allowed_nav_items": items}

--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -62,6 +62,17 @@ class SidebarPermissionsTests(TestCase):
 
         self.assertEqual(result["allowed_nav_items"], ["events"])
 
+    def test_role_permission_case_insensitive(self):
+        """Role matching should ignore case."""
+        user = User.objects.create_user("eve", password="pass")
+        SidebarPermission.objects.create(role="faculty", items=["events"])
+
+        request = self._get_request(user)
+        request.session["role"] = "Faculty"  # Mixed case
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], ["events"])
+
     def test_user_permission_overrides_role(self):
         """User-specific permissions override role permissions."""
         user = User.objects.create_user("carol", password="pass")

--- a/core/views.py
+++ b/core/views.py
@@ -1462,16 +1462,18 @@ def admin_sidebar_permissions(request):
 
     selected_user = request.GET.get("user")
     selected_role = request.GET.get("role")
+    if selected_role:
+        selected_role = selected_role.lower()
     permission = None
     from .models import SidebarPermission
     if selected_user:
         permission = SidebarPermission.objects.filter(user_id=selected_user).first()
     elif selected_role:
-        permission = SidebarPermission.objects.filter(role=selected_role).first()
+        permission = SidebarPermission.objects.filter(role__iexact=selected_role).first()
 
     if request.method == "POST":
         target_user = request.POST.get("user") or None
-        target_role = request.POST.get("role") or ""
+        target_role = (request.POST.get("role") or "").lower()
         items = request.POST.getlist("items")
 
         permission, _ = SidebarPermission.objects.get_or_create(


### PR DESCRIPTION
## Summary
- Normalize role names when assigning sidebar permissions
- Match session roles case-insensitively in context processor
- Test case verifying role lookup ignores case

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fa144c20832c9e5fc6659aaac1f0