### PR TITLE
Guard reset draft without proposal

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -89,6 +89,10 @@ $(document).ready(function() {
     }
 
     function resetProposalDraft() {
+        if (!window.PROPOSAL_ID) {
+            alert('No saved draft to reset yet.');
+            return;
+        }
         if (!confirm('Are you sure you want to reset this draft?')) return;
         const pid = window.PROPOSAL_ID;
         fetch(window.RESET_DRAFT_URL, {
@@ -3039,6 +3043,7 @@ function getWhyThisEventForm() {
             if (detail && detail.proposalId) {
                 window.PROPOSAL_ID = detail.proposalId;
                 updateCdlNavLink(detail.proposalId);
+                $('#reset-draft-btn').prop('disabled', false);
             }
             const indicator = $('#autosave-indicator');
             indicator.removeClass('saving error').addClass('saved');

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -88,7 +88,8 @@
             <p class="content-subtitle" id="main-subtitle">Organization details and event basics</p>
             <div class="content-actions">
                 <button type="button" id="autofill-btn" class="btn-draft">Auto-Fill Test Data</button>
-                <button type="button" id="reset-draft-btn" class="btn-draft">Reset Draft</button>
+                <button type="button" id="reset-draft-btn" class="btn-draft"
+                        {% if not proposal.id %}disabled{% endif %}>Reset Draft</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Guard `resetProposalDraft` against missing `PROPOSAL_ID`
- Disable reset draft button until a draft exists and enable after autosave

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d53fde4832caaf836083e84344c