### PR TITLE
Add loading overlay during proposal saves

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -3132,3 +3132,44 @@ textarea {
         padding: 1.5rem;
     }
 }
+
+/* Loading overlay displayed during section saves */
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    z-index: 2000;
+}
+
+.loading-overlay.show {
+    display: flex;
+}
+
+.loading-overlay .spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #e5e7eb;
+    border-top: 4px solid var(--primary-blue, #2563eb);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 1rem;
+}
+
+.loading-overlay p {
+    margin: 0;
+    color: #374151;
+    font-size: 0.95rem;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1,3 +1,17 @@
+function showLoadingOverlay() {
+    const overlay = document.getElementById('loadingOverlay');
+    if (overlay) {
+        overlay.classList.add('show');
+    }
+}
+
+function hideLoadingOverlay() {
+    const overlay = document.getElementById('loadingOverlay');
+    if (overlay) {
+        overlay.classList.remove('show');
+    }
+}
+
 $(document).ready(function() {
     console.log('Initializing dashboard...');
     addAnimationStyles();
@@ -2076,9 +2090,11 @@ function getWhyThisEventForm() {
         if (!currentExpandedCard) return;
 
         if (validateCurrentSection()) {
+            showLoadingOverlay();
             if (window.AutosaveManager && window.AutosaveManager.manualSave) {
                 window.AutosaveManager.manualSave()
                     .then(() => {
+                        hideLoadingOverlay();
                         markSectionComplete(currentExpandedCard);
                         showNotification('Section saved successfully!', 'success');
 
@@ -2097,6 +2113,7 @@ function getWhyThisEventForm() {
                         }
                     })
                     .catch(err => {
+                        hideLoadingOverlay();
                         console.error('Autosave failed:', err);
                         if (err && err.errors) {
                             handleAutosaveErrors(err);
@@ -2104,6 +2121,7 @@ function getWhyThisEventForm() {
                         showNotification('Autosave failed. Please check for missing fields.', 'error');
                     });
             } else {
+                hideLoadingOverlay();
                 markSectionComplete(currentExpandedCard);
             }
         } else {
@@ -3064,14 +3082,18 @@ function removeSubmitSection() {
 
 // Function to manually save draft
 function saveDraft() {
+  showLoadingOverlay();
   if (window.autosaveDraft) {
     window.autosaveDraft().then(() => {
+      hideLoadingOverlay();
       alert('Draft saved successfully!');
     }).catch((error) => {
+      hideLoadingOverlay();
       console.error('Failed to save draft:', error);
       alert('Failed to save draft. Please try again.');
     });
   } else {
+    hideLoadingOverlay();
     console.error('Autosave function not available');
     alert('Save function not available. Please try submitting the form.');
   }

--- a/emt/templates/emt/cdl_support.html
+++ b/emt/templates/emt/cdl_support.html
@@ -202,6 +202,11 @@
     </div>
   </form>
 </div>
+
+<div id="loadingOverlay" class="loading-overlay">
+  <div class="spinner"></div>
+  <p>Saving...</p>
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -354,6 +354,11 @@
         </div>
     </div>
 </div>
+
+<div id="loadingOverlay" class="loading-overlay">
+    <div class="spinner"></div>
+    <p>Saving...</p>
+</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- show spinner overlay when saving proposal sections or drafts
- provide markup and styles for new loading overlay

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a70202ace0832ca5be4d52e2f4dd0e