### PR TITLE
Use proposal focus type in event reports

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -469,7 +469,7 @@ document.addEventListener('DOMContentLoaded', function(){
   });
   
   function getEventInformationContent() {
-      const selectedEventType = window.REPORT_ACTUAL_EVENT_TYPE || (window.PROPOSAL_DATA ? window.PROPOSAL_DATA.event_focus_type || '' : '');
+      const eventTypeValue = window.REPORT_ACTUAL_EVENT_TYPE || (window.PROPOSAL_DATA ? window.PROPOSAL_DATA.event_focus_type || '' : '');
       return `
           <!-- Organization Information Section -->
           <div class="form-section-header">
@@ -540,25 +540,9 @@ document.addEventListener('DOMContentLoaded', function(){
                   <div class="help-text">Academic year from proposal (editable)</div>
               </div>
               <div class="input-group">
-                  <label for="event-type-modern">Actual Event Type *</label>
-                  <select id="event-type-modern" name="actual_event_type" required>
-                      <option value="">Select the type of event that was conducted</option>
-                      <option value="Training Program" ${selectedEventType === 'Training Program' ? 'selected' : ''}>Training Program</option>
-                      <option value="Workshop" ${selectedEventType === 'Workshop' ? 'selected' : ''}>Workshop</option>
-                      <option value="Seminar" ${selectedEventType === 'Seminar' ? 'selected' : ''}>Seminar</option>
-                      <option value="Conference" ${selectedEventType === 'Conference' ? 'selected' : ''}>Conference</option>
-                      <option value="Guest Lecture" ${selectedEventType === 'Guest Lecture' ? 'selected' : ''}>Guest Lecture</option>
-                      <option value="Webinar" ${selectedEventType === 'Webinar' ? 'selected' : ''}>Webinar</option>
-                      <option value="Competition" ${selectedEventType === 'Competition' ? 'selected' : ''}>Competition</option>
-                      <option value="Cultural Event" ${selectedEventType === 'Cultural Event' ? 'selected' : ''}>Cultural Event</option>
-                      <option value="Sports Event" ${selectedEventType === 'Sports Event' ? 'selected' : ''}>Sports Event</option>
-                      <option value="Exhibition" ${selectedEventType === 'Exhibition' ? 'selected' : ''}>Exhibition</option>
-                      <option value="Panel Discussion" ${selectedEventType === 'Panel Discussion' ? 'selected' : ''}>Panel Discussion</option>
-                      <option value="Hackathon" ${selectedEventType === 'Hackathon' ? 'selected' : ''}>Hackathon</option>
-                      <option value="Field Trip" ${selectedEventType === 'Field Trip' ? 'selected' : ''}>Field Trip</option>
-                      <option value="Other" ${selectedEventType === 'Other' ? 'selected' : ''}>Other</option>
-                  </select>
-                  <div class="help-text">Select the actual type of event that was conducted</div>
+                  <label for="event-type-modern">Event Type *</label>
+                  <input type="text" id="event-type-modern" name="actual_event_type" value="${eventTypeValue}" readonly>
+                  <div class="help-text">Event type from proposal (not editable)</div>
               </div>
           </div>
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -168,30 +168,12 @@
                                 <div class="help-text">Academic year from proposal (editable)</div>
                             </div>
                             <div class="input-group">
-                                <label for="event-type-modern">Actual Event Type *</label>
-                                {% with selected_event_type=form.actual_event_type.value|default:proposal.event_focus_type %}
-                                <select id="event-type-modern" name="actual_event_type" required>
-                                    <option value="">Select the type of event that was conducted</option>
-                                    <option value="Training Program" {% if selected_event_type == "Training Program" %}selected{% endif %}>Training Program</option>
-                                    <option value="Workshop" {% if selected_event_type == "Workshop" %}selected{% endif %}>Workshop</option>
-                                    <option value="Seminar" {% if selected_event_type == "Seminar" %}selected{% endif %}>Seminar</option>
-                                    <option value="Conference" {% if selected_event_type == "Conference" %}selected{% endif %}>Conference</option>
-                                    <option value="Guest Lecture" {% if selected_event_type == "Guest Lecture" %}selected{% endif %}>Guest Lecture</option>
-                                    <option value="Webinar" {% if selected_event_type == "Webinar" %}selected{% endif %}>Webinar</option>
-                                    <option value="Competition" {% if selected_event_type == "Competition" %}selected{% endif %}>Competition</option>
-                                    <option value="Cultural Event" {% if selected_event_type == "Cultural Event" %}selected{% endif %}>Cultural Event</option>
-                                    <option value="Sports Event" {% if selected_event_type == "Sports Event" %}selected{% endif %}>Sports Event</option>
-                                    <option value="Exhibition" {% if selected_event_type == "Exhibition" %}selected{% endif %}>Exhibition</option>
-                                    <option value="Panel Discussion" {% if selected_event_type == "Panel Discussion" %}selected{% endif %}>Panel Discussion</option>
-                                    <option value="Hackathon" {% if selected_event_type == "Hackathon" %}selected{% endif %}>Hackathon</option>
-                                    <option value="Field Trip" {% if selected_event_type == "Field Trip" %}selected{% endif %}>Field Trip</option>
-                                    <option value="Other" {% if selected_event_type == "Other" %}selected{% endif %}>Other</option>
-                                </select>
+                                <label for="event-type-modern">Event Type *</label>
+                                <input type="text" id="event-type-modern" name="actual_event_type" value="{{ form.actual_event_type.value|default:proposal.event_focus_type }}" readonly>
                                 {% if form.actual_event_type.errors %}
                                     <div class="field-error">{{ form.actual_event_type.errors.0 }}</div>
                                 {% endif %}
-                                {% endwith %}
-                                <div class="help-text">Select the actual type of event that was conducted</div>
+                                <div class="help-text">Event type from proposal (not editable)</div>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- remove hardcoded event-type dropdown from event report form
- display proposal's event focus type as read-only input

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a69df72d70832c8e9ec3a6c22c308d