### PR TITLE
feat: allow resetting proposal drafts

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -88,6 +88,28 @@ $(document).ready(function() {
         link.attr('data-url', url);
     }
 
+    function resetProposalDraft() {
+        if (!confirm('Are you sure you want to reset this draft?')) return;
+        const pid = window.PROPOSAL_ID;
+        fetch(window.RESET_DRAFT_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': window.AUTOSAVE_CSRF || ''
+            },
+            body: JSON.stringify({ proposal_id: pid })
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                window.location.href = window.RESET_DRAFT_REDIRECT_URL;
+            } else {
+                alert('Failed to reset draft');
+            }
+        })
+        .catch(() => alert('Failed to reset draft'));
+    }
+
     initializeDashboard();
 
     function initializeDashboard() {
@@ -100,6 +122,7 @@ $(document).ready(function() {
             updateCdlNavLink(window.PROPOSAL_ID);
         }
         $('#autofill-btn').on('click', () => autofillTestData(currentExpandedCard));
+        $('#reset-draft-btn').on('click', resetProposalDraft);
         if (!$('.form-errors-banner').length) {
             setTimeout(() => {
                 activateSection('basic-info');

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -87,6 +87,9 @@
             <h1 class="content-title" id="main-title">Basic Information</h1>
             <p class="content-subtitle" id="main-subtitle">Organization details and event basics</p>
             <button type="button" id="autofill-btn" class="btn-draft" style="margin-top:0.5rem;">Auto-Fill Test Data</button>
+            {% if proposal %}
+            <button type="button" id="reset-draft-btn" class="btn-draft" style="margin-top:0.5rem; margin-left:0.5rem;">Reset Draft</button>
+            {% endif %}
         </div>
 
         {% if form.errors %}
@@ -372,6 +375,8 @@
         window.PROPOSAL_STATUS = "{{ proposal.status|default:'draft' }}";
         window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
         window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+        window.RESET_DRAFT_URL = "{% url 'emt:reset_proposal_draft' %}";
+        window.RESET_DRAFT_REDIRECT_URL = "{% url 'emt:submit_proposal' %}";
         window.API_ORGANIZATIONS = "{% url 'emt:api_organizations' %}";
         window.API_FACULTY = "{% url 'emt:api_faculty' %}";
         window.API_CLASSES_BASE = "{% url 'emt:api_classes' 0 %}".split('0/')[0];

--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -382,6 +382,24 @@ class AutosaveProposalTests(TestCase):
         self.assertIn("speakers", data.get("errors", {}))
         self.assertIn("full_name", data["errors"]["speakers"]["0"])
 
+    def test_reset_proposal_draft_deletes_draft(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        pid = resp.json()["proposal_id"]
+        self.assertTrue(EventProposal.objects.filter(id=pid).exists())
+
+        resp2 = self.client.post(
+            reverse("emt:reset_proposal_draft"),
+            data=json.dumps({"proposal_id": pid}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp2.status_code, 200)
+        self.assertFalse(EventProposal.objects.filter(id=pid).exists())
+
 
 class EventProposalOrganizationPrefillTests(TestCase):
     def setUp(self):

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('cdl/post-event/<int:proposal_id>/', views.cdl_post_event, name='cdl_post_event'),
     path('proposal-status/<int:proposal_id>/', views.proposal_status_detail, name='proposal_status_detail'),
     path('autosave-proposal/', views.autosave_proposal, name='autosave_proposal'),
+    path('reset-proposal-draft/', views.reset_proposal_draft, name='reset_proposal_draft'),
     path('autosave-need-analysis/', views.autosave_need_analysis, name='autosave_need_analysis'),
     path('pending-reports/', views.pending_reports, name='pending_reports'),
     path('generate-report/<int:proposal_id>/', views.generate_report, name='generate_report'),

--- a/emt/views.py
+++ b/emt/views.py
@@ -575,6 +575,29 @@ def autosave_proposal(request):
     return JsonResponse({"success": True, "proposal_id": proposal.id})
 
 
+@login_required
+@require_POST
+def reset_proposal_draft(request):
+    """Delete the current draft proposal and its related data."""
+    try:
+        data = json.loads(request.body.decode("utf-8")) if request.body else {}
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
+
+    pid = data.get("proposal_id")
+    if not pid:
+        return JsonResponse({"success": False, "error": "proposal_id required"}, status=400)
+
+    proposal = EventProposal.objects.filter(
+        id=pid, submitted_by=request.user, status="draft"
+    ).first()
+    if not proposal:
+        return JsonResponse({"success": False, "error": "Draft not found"}, status=404)
+
+    proposal.delete()
+    return JsonResponse({"success": True})
+
+
 # ──────────────────────────────────────────────────────────────
 #  Remaining steps (unchanged)
 # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add Reset Draft button to proposal submission page
- support clearing draft proposals via new endpoint
- cover draft reset with tests

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7481fcf5c832cabeefa68b11925f2