### PR TITLE
Use proposal data when viewing event reports

### DIFF
--- a/emt/models.py
+++ b/emt/models.py
@@ -12,9 +12,8 @@ class EventProposal(models.Model):
 
     @property
     def title(self):
-        if self.proposal and self.proposal.event_title:
-            return self.proposal.event_title
-        return "Untitled Event Report"
+        """Convenience property to return the proposal's event title."""
+        return self.event_title or "Untitled Event"
     class Status(models.TextChoices):
         DRAFT = 'draft', 'Draft'
         SUBMITTED = 'submitted', 'Submitted'

--- a/emt/templates/emt/view_report.html
+++ b/emt/templates/emt/view_report.html
@@ -37,9 +37,9 @@
             <!-- Report Content -->
             <div class="report-content-wrapper">
                 <div class="report-title">
-                    <h2>{{ report.proposal.title|default:"Untitled Event" }}</h2>
+                    <h2>{{ report.proposal.event_title|default:"Untitled Event" }}</h2>
                 </div>
-                
+
                 <div class="report-meta-grid">
                     <div class="meta-row">
                         <span class="meta-label">Organization:</span>
@@ -47,7 +47,18 @@
                     </div>
                     <div class="meta-row">
                         <span class="meta-label">Event Date:</span>
-                        <span class="meta-value">{{ report.proposal.event_datetime|date:"M j, Y" }}</span>
+                        <span class="meta-value">
+                            {% if report.proposal.event_start_date %}
+                                {{ report.proposal.event_start_date|date:"M j, Y" }}
+                                {% if report.proposal.event_end_date and report.proposal.event_end_date != report.proposal.event_start_date %}
+                                    - {{ report.proposal.event_end_date|date:"M j, Y" }}
+                                {% endif %}
+                            {% elif report.proposal.event_datetime %}
+                                {{ report.proposal.event_datetime|date:"M j, Y" }}
+                            {% else %}
+                                N/A
+                            {% endif %}
+                        </span>
                     </div>
                     <div class="meta-row">
                         <span class="meta-label">Report Generated:</span>


### PR DESCRIPTION
## Summary
- expose `EventProposal.title` so templates can access the original event title
- show proposal title and proper date range on event report view

## Testing
- `python manage.py test emt.tests.test_event_report_view` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eb58d44c832ca4b46f849565fcdf