### PR TITLE
Persist outcome selections in event report modal

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1168,6 +1168,12 @@ function openOutcomeModal(){
     alert('No organization set for this proposal.');
     return;
   }
+  const field = document.getElementById('id_pos_pso_mapping');
+  const selectedSet = new Set(
+    (field ? field.value.split('\n') : [])
+      .map(s => s.trim())
+      .filter(Boolean)
+  );
   modal.classList.add('show');
   container.textContent = 'Loading...';
   fetch(url)
@@ -1175,8 +1181,8 @@ function openOutcomeModal(){
     .then(data => {
       if(data.success){
         container.innerHTML = '';
-        data.pos.forEach(po => { addOption(container,'PO: ' + po.description); });
-        data.psos.forEach(pso => { addOption(container,'PSO: ' + pso.description); });
+        data.pos.forEach(po => { addOption(container,'PO: ' + po.description, selectedSet); });
+        data.psos.forEach(pso => { addOption(container,'PSO: ' + pso.description, selectedSet); });
       } else {
         container.textContent = 'No data';
       }
@@ -1184,11 +1190,14 @@ function openOutcomeModal(){
     .catch(() => { container.textContent = 'Error loading'; });
 }
 
-function addOption(container, labelText){
+function addOption(container, labelText, checkedSet){
   const lbl = document.createElement('label');
   const cb = document.createElement('input');
   cb.type = 'checkbox';
   cb.value = labelText;
+  if(checkedSet && checkedSet.has(labelText)){
+    cb.checked = true;
+  }
   lbl.appendChild(cb);
   lbl.appendChild(document.createTextNode(' ' + labelText));
   container.appendChild(lbl);
@@ -1211,9 +1220,7 @@ if(_outcomeSaveBtn && document.getElementById('outcomeModal')){
         const selected = Array.from(modal.querySelectorAll('input[type=checkbox]:checked')).map(c => c.value);
         const field = document.getElementById('id_pos_pso_mapping');
         if(!field) return;
-        let existing = field.value.trim();
-        if(existing){ existing += '\n'; }
-        field.value = existing + selected.join('\n');
+        field.value = selected.join('\n');
         modal.classList.remove('show');
     };
 }


### PR DESCRIPTION
## Summary
- pre-populate outcome modal checkboxes based on current POS/PSO mapping
- replace outcome save logic to overwrite mapping with checked options only

## Testing
- `python manage.py test` *(fails: connection to server ... network is unreachable)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a703ebf630832c8bdbc5378d0df759