### PR TITLE
Use serial numbers for dynamic activity labels

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -414,11 +414,11 @@ $(document).ready(function() {
                     html += `
                         <div class="dynamic-activity-group">
                             <div class="input-group">
-                                <label for="activity_name_${i}">Activity ${i} Name</label>
+                                <label for="activity_name_${i}">${i}. Activity Name</label>
                                 <input type="text" id="activity_name_${i}" name="activity_name_${i}" required>
                             </div>
                             <div class="input-group">
-                                <label for="activity_date_${i}">Activity ${i} Date</label>
+                                <label for="activity_date_${i}">${i}. Activity Date</label>
                                 <input type="date" id="activity_date_${i}" name="activity_date_${i}" required>
                             </div>
                         </div>`;

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1488,11 +1488,11 @@ function setupDynamicActivities() {
             row.className = 'activity-row';
             row.innerHTML = `
                 <div class="input-group">
-                    <label for="activity_name_${idx + 1}" class="activity-label">Activity ${idx + 1} Name</label>
+                    <label for="activity_name_${idx + 1}" class="activity-label">${idx + 1}. Activity Name</label>
                     <input type="text" id="activity_name_${idx + 1}" name="activity_name_${idx + 1}" value="${act.activity_name || ''}">
                 </div>
                 <div class="input-group">
-                    <label for="activity_date_${idx + 1}" class="date-label">Activity ${idx + 1} Date</label>
+                    <label for="activity_date_${idx + 1}" class="date-label">${idx + 1}. Activity Date</label>
                     <input type="date" id="activity_date_${idx + 1}" name="activity_date_${idx + 1}" value="${act.activity_date || ''}">
                 </div>
                 <button type="button" class="remove-activity" data-index="${idx}">Remove</button>


### PR DESCRIPTION
## Summary
- Display serial-numbered labels for dynamic activity names and dates in proposal and event report forms

## Testing
- `python manage.py test` *(fails: OperationalError - connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a710456870832ca7f590b7956b0c87