### PR TITLE
Add removable activity rows for activities

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -413,6 +413,32 @@ $(document).ready(function() {
         const numActivitiesInput = document.getElementById('num-activities-modern');
         if (!numActivitiesInput || numActivitiesInput.dataset.listenerAttached) return;
         const container = document.getElementById('dynamic-activities-section');
+
+        function reindexActivityRows() {
+            const groups = container.querySelectorAll('.dynamic-activity-group');
+            groups.forEach((group, idx) => {
+                const num = idx + 1;
+                const nameInput = group.querySelector('input[id^="activity_name"]');
+                const dateInput = group.querySelector('input[id^="activity_date"]');
+                const nameLabel = group.querySelector('label[for^="activity_name"]');
+                const dateLabel = group.querySelector('label[for^="activity_date"]');
+                if (nameInput && nameLabel) {
+                    nameInput.id = nameInput.name = `activity_name_${num}`;
+                    nameLabel.setAttribute('for', `activity_name_${num}`);
+                    nameLabel.textContent = `${num}. Activity Name`;
+                }
+                if (dateInput && dateLabel) {
+                    dateInput.id = dateInput.name = `activity_date_${num}`;
+                    dateLabel.setAttribute('for', `activity_date_${num}`);
+                    dateLabel.textContent = `${num}. Activity Date`;
+                }
+            });
+            numActivitiesInput.value = groups.length;
+            if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                window.AutosaveManager.reinitialize();
+            }
+        }
+
         function render(count) {
             if (!container) return;
             container.innerHTML = '';
@@ -429,6 +455,7 @@ $(document).ready(function() {
                                 <label for="activity_date_${i}">${i}. Activity Date</label>
                                 <input type="date" id="activity_date_${i}" name="activity_date_${i}" required>
                             </div>
+                            <button type="button" class="remove-activity">×</button>
                         </div>`;
                 }
                 container.innerHTML = html;
@@ -439,11 +466,20 @@ $(document).ready(function() {
                         $(`#activity_date_${index}`).val(act.date);
                     });
                 }
-                if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
-                    window.AutosaveManager.reinitialize();
-                }
+                reindexActivityRows();
             }
         }
+
+        container.addEventListener('click', (e) => {
+            if (e.target.classList.contains('remove-activity')) {
+                const group = e.target.closest('.dynamic-activity-group');
+                if (group) {
+                    group.remove();
+                    reindexActivityRows();
+                }
+            }
+        });
+
         numActivitiesInput.addEventListener('input', () => {
             const count = parseInt(numActivitiesInput.value, 10);
             render(count);

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1495,7 +1495,7 @@ function setupDynamicActivities() {
                     <label for="activity_date_${idx + 1}" class="date-label">${idx + 1}. Activity Date</label>
                     <input type="date" id="activity_date_${idx + 1}" name="activity_date_${idx + 1}" value="${act.activity_date || ''}">
                 </div>
-                <button type="button" class="remove-activity" data-index="${idx}">Remove</button>
+                <button type="button" class="remove-activity">×</button>
             `;
             container.appendChild(row);
         });
@@ -1505,9 +1505,12 @@ function setupDynamicActivities() {
 
     container.addEventListener('click', (e) => {
         if (e.target.classList.contains('remove-activity')) {
-            const index = parseInt(e.target.dataset.index, 10);
-            activities.splice(index, 1);
-            render();
+            const row = e.target.closest('.activity-row');
+            const index = Array.from(container.children).indexOf(row);
+            if (index > -1) {
+                activities.splice(index, 1);
+                render();
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- add inline remove buttons for dynamic activities on proposal dashboard
- mirror remove-row handling in event report submission

## Testing
- `npm test` *(fails: net::ERR_CERT_AUTHORITY_INVALID at https://example.com)*
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*
- `node` (reindex activities demo)


------
https://chatgpt.com/codex/tasks/task_e_68a7141a77f0832c93792334c9acf335