### PR TITLE
feat: modernize attendance upload with async data fetch

### DIFF
--- a/emt/static/emt/css/attendance.css
+++ b/emt/static/emt/css/attendance.css
@@ -1,6 +1,30 @@
-.summary span { margin-right: 1rem; }
-#attendance-table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
-#attendance-table th, #attendance-table td { border: 1px solid #ccc; padding: 4px; text-align: left; }
-.actions { margin-top: 1rem; }
+.attendance-container {
+  background: var(--surface-color, #fff);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.page-title {
+  margin-bottom: 1rem;
+}
+.summary {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+.summary span {
+  font-weight: 600;
+}
+#attendance-table { margin-top: 1rem; }
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+}
 .pagination { margin-top: 1rem; }
 .error { color: red; }
+.loading {
+  margin-top: 1rem;
+  display: none;
+}

--- a/emt/static/emt/js/attendance.js
+++ b/emt/static/emt/js/attendance.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const presentEl = document.getElementById('present-count');
     const absentEl = document.getElementById('absent-count');
     const volunteerEl = document.getElementById('volunteer-count');
+    const loadingEl = document.getElementById('loading');
 
     function renderTable() {
         tableBody.innerHTML = '';
@@ -102,6 +103,27 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    function fetchRows() {
+        if (!dataUrl) {
+            renderTable();
+            return;
+        }
+        loadingEl.style.display = 'block';
+        fetch(dataUrl)
+            .then(r => r.json())
+            .then(data => {
+                rows = data.rows || [];
+                renderTable();
+            })
+            .finally(() => {
+                loadingEl.style.display = 'none';
+            });
+    }
+
     setupPagination();
-    renderTable();
+    if (rows.length === 0) {
+        fetchRows();
+    } else {
+        renderTable();
+    }
 });

--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -1,19 +1,24 @@
+{% extends "base.html" %}
 {% load static %}
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Upload Attendance CSV</title>
-    <link rel="stylesheet" href="{% static 'emt/css/attendance.css' %}">
-</head>
-<body>
-    <h1>Upload Attendance CSV</h1>
+
+{% block title %}Attendance Upload{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'emt/css/attendance.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="attendance-container">
+    <h1 class="page-title">Attendance CSV Upload</h1>
+
     {% if error %}
-    <div class="error">{{ error }}</div>
+    <div class="alert alert-danger">{{ error }}</div>
     {% endif %}
-    <form method="post" enctype="multipart/form-data">
+
+    <form method="post" enctype="multipart/form-data" class="mb-4">
         {% csrf_token %}
-        <input type="file" name="csv_file" accept=".csv">
-        <button type="submit">Upload</button>
+        <input type="file" name="csv_file" accept=".csv" class="form-control-file mb-2">
+        <button type="submit" class="btn btn-primary">Upload</button>
     </form>
 
     <div id="summary" class="summary">
@@ -23,7 +28,9 @@
         <span>Volunteers: <span id="volunteer-count">{{ counts.volunteers }}</span></span>
     </div>
 
-    <table id="attendance-table">
+    <div id="loading" class="loading">Loading...</div>
+
+    <table id="attendance-table" class="table table-sm mt-3">
         <thead>
             <tr>
                 <th>Registration No</th>
@@ -37,17 +44,19 @@
     </table>
 
     <div class="actions">
-        <button id="save-event-report">Save to Event Report</button>
-        <button id="download-csv">Download CSV</button>
+        <button id="save-event-report" class="btn btn-primary">Save to Event Report</button>
+        <button id="download-csv" class="btn btn-secondary">Download CSV</button>
     </div>
+</div>
 
-    <script>
-        const initialRows = {{ rows_json|default:'[]'|safe }};
-        const saveUrl = "{% url 'emt:attendance_save' report.id %}";
-        const downloadUrl = "{% url 'emt:attendance_download' report.id %}";
-        const downloadFilename = "student_audience_{{ report.id }}.csv";
-        const csrftoken = '{{ csrf_token }}';
-    </script>
-    <script src="{% static 'emt/js/attendance.js' %}"></script>
-</body>
-</html>
+<script>
+    const initialRows = {{ rows_json|default:'[]'|safe }};
+    const saveUrl = "{% url 'emt:attendance_save' report.id %}";
+    const downloadUrl = "{% url 'emt:attendance_download' report.id %}";
+    const dataUrl = "{% url 'emt:attendance_data' report.id %}";
+    const downloadFilename = "student_audience_{{ report.id }}.csv";
+    const csrftoken = '{{ csrf_token }}';
+</script>
+<script src="{% static 'emt/js/attendance.js' %}"></script>
+{% endblock %}
+

--- a/emt/tests/test_attendance_data_view.py
+++ b/emt/tests/test_attendance_data_view.py
@@ -1,0 +1,41 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from emt.models import EventProposal, EventReport, AttendanceRow
+
+
+class AttendanceDataViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client.force_login(self.user)
+        proposal = EventProposal.objects.create(
+            submitted_by=self.user, event_title="Sample"
+        )
+        self.report = EventReport.objects.create(proposal=proposal)
+        AttendanceRow.objects.create(
+            event_report=self.report,
+            registration_no="R1",
+            full_name="Bob",
+            student_class="CSE",
+            absent=False,
+            volunteer=True,
+        )
+        AttendanceRow.objects.create(
+            event_report=self.report,
+            registration_no="R2",
+            full_name="Eve",
+            student_class="CSE",
+            absent=True,
+            volunteer=False,
+        )
+
+    def test_returns_rows_and_counts(self):
+        url = reverse("emt:attendance_data", args=[self.report.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["rows"]), 2)
+        self.assertEqual(data["counts"]["absent"], 1)
+        self.assertEqual(data["counts"]["volunteers"], 1)
+

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path('reports/<int:report_id>/attendance/upload/', views.upload_attendance_csv, name='attendance_upload'),
     path('reports/<int:report_id>/attendance/save/', views.save_attendance_rows, name='attendance_save'),
     path('reports/<int:report_id>/attendance/download/', views.download_attendance_csv, name='attendance_download'),
+    path('reports/<int:report_id>/attendance/data/', views.attendance_data, name='attendance_data'),
 
     # THE NEW, GENERIC ORG API ENDPOINT:
     path('api/organizations/', views.api_organizations, name='api_organizations'),


### PR DESCRIPTION
## Summary
- restyle attendance upload page to use app theme and bootstrap components
- load attendance rows via new `attendance_data` API endpoint
- cover data endpoint with unit test

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f66e5d88832c8deb836747c086a0