### PR TITLE
Handle empty flow values in autosave

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -45,7 +45,11 @@ window.AutosaveManager = (function() {
                     || inputs.find(i => i.type !== 'hidden')
                     || inputs.find(i => i.value.trim() !== '')
                     || field;
-                data[name] = preferred.value;
+                let value = preferred.value;
+                if (name === 'flow' && value === '[]') {
+                    value = '';
+                }
+                data[name] = value;
             }
         });
         return data;
@@ -136,7 +140,9 @@ window.AutosaveManager = (function() {
         fields.forEach(f => {
             if (saved.hasOwnProperty(f.name)) {
                 const val = saved[f.name];
-                if (f.type === 'checkbox') {
+                if (f.name === 'flow' && val === '[]') {
+                    f.value = '';
+                } else if (f.type === 'checkbox') {
                     if (Array.isArray(val)) {
                         f.checked = val.includes(f.value);
                     } else {


### PR DESCRIPTION
## Summary
- Avoid persisting "[]" for an empty `flow` when collecting field data
- Skip restoring `flow` value if draft contains "[]"

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*
- `npm test` *(fails: Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68a742778570832cb565cd851a4e658f