### PR TITLE
Add proposal review step before final submission

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3274,7 +3274,7 @@ function addSubmitSection() {
       <h5 class="mb-3" style="color: var(--primary-blue); font-weight: 600;">Submit Proposal</h5>
       <div class="d-flex gap-3 justify-content-center">
         <button type="button" class="btn-save-section" onclick="saveDraft()">Save as Draft</button>
-        <button type="submit" class="btn-submit">Submit Proposal</button>
+        <button type="submit" class="btn-submit" name="review_submit">Submit Proposal</button>
       </div>
       <p class="submit-help-text">Review all sections before final submission</p>
     </div>

--- a/emt/templates/emt/review_proposal.html
+++ b/emt/templates/emt/review_proposal.html
@@ -1,0 +1,157 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Review Proposal{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" href="{% static 'emt/css/proposal_status_detail.css' %}">
+<link rel="stylesheet" href="{% static 'emt/css/review_proposal.css' %}">
+
+<div class="detail-container review-grid">
+  <!-- LEFT COLUMN: Event Info Card -->
+  <aside class="timeline-column review-side">
+    <div class="info-card event-details-card">
+      <h2>Event Information</h2>
+      <table>
+        <tr><th>Organization</th><td>{{ proposal.organization.name|default:"—" }}</td></tr>
+        <tr>
+          <th>Committees &amp; Collaborations</th>
+          <td>
+            {% if proposal.committees_collaborations %}
+              {{ proposal.committees_collaborations }}
+            {% elif proposal.committees %}
+              {{ proposal.committees }}
+            {% else %}
+              —
+            {% endif %}
+          </td>
+        </tr>
+        <tr><th>Event Title</th><td>{{ proposal.event_title }}</td></tr>
+        <tr><th>No. of Activities</th><td>{{ proposal.num_activities|default:"—" }}</td></tr>
+        <tr>
+          <th>Start Date</th>
+          <td>
+            {% if proposal.event_start_date %}
+              {{ proposal.event_start_date|date:"d M Y" }}
+            {% elif proposal.event_datetime %}
+              {{ proposal.event_datetime|date:"d M Y" }}
+            {% else %}
+              —
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>End Date</th>
+          <td>
+            {% if proposal.event_end_date %}
+              {{ proposal.event_end_date|date:"d M Y" }}
+            {% elif proposal.event_datetime %}
+              {{ proposal.event_datetime|date:"d M Y" }}
+            {% else %}
+              —
+            {% endif %}
+          </td>
+        </tr>
+        <tr><th>Venue</th><td>{{ proposal.venue|default:"—" }}</td></tr>
+        <tr><th>Academic Year</th><td>{{ proposal.academic_year|default:"—" }}</td></tr>
+        <tr><th>Target Audience</th><td>{{ proposal.target_audience|default:"—" }}</td></tr>
+        <tr><th>POS &amp; PSO</th><td>{{ proposal.pos_pso|default:"—" }}</td></tr>
+        <tr>
+          <th>SDG Goals</th>
+          <td>
+            {% with goals=proposal.sdg_goals.all %}
+              {% if goals %}
+                {% for goal in goals %}
+                  {{ goal.name }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+              {% else %}
+                —
+              {% endif %}
+            {% endwith %}
+          </td>
+        </tr>
+        <tr>
+          <th>Faculty Incharges</th>
+          <td>
+            {% with facs=proposal.faculty_incharges.all %}
+              {% if facs %}
+                {% for fac in facs %}
+                  {{ fac.get_full_name|default:fac.username }} ({{ fac.email }}){% if not forloop.last %}, {% endif %}
+                {% endfor %}
+              {% else %}
+                —
+              {% endif %}
+            {% endwith %}
+          </td>
+        </tr>
+        <tr><th>Student Coordinators</th><td>{{ proposal.student_coordinators|default:"—" }}</td></tr>
+        <tr><th>Type (Focus)</th><td>{{ proposal.event_focus_type|default:"—" }}</td></tr>
+      </table>
+    </div>
+  </aside>
+
+  <!-- RIGHT COLUMN: Proposal Details -->
+  <main class="details-column review-main">
+    <header class="review-header overview-card">
+      <div class="review-heading">
+        <h1 class="review-title">Review Proposal</h1>
+        <span class="meta">{{ proposal.event_title }}</span>
+      </div>
+      <div class="review-actions">
+        <a href="{% url 'emt:submit_proposal_with_pk' proposal.id %}" class="btn-save-section">Edit</a>
+        <form method="post" style="display:inline;">
+          {% csrf_token %}
+          <button type="submit" name="final_submit" class="btn-submit">Confirm Submit</button>
+        </form>
+      </div>
+    </header>
+
+    {% include "emt/partials/review_section.html" with title="Need Analysis" body=need_analysis.content %}
+    {% include "emt/partials/review_section.html" with title="Objectives" body=objectives.content %}
+    {% include "emt/partials/review_section.html" with title="Expected Outcomes" body=outcomes.content %}
+    {% include "emt/partials/review_section.html" with title="Tentative Flow" body=flow.content %}
+
+    <div class="event-details-card">
+      <h3>Speaker Profile</h3>
+      {% if speakers %}
+        {% for sp in speakers %}
+          <div class="speaker-profile-block">
+            <div><strong>{{ sp.full_name }}</strong> - {{ sp.designation }}{% if sp.affiliation %} ({{ sp.affiliation }}){% endif %}</div>
+            {% if sp.detailed_profile %}<div>{{ sp.detailed_profile|linebreaksbr }}</div>{% endif %}
+          </div>
+        {% endfor %}
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
+    </div>
+
+    <div class="event-details-card">
+      <h3>Expense Details</h3>
+      {% if expenses %}
+        <table class="review-table">
+          <tr><th>Sl. No.</th><th>Particulars</th><th>Amount</th></tr>
+          {% for e in expenses %}
+            <tr><td>{{ e.sl_no }}</td><td>{{ e.particulars }}</td><td>{{ e.amount }}</td></tr>
+          {% endfor %}
+        </table>
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
+    </div>
+
+    <div class="event-details-card">
+      <h3>Income Details</h3>
+      {% if income %}
+        <table class="review-table">
+          <tr><th>Sl. No.</th><th>Particulars</th><th>Participants</th><th>Rate</th><th>Amount</th></tr>
+          {% for i in income %}
+            <tr><td>{{ i.sl_no }}</td><td>{{ i.particulars }}</td><td>{{ i.participants }}</td><td>{{ i.rate }}</td><td>{{ i.amount }}</td></tr>
+          {% endfor %}
+        </table>
+      {% else %}
+        <div class="detail-block">—</div>
+      {% endif %}
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/emt/tests/test_proposal_review.py
+++ b/emt/tests/test_proposal_review.py
@@ -1,0 +1,51 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+import json
+
+from emt.models import EventProposal
+from core.models import (
+    OrganizationType,
+    Organization,
+    OrganizationRole,
+    RoleAssignment,
+)
+
+
+class ProposalReviewFlowTests(TestCase):
+    def setUp(self):
+        self.ot = OrganizationType.objects.create(name="Dept")
+        self.org = Organization.objects.create(name="Science", org_type=self.ot)
+        self.faculty_role = OrganizationRole.objects.create(
+            organization=self.org, name="Faculty"
+        )
+        self.user = User.objects.create(username="u1", first_name="Test", email="u1@example.com")
+        RoleAssignment.objects.create(user=self.user, role=self.faculty_role, organization=self.org)
+        self.client.force_login(self.user)
+
+    def _payload(self):
+        return {
+            "organization_type": str(self.ot.id),
+            "organization": str(self.org.id),
+            "academic_year": "2024-2025",
+        }
+
+    def test_review_and_final_submit_flow(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        pid = resp.json()["proposal_id"]
+
+        post_data = self._payload()
+        post_data["review_submit"] = "1"
+        resp2 = self.client.post(reverse("emt:submit_proposal_with_pk", args=[pid]), post_data)
+        self.assertEqual(resp2.status_code, 302)
+        self.assertIn(reverse("emt:review_proposal", args=[pid]), resp2.headers["Location"])
+
+        resp3 = self.client.post(reverse("emt:review_proposal", args=[pid]), {"final_submit": "1"})
+        self.assertEqual(resp3.status_code, 302)
+        proposal = EventProposal.objects.get(id=pid)
+        self.assertEqual(proposal.status, EventProposal.Status.SUBMITTED)

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path('cdl-support/<int:proposal_id>/', views.submit_cdl_support, name='submit_cdl_support'),
     path('cdl/post-event/<int:proposal_id>/', views.cdl_post_event, name='cdl_post_event'),
     path('proposal-status/<int:proposal_id>/', views.proposal_status_detail, name='proposal_status_detail'),
+    path('review/<int:proposal_id>/', views.review_proposal, name='review_proposal'),
     path('autosave-proposal/', views.autosave_proposal, name='autosave_proposal'),
     path('reset-proposal-draft/', views.reset_proposal_draft, name='reset_proposal_draft'),
     path('autosave-need-analysis/', views.autosave_need_analysis, name='autosave_need_analysis'),


### PR DESCRIPTION
## Summary
- Introduce a review screen that summarizes proposal details and allows editing before confirming submission
- Send proposal form submission to the new review step via `review_submit`
- Cover review-to-final submission flow with tests

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a749a47df4832ca23b42f5e532a5ee