### PR TITLE
Remove draft options from CDL proposal section and direct to review

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3336,13 +3336,12 @@ function addSubmitSection() {
     return;
   }
 
-  // Create the submit section HTML with proper application styling
+  // Create the submit section HTML with only the final submit action
   const submitSectionHTML = `
     <div class="submit-section">
       <h5 class="mb-3" style="color: var(--primary-blue); font-weight: 600;">Submit Proposal</h5>
       <div class="d-flex gap-3 justify-content-center">
-        <button type="button" class="btn-save-section" onclick="saveDraft()">Save as Draft</button>
-        <button type="submit" class="btn-submit" name="review_submit">Submit Proposal</button>
+        <button type="submit" class="btn-submit" name="review_submit" id="submit-proposal-btn" disabled>Submit Proposal</button>
       </div>
       <p class="submit-help-text">Review all sections before final submission</p>
     </div>
@@ -3359,21 +3358,3 @@ function removeSubmitSection() {
   }
 }
 
-// Function to manually save draft
-function saveDraft() {
-  showLoadingOverlay();
-  if (window.autosaveDraft) {
-    window.autosaveDraft().then(() => {
-      hideLoadingOverlay();
-      alert('Draft saved successfully!');
-    }).catch((error) => {
-      hideLoadingOverlay();
-      console.error('Failed to save draft:', error);
-      alert('Failed to save draft. Please try again.');
-    });
-  } else {
-    hideLoadingOverlay();
-    console.error('Autosave function not available');
-    alert('Save function not available. Please try submitting the form.');
-  }
-}

--- a/emt/templates/emt/cdl_support.html
+++ b/emt/templates/emt/cdl_support.html
@@ -193,13 +193,6 @@
       </div>
     </div>
 
-    <!-- Save Section - Matching Income Layout -->
-    <div class="form-row full-width">
-      <div class="save-section-container">
-        <button type="submit" class="btn-save-section" id="submit-proposal-btn">SAVE & CONTINUE</button>
-        <div class="save-help-text">Complete this section to unlock the next one</div>
-      </div>
-    </div>
   </form>
 </div>
 


### PR DESCRIPTION
## Summary
- remove unused Save & Continue block from CDL support step
- streamline final submit area with single Submit Proposal button and remove manual draft code

## Testing
- ❌ `python manage.py test emt.tests.test_proposal_review -v 2` (database connection failed: Network is unreachable)

------
https://chatgpt.com/codex/tasks/task_e_68a757b362b0832c9def116ffbad9278