### PR TITLE
feat: hide user names in target audience

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1032,7 +1032,7 @@ $(document).ready(function() {
         }
 
         $('#audienceSave').off('click').on('click', () => {
-            const names = selected.map(it => it.name).concat(userSelected.map(u => u.name));
+            const names = selected.map(it => it.name);
             audienceField.val(names.join(', ')).trigger('change').trigger('input');
             if (currentType === 'students') {
                 classIdsField


### PR DESCRIPTION
## Summary
- prevent individual user names from showing in proposal target audience field

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5d126d8832c987b9946a9276cf6