### PR TITLE
Ensure Reset Draft control always visible next to Auto-Fill

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -21,6 +21,12 @@
   cursor: not-allowed;
 }
 
+.content-actions {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
 /* Ensure consistent font size for Save & Continue button */
 .btn-save-section {
   font-size: 1rem !important;

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -86,10 +86,10 @@
         <div class="content-header">
             <h1 class="content-title" id="main-title">Basic Information</h1>
             <p class="content-subtitle" id="main-subtitle">Organization details and event basics</p>
-            <button type="button" id="autofill-btn" class="btn-draft" style="margin-top:0.5rem;">Auto-Fill Test Data</button>
-            {% if proposal %}
-            <button type="button" id="reset-draft-btn" class="btn-draft" style="margin-top:0.5rem; margin-left:0.5rem;">Reset Draft</button>
-            {% endif %}
+            <div class="content-actions">
+                <button type="button" id="autofill-btn" class="btn-draft">Auto-Fill Test Data</button>
+                <button type="button" id="reset-draft-btn" class="btn-draft">Reset Draft</button>
+            </div>
         </div>
 
         {% if form.errors %}


### PR DESCRIPTION
## Summary
- Always show Reset Draft button beside Auto-Fill on submit proposal page
- Group actions with new `content-actions` flex container
- Add CSS for action container and confirm JS binding remains

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*
- `npm test` *(fails: page.goto net::ERR_CERT_AUTHORITY_INVALID at https://example.com/)*

------
https://chatgpt.com/codex/tasks/task_e_68a74afa2758832cbc698322f6c1ad90