### PR TITLE
Fix sidebar permission role isolation

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -67,7 +67,9 @@ def sidebar_permissions(request):
     if perm:
         items = perm.items
     elif session_role:
-        perm = SidebarPermission.objects.filter(role__iexact=session_role).first()
+        perm = SidebarPermission.objects.filter(
+            user__isnull=True, role__iexact=session_role
+        ).first()
         if perm:
             items = perm.items
     return {"allowed_nav_items": items}

--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -85,6 +85,22 @@ class SidebarPermissionsTests(TestCase):
 
         self.assertEqual(result["allowed_nav_items"], ["dashboard"])
 
+    def test_user_specific_role_record_does_not_affect_others(self):
+        """A user-specific record with a role should not override role defaults."""
+        role_items = ["events"]
+        SidebarPermission.objects.create(role="faculty", items=role_items)
+        user_with_override = User.objects.create_user("carol", password="pass")
+        SidebarPermission.objects.create(
+            user=user_with_override, role="faculty", items=["dashboard"]
+        )
+        other_user = User.objects.create_user("dave", password="pass")
+
+        request = self._get_request(other_user)
+        request.session["role"] = "faculty"
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], role_items)
+
 
 class SidebarPermissionsViewTests(TestCase):
     def setUp(self):

--- a/core/views.py
+++ b/core/views.py
@@ -1469,17 +1469,23 @@ def admin_sidebar_permissions(request):
     if selected_user:
         permission = SidebarPermission.objects.filter(user_id=selected_user).first()
     elif selected_role:
-        permission = SidebarPermission.objects.filter(role__iexact=selected_role).first()
+        permission = SidebarPermission.objects.filter(
+            user__isnull=True, role__iexact=selected_role
+        ).first()
 
     if request.method == "POST":
         target_user = request.POST.get("user") or None
         target_role = (request.POST.get("role") or "").lower()
         items = request.POST.getlist("items")
 
-        permission, _ = SidebarPermission.objects.get_or_create(
-            user_id=target_user if target_user else None,
-            role=target_role,
-        )
+        if target_user:
+            permission, _ = SidebarPermission.objects.get_or_create(
+                user_id=target_user, role=""
+            )
+        else:
+            permission, _ = SidebarPermission.objects.get_or_create(
+                user=None, role=target_role
+            )
         permission.items = items
         permission.save()
         messages.success(request, "Sidebar permissions updated")


### PR DESCRIPTION
## Summary
- ensure role-based sidebar permissions ignore user-specific records
- prevent duplicate sidebar permissions by separating user and role records
- keep role defaults intact across users

## Testing
- `python manage.py test core.tests.test_sidebar_permissions -v 2` *(fails: TypeError: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68a5fee327e8832c84ab9ff5fefc1fb5