### PR TITLE
Enable reset draft button after autosave

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -124,6 +124,7 @@ $(document).ready(function() {
         enablePreviouslyVisitedSections();
         if (window.PROPOSAL_ID) {
             updateCdlNavLink(window.PROPOSAL_ID);
+            $('#reset-draft-btn').prop('disabled', false).removeAttr('disabled');
         }
         $('#autofill-btn').on('click', () => autofillTestData(currentExpandedCard));
         $('#reset-draft-btn').on('click', resetProposalDraft);
@@ -3043,7 +3044,7 @@ function getWhyThisEventForm() {
             if (detail && detail.proposalId) {
                 window.PROPOSAL_ID = detail.proposalId;
                 updateCdlNavLink(detail.proposalId);
-                $('#reset-draft-btn').prop('disabled', false);
+                $('#reset-draft-btn').prop('disabled', false).removeAttr('disabled');
             }
             const indicator = $('#autosave-indicator');
             indicator.removeClass('saving error').addClass('saved');


### PR DESCRIPTION
## Summary
- Re-enable reset draft button when autosave succeeds and assign proposal ID
- On dashboard init, enable reset button immediately if a proposal already exists

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*
- `npm test` *(fails: page.goto: net::ERR_CERT_AUTHORITY_INVALID at https://example.com/)*
- `node -` manual verification script confirms button is enabled after init and autosave


------
https://chatgpt.com/codex/tasks/task_e_68a74efb1d5c832ca9aa55f6a8d18066