### PR TITLE
Fix POS/PSO autosave by preferring visible field values

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -39,7 +39,13 @@ window.AutosaveManager = (function() {
             } else if (field.multiple) {
                 data[name] = Array.from(field.selectedOptions).map(o => o.value);
             } else {
-                data[name] = field.value;
+                // When multiple inputs share the same name (e.g. hidden Django field
+                // and visible modern field), prefer a visible, non-empty value.
+                const preferred = inputs.find(i => i.type !== 'hidden' && i.value.trim() !== '')
+                    || inputs.find(i => i.type !== 'hidden')
+                    || inputs.find(i => i.value.trim() !== '')
+                    || field;
+                data[name] = preferred.value;
             }
         });
         return data;


### PR DESCRIPTION
## Summary
- ensure AutosaveManager collects the visible value when multiple fields share the same name
- prevents hidden Django fields from overriding user input (e.g. POS & PSO)

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ff44b9dc832ca73bc359e60fc264