### PR TITLE
Skip validation for empty schedule entries

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -175,6 +175,9 @@ def _save_text_sections(proposal, data):
         if field in data:
             content = data.get(field) or ""
             if field == "flow":
+                content = content.strip()
+                if not content:
+                    continue
                 try:
                     content = _clean_flow_content(content)
                 except forms.ValidationError as e:


### PR DESCRIPTION
## Summary
- avoid validating schedule when no entries exist to prevent spurious errors on basic info save

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a723829ae4832c814973b0a22fafea