### PR TITLE
Improve autosave error handling in proposal dashboard

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2242,6 +2242,12 @@ function getWhyThisEventForm() {
                         console.error('Autosave failed:', err);
                         if (err && err.errors) {
                             handleAutosaveErrors(err);
+                            if (firstErrorField && firstErrorField.length) {
+                                $('html, body').animate({
+                                    scrollTop: firstErrorField.offset().top - 100
+                                }, 500);
+                                firstErrorField.focus();
+                            }
                         }
                         showNotification('Autosave failed. Please check for missing fields.', 'error');
                     });


### PR DESCRIPTION
## Summary
- Scroll to the first field with an error when autosave validation fails

## Testing
- `npm test` *(fails: playwright: not found)*
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a71d32be80832c9f7e37bc69a28293