### PR TITLE
feat: add inline remove buttons for activities

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1048,13 +1048,14 @@
 /* Dynamic Activities Styling */
 .dynamic-activity-group {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr auto;
     gap: 1rem;
     padding: 1rem;
     background: #f9fafb;
     border: 1px solid #e5e7eb;
     border-radius: 8px;
     margin-bottom: 1rem;
+    align-items: center;
 }
 
 .dynamic-activity-group:last-child {
@@ -1066,13 +1067,18 @@
     display: grid;
     grid-template-columns: 1fr 1fr auto;
     gap: 1rem;
-    align-items: flex-end;
+    align-items: center;
     margin-bottom: 0.5rem;
 }
 
-.activity-row .remove-activity {
+.activity-row .remove-activity,
+.dynamic-activity-group .remove-activity {
     align-self: center;
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem;
+    border: none;
+    background: transparent;
+    color: #dc3545;
+    cursor: pointer;
 }
 
 /* Save Section Styling */

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -415,13 +415,13 @@ $(document).ready(function() {
         const container = document.getElementById('dynamic-activities-section');
 
         function reindexActivityRows() {
-            const groups = container.querySelectorAll('.dynamic-activity-group');
-            groups.forEach((group, idx) => {
+            const rows = container.querySelectorAll('.activity-row');
+            rows.forEach((row, idx) => {
                 const num = idx + 1;
-                const nameInput = group.querySelector('input[id^="activity_name"]');
-                const dateInput = group.querySelector('input[id^="activity_date"]');
-                const nameLabel = group.querySelector('label[for^="activity_name"]');
-                const dateLabel = group.querySelector('label[for^="activity_date"]');
+                const nameInput = row.querySelector('input[id^="activity_name"]');
+                const dateInput = row.querySelector('input[id^="activity_date"]');
+                const nameLabel = row.querySelector('label[for^="activity_name"]');
+                const dateLabel = row.querySelector('label[for^="activity_date"]');
                 if (nameInput && nameLabel) {
                     nameInput.id = nameInput.name = `activity_name_${num}`;
                     nameLabel.setAttribute('for', `activity_name_${num}`);
@@ -433,7 +433,7 @@ $(document).ready(function() {
                     dateLabel.textContent = `${num}. Activity Date`;
                 }
             });
-            numActivitiesInput.value = groups.length;
+            numActivitiesInput.value = rows.length;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
@@ -446,7 +446,7 @@ $(document).ready(function() {
                 let html = '';
                 for (let i = 1; i <= Math.min(count, 50); i++) {
                     html += `
-                        <div class="dynamic-activity-group">
+                        <div class="activity-row">
                             <div class="input-group">
                                 <label for="activity_name_${i}">${i}. Activity Name</label>
                                 <input type="text" id="activity_name_${i}" name="activity_name_${i}" required>
@@ -455,7 +455,7 @@ $(document).ready(function() {
                                 <label for="activity_date_${i}">${i}. Activity Date</label>
                                 <input type="date" id="activity_date_${i}" name="activity_date_${i}" required>
                             </div>
-                            <button type="button" class="remove-activity">×</button>
+                            <button type="button" class="remove-activity btn btn-sm btn-outline-danger">×</button>
                         </div>`;
                 }
                 container.innerHTML = html;
@@ -472,9 +472,9 @@ $(document).ready(function() {
 
         container.addEventListener('click', (e) => {
             if (e.target.classList.contains('remove-activity')) {
-                const group = e.target.closest('.dynamic-activity-group');
-                if (group) {
-                    group.remove();
+                const row = e.target.closest('.activity-row');
+                if (row) {
+                    row.remove();
                     reindexActivityRows();
                 }
             }

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1495,7 +1495,7 @@ function setupDynamicActivities() {
                     <label for="activity_date_${idx + 1}" class="date-label">${idx + 1}. Activity Date</label>
                     <input type="date" id="activity_date_${idx + 1}" name="activity_date_${idx + 1}" value="${act.activity_date || ''}">
                 </div>
-                <button type="button" class="remove-activity">×</button>
+                <button type="button" class="remove-activity btn btn-sm btn-outline-danger">×</button>
             `;
             container.appendChild(row);
         });


### PR DESCRIPTION
## Summary
- wrap dynamic activity rows in `.activity-row` containers with inline remove buttons
- style activity rows for three-column layout and compact remove button

## Testing
- `npm test` *(fails: sh: 1: playwright: not found)*
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a9fd4dc832caef906b9651ae4bf