### PR TITLE
Add validation for speaker names in event proposals

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.models import User
+from django.core.validators import RegexValidator
 from django.urls import reverse_lazy
 from .models import (
     EventProposal, EventNeedAnalysis, EventObjectives,
@@ -13,6 +14,13 @@ from core.models import (
     SDGGoal,
     SDG_GOALS,
     OrganizationMembership,
+)
+
+# Reusable validator to ensure names contain only letters and basic punctuation
+NAME_PATTERN = r"^[A-Za-z .'-]+$"
+name_validator = RegexValidator(
+    NAME_PATTERN,
+    "Only letters and standard punctuation (.'- and spaces) are allowed.",
 )
 
 class EventProposalForm(forms.ModelForm):
@@ -206,6 +214,11 @@ class TentativeFlowForm(forms.ModelForm):
         }
 
 class SpeakerProfileForm(forms.ModelForm):
+    full_name = forms.CharField(
+        validators=[name_validator],
+        widget=forms.TextInput(attrs={'pattern': NAME_PATTERN}),
+    )
+
     class Meta:
         model   = SpeakerProfile
         fields  = [
@@ -312,6 +325,12 @@ class CDLSupportForm(forms.ModelForm):
         required=False, label="Do you need CDL help with event certificates?"
     )
 
+    resource_person_name = forms.CharField(
+        required=False,
+        validators=[name_validator],
+        widget=forms.TextInput(attrs={'pattern': NAME_PATTERN}),
+    )
+
     class Meta:
         model = CDLSupport
         fields = [
@@ -352,6 +371,11 @@ class CDLSupportForm(forms.ModelForm):
 
 
 class CertificateRecipientForm(forms.ModelForm):
+    name = forms.CharField(
+        validators=[name_validator],
+        widget=forms.TextInput(attrs={'pattern': NAME_PATTERN}),
+    )
+
     class Meta:
         model = CDLCertificateRecipient
         fields = ["name", "role", "certificate_type"]

--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -362,6 +362,26 @@ class AutosaveProposalTests(TestCase):
         self.assertIn("speakers", data.get("errors", {}))
         self.assertIn("designation", data["errors"]["speakers"]["0"])
 
+    def test_autosave_speaker_invalid_name(self):
+        payload = self._payload()
+        payload.update({
+            "speaker_full_name_0": "1234",
+            "speaker_designation_0": "Prof",
+            "speaker_affiliation_0": "Uni",
+            "speaker_contact_email_0": "a@b.com",
+            "speaker_detailed_profile_0": "Profile",
+        })
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data.get("success"))
+        self.assertIn("speakers", data.get("errors", {}))
+        self.assertIn("full_name", data["errors"]["speakers"]["0"])
+
 
 class EventProposalOrganizationPrefillTests(TestCase):
     def setUp(self):

--- a/emt/views.py
+++ b/emt/views.py
@@ -22,8 +22,8 @@ from .models import (
 from .forms import (
     EventProposalForm, NeedAnalysisForm, ExpectedOutcomesForm,
     ObjectivesForm, TentativeFlowForm, SpeakerProfileForm,
-    ExpenseDetailForm,EventReportForm, EventReportAttachmentForm, CDLSupportForm,
-    CertificateRecipientForm, CDLMessageForm
+    ExpenseDetailForm, EventReportForm, EventReportAttachmentForm, CDLSupportForm,
+    CertificateRecipientForm, CDLMessageForm, NAME_PATTERN,
 )
 from django.forms import modelformset_factory
 from core.models import (
@@ -81,6 +81,7 @@ import logging
 
 # Get an instance of the logger for the 'emt' app
 logger = logging.getLogger(__name__) # __name__ will resolve to 'emt.views'
+NAME_RE = re.compile(NAME_PATTERN)
 # Configure Gemini API key from environment variable(s)
 # Prefer `GEMINI_API_KEY`; fall back to `GOOGLE_API_KEY`
 api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
@@ -458,6 +459,8 @@ def autosave_proposal(request):
             value = data.get(f"speaker_{field}_{sp_idx}")
             if value:
                 has_any = True
+                if field == "full_name" and not NAME_RE.fullmatch(value):
+                    missing[field] = "Enter a valid name (letters, spaces, .'- only)."
             else:
                 missing[field] = "This field is required."
         if has_any and missing:


### PR DESCRIPTION
## Summary
- add reusable name validator for forms
- reject invalid speaker names during proposal autosave
- test autosave rejects numeric speaker names

## Testing
- `python manage.py test emt.tests.test_existing -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a70652bc80832c997fa84078234c46