### PR TITLE
Fix proposal autosave triggers and add validation tests

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1092,7 +1092,11 @@ $(document).ready(function() {
             modernField.val(djangoField.val());
             modernField.on('input change', function() {
                 const value = $(this).val();
-                djangoField.val(value).trigger('change');
+                djangoField.val(value);
+                if (djangoField[0]) {
+                    djangoField[0].dispatchEvent(new Event('input', { bubbles: true }));
+                    djangoField[0].dispatchEvent(new Event('change', { bubbles: true }));
+                }
                 clearFieldError($(this));
             });
         }

--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -331,6 +331,37 @@ class AutosaveProposalTests(TestCase):
         saved_ids = set(proposal.sdg_goals.values_list("id", flat=True))
         self.assertEqual(saved_ids, {g1.id, g2.id})
 
+    def test_autosave_activity_missing_fields(self):
+        payload = self._payload()
+        payload.update({
+            "num_activities": "1",
+            "activity_name_1": "Orientation"
+        })
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data.get("success"))
+        self.assertIn("activities", data.get("errors", {}))
+        self.assertIn("date", data["errors"]["activities"]["1"])
+
+    def test_autosave_speaker_missing_fields(self):
+        payload = self._payload()
+        payload.update({"speaker_full_name_0": "Dr. Jane"})
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data.get("success"))
+        self.assertIn("speakers", data.get("errors", {}))
+        self.assertIn("designation", data["errors"]["speakers"]["0"])
+
 
 class EventProposalOrganizationPrefillTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- trigger autosave for hidden Django fields on input and change events so all visible fields autosave
- add tests covering activity and speaker validation for autosave endpoint

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e889427c832c9a8bd7397bf07be0