### PR TITLE
Ignore stale user role sidebar permissions

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -63,7 +63,9 @@ def sidebar_permissions(request):
         return {"allowed_nav_items": []}
 
     items = None
-    perm = SidebarPermission.objects.filter(user=request.user).first()
+    perm = SidebarPermission.objects.filter(
+        user=request.user, role__in=["", None]
+    ).first()
     if perm:
         items = perm.items
     elif session_role:

--- a/core/tests/test_sidebar_permissions.py
+++ b/core/tests/test_sidebar_permissions.py
@@ -85,6 +85,21 @@ class SidebarPermissionsTests(TestCase):
 
         self.assertEqual(result["allowed_nav_items"], ["dashboard"])
 
+    def test_stale_user_role_record_ignored(self):
+        """A user-specific record with a role should not override role defaults."""
+        role_items = ["events"]
+        SidebarPermission.objects.create(role="faculty", items=role_items)
+        user = User.objects.create_user("erin", password="pass")
+        SidebarPermission.objects.create(
+            user=user, role="faculty", items=["dashboard"]
+        )
+
+        request = self._get_request(user)
+        request.session["role"] = "faculty"
+        result = sidebar_permissions(request)
+
+        self.assertEqual(result["allowed_nav_items"], role_items)
+
     def test_user_specific_role_record_does_not_affect_others(self):
         """A user-specific record with a role should not override role defaults."""
         role_items = ["events"]


### PR DESCRIPTION
## Summary
- Look up user-specific sidebar permissions only when `role` is blank
- Add regression test ensuring stale `SidebarPermission(user, role="faculty")` doesn't override global role

## Testing
- `python manage.py test core.tests.test_sidebar_permissions -v 2 --settings=iqac_project.test_settings`


------
https://chatgpt.com/codex/tasks/task_e_68a602437574832c8846694e984ada34