### PR TITLE
Reset draft proposal form to clear inputs and autosave data

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -129,16 +129,22 @@ $(document).ready(function() {
 
         if (!confirm('Are you sure you want to reset this draft?')) return;
 
-        formFields.each(function() {
-            if (this.type === 'checkbox' || this.type === 'radio') {
-                this.checked = false;
-            } else {
-                $(this).val('');
-            }
-        }).trigger('change');
+        const form = document.getElementById('proposal-form');
+        if (form) {
+            form.reset();
+            Array.from(form.elements).forEach(el => {
+                el.classList.remove('is-invalid', 'is-valid', 'has-error');
+                $(el).siblings('.error-message').remove();
+            });
+            $(form).find('input, textarea, select').trigger('change');
+        }
 
         ['section_need_analysis', 'section_objectives', 'section_outcomes', 'section_flow']
             .forEach(key => localStorage.removeItem(key));
+
+        if (window.AutosaveManager && window.AutosaveManager.clearLocal) {
+            window.AutosaveManager.clearLocal();
+        }
 
         clearValidationErrors();
         updateResetButtonState();


### PR DESCRIPTION
## Summary
- Replace manual input clearing with form.reset
- Remove validation state and local storage including autosave data
- Re-disable reset button after clearing

## Testing
- ⚠️ `python manage.py test` (database connection error)
- ⚠️ `npm test` (playwright not found)


------
https://chatgpt.com/codex/tasks/task_e_68a7532bff3c832cbbd4feb68e1c6dd6