### PR TITLE
Enable organization results in global search bar

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3747,24 +3747,25 @@ def api_create_faculty_meeting(request):
 def api_global_search(request):
     """
     Global search API endpoint for the Central Command Center.
-    Searches across Students, Event Proposals, Reports, and Users.
+    Searches across Students, Event Proposals, Reports, Organizations, and Users.
     """
     from django.db.models import Q
     from django.contrib.auth.models import User
     import json
     query = request.GET.get('q', '').strip()
-    if len(query) < 2:
+    if len(query) < 1:
         return JsonResponse({
             'success': True,
             'results': {
                 'students': [],
                 'proposals': [],
                 'reports': [],
+                'organizations': [],
                 'users': []
             }
         })
     try:
-        results = {'students': [], 'proposals': [], 'reports': [], 'users': []}
+        results = {'students': [], 'proposals': [], 'reports': [], 'organizations': [], 'users': []}
         try:
             from transcript.models import Student
             students = Student.objects.filter(
@@ -3843,6 +3844,20 @@ def api_global_search(request):
             } for report in reports]
         except (ImportError, AttributeError):
             results['reports'] = []
+
+        # Organizations
+        organizations = Organization.objects.filter(
+            Q(name__icontains=query) | Q(org_type__name__icontains=query)
+        ).select_related('org_type')[:5]
+        results['organizations'] = [
+            {
+                'id': org.id,
+                'name': org.name,
+                'org_type': org.org_type.name if org.org_type else 'N/A',
+                'url': f'/core-admin/user-roles/{org.id}/'
+            }
+            for org in organizations
+        ]
         if request.user.is_superuser or hasattr(request.user, 'profile'):
             users = User.objects.filter(
                 Q(first_name__icontains=query) |
@@ -3867,6 +3882,7 @@ def api_global_search(request):
                 'students': [],
                 'proposals': [],
                 'reports': [],
+                'organizations': [],
                 'users': []
             }
         }, status=500)

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
       <div class="utility-center" style="flex: 1; display: flex; justify-content: center;">
         <div class="universal-search" style="max-width: 500px; width: 100%;">
           <i class="fas fa-search search-icon"></i>
-          <input type="text" id="globalSearch" placeholder="Search students, reports, proposals..." class="search-input" autocomplete="off">
+          <input type="text" id="globalSearch" placeholder="Search students, reports, proposals, organizations..." class="search-input" autocomplete="off">
           <div class="search-shortcut">Ctrl+K</div>
           <div class="search-results" id="searchResults"></div>
         </div>
@@ -407,7 +407,7 @@
           // Clear previous timeout
           clearTimeout(searchTimeout);
           
-          if (query.length < 2) {
+          if (query.length < 1) {
             searchResults.classList.remove('show');
             return;
           }
@@ -456,10 +456,11 @@
           .then(data => {
             if (data.success) {
               displaySearchResults(
-                data.results.students || [], 
-                data.results.proposals || [], 
+                data.results.students || [],
+                data.results.proposals || [],
                 data.results.reports || [],
                 data.results.users || [],
+                data.results.organizations || [],
                 query
               );
             } else {
@@ -490,10 +491,10 @@
         return cookieValue;
       }
 
-      function displaySearchResults(students, proposals, reports, users, query) {
+      function displaySearchResults(students, proposals, reports, users, organizations, query) {
         let html = '';
 
-        if (students.length === 0 && proposals.length === 0 && reports.length === 0 && users.length === 0) {
+        if (students.length === 0 && proposals.length === 0 && reports.length === 0 && users.length === 0 && organizations.length === 0) {
           html = `<div class="search-no-results">No results found for "${query}"</div>`;
         } else {
           // Students section
@@ -544,6 +545,24 @@
                   <div class="search-item-content">
                     <div class="search-item-title">${report.title}</div>
                     <div class="search-item-subtitle">${report.date} • ${report.type}</div>
+                  </div>
+                </a>
+              `;
+            });
+          }
+
+          // Organizations section
+          if (organizations.length > 0) {
+            html += '<div class="search-category">Organizations</div>';
+            organizations.forEach(org => {
+              html += `
+                <a href="${org.url}" class="search-item">
+                  <div class="search-item-icon">
+                    <i class="fas fa-building"></i>
+                  </div>
+                  <div class="search-item-content">
+                    <div class="search-item-title">${org.name}</div>
+                    <div class="search-item-subtitle">${org.org_type}</div>
                   </div>
                 </a>
               `;


### PR DESCRIPTION
## Summary
- extend global search endpoint to return organizations
- show organization matches in universal search dropdown
- allow single-character queries

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a74485d4f8832cbd9a6d2079b20190