### PR TITLE
feat: add schedule table for proposal flow

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1875,6 +1875,45 @@
     }
 }
 
+/* Tentative flow schedule table */
+.schedule-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+}
+
+.schedule-table th,
+.schedule-table td {
+    border: 1px solid var(--border-color, #e5e7eb);
+    padding: 0.5rem;
+}
+
+.schedule-table th {
+    background: var(--background, #f9fafb);
+    text-align: left;
+}
+
+#add-row-btn {
+    background: var(--primary-blue, #2563eb);
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    margin-bottom: 1rem;
+}
+
+#add-row-btn:hover {
+    background: var(--primary-blue-dark, #1e40af);
+}
+
+.btn-remove-row {
+    background: var(--border-color, #e5e7eb);
+    border: none;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+}
+
 /* Override default form grid for expenses section */
 .expenses-section .form-grid,
 .expenses-section .form-row {

--- a/emt/static/emt/js/tentative_flow.js
+++ b/emt/static/emt/js/tentative_flow.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tableBody = document.querySelector('#flow-table tbody');
+  const addRowBtn = document.getElementById('add-row-btn');
+  const hiddenField = document.getElementById('id_content');
+  const form = document.querySelector('form');
+
+  function addRow(time = '', activity = '') {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td><input type="text" class="time-input" value="${time}"></td>
+      <td><input type="text" class="activity-input" value="${activity}"></td>
+      <td><button type="button" class="btn-remove-row">Remove</button></td>
+    `;
+    row.querySelector('.btn-remove-row').addEventListener('click', () => row.remove());
+    tableBody.appendChild(row);
+  }
+
+  // Load existing schedule
+  const initial = (hiddenField.value || '').trim();
+  if (initial) {
+    initial.split('\n').forEach(line => {
+      const parts = line.split(/[-–]\s*/);
+      const time = parts.shift()?.trim() || '';
+      const activity = parts.join(' - ').trim();
+      addRow(time, activity);
+    });
+  } else {
+    addRow();
+  }
+
+  addRowBtn.addEventListener('click', () => addRow());
+
+  form.addEventListener('submit', () => {
+    const lines = [];
+    tableBody.querySelectorAll('tr').forEach(tr => {
+      const time = tr.querySelector('.time-input').value.trim();
+      const activity = tr.querySelector('.activity-input').value.trim();
+      if (time || activity) {
+        lines.push(`${time} – ${activity}`);
+      }
+    });
+    hiddenField.value = lines.join('\n');
+  });
+});
+

--- a/emt/templates/emt/tentative_flow.html
+++ b/emt/templates/emt/tentative_flow.html
@@ -20,10 +20,21 @@
       <div class="section">
         <h3>Flow Plan</h3>
         <p>Enter a timeline/sequence of the event.</p>
-        <div class="input-group">
-          {{ form.content.label_tag }}
-          {{ form.content }}
-        </div>
+        {% if form.content.errors %}
+          <div class="errorlist">{{ form.content.errors }}</div>
+        {% endif %}
+        <textarea id="id_content" name="content" hidden>{{ form.content.value|default_if_none:'' }}</textarea>
+        <table id="flow-table" class="schedule-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Activity</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <button type="button" id="add-row-btn">Add Row</button>
       </div>
       <div class="input-group">
         <button type="submit" class="btn">Save & Continue</button>
@@ -39,5 +50,6 @@
     window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
     window.AUTOSAVE_CSRF = "{{ csrf_token }}";
   </script>
+  <script src="{% static 'emt/js/tentative_flow.js' %}"></script>
   <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace tentative flow textarea with dynamic schedule table
- add javascript to manage table rows and serialize schedule
- style schedule table and buttons

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a70da10c9c832cb1fd40b3ed049f42