### PR TITLE
Add review and persist AI-generated text

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3286,28 +3286,39 @@ function showCard(field, content){
 function applyGeneratedToField(field, text) {
   const id = `id_${field}`;
 
+  function triggerSave() {
+    if (window.AutosaveManager && window.AutosaveManager.manualSave) {
+      try { window.AutosaveManager.manualSave(); } catch (e) {}
+    }
+  }
+
   if (window.CKEDITOR && CKEDITOR.instances[id]) {
     CKEDITOR.instances[id].setData(text);
+    triggerSave();
     return;
   }
   if (window.ClassicEditor && window._editors && window._editors[field]) {
     window._editors[field].setData(text);
+    triggerSave();
     return;
   }
   if (window.tinymce && tinymce.get(id)) {
     tinymce.get(id).setContent(text);
+    triggerSave();
     return;
   }
   if (window.Quill && window._quills && window._quills[field]) {
     const q = window._quills[field];
     q.setText("");
     q.clipboard.dangerouslyPasteHTML(0, text);
+    triggerSave();
     return;
   }
   const el = document.getElementById(id);
   if (el) {
     el.value = text;
     el.dispatchEvent(new Event('input', { bubbles: true }));
+    triggerSave();
   }
 }
 

--- a/emt/templates/emt/need_analysis.html
+++ b/emt/templates/emt/need_analysis.html
@@ -61,6 +61,10 @@
         const data = await resp.json();
         if (resp.ok && data.ok) {
           textarea.value = textarea.value ? textarea.value + '\n' + data.text : data.text;
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+          if (window.AutosaveManager && window.AutosaveManager.manualSave) {
+            try { window.AutosaveManager.manualSave(); } catch (e) {}
+          }
           textarea.focus();
         } else {
           aiErr.textContent = data.error || 'Generation failed';

--- a/emt/templates/emt/review_proposal.html
+++ b/emt/templates/emt/review_proposal.html
@@ -160,9 +160,21 @@
         <tr><th>Needs Support</th><td>{{ cdl_support.needs_support|yesno:"Yes,No" }}</td></tr>
         {% if cdl_support.poster_required %}
         <tr><th>Poster</th><td>{{ cdl_support.get_poster_choice_display }}</td></tr>
+        {% if cdl_support.organization_name %}<tr><th>Organization</th><td>{{ cdl_support.organization_name }}</td></tr>{% endif %}
+        {% if cdl_support.poster_event_title %}<tr><th>Poster Title</th><td>{{ cdl_support.poster_event_title }}</td></tr>{% endif %}
+        {% if cdl_support.poster_date %}<tr><th>Poster Date</th><td>{{ cdl_support.poster_date }}</td></tr>{% endif %}
+        {% if cdl_support.poster_time %}<tr><th>Poster Time</th><td>{{ cdl_support.poster_time }}</td></tr>{% endif %}
+        {% if cdl_support.poster_venue %}<tr><th>Poster Venue</th><td>{{ cdl_support.poster_venue }}</td></tr>{% endif %}
+        {% if cdl_support.resource_person_name %}
+        <tr><th>Resource Person</th><td>{{ cdl_support.resource_person_name }}{% if cdl_support.resource_person_designation %} ({{ cdl_support.resource_person_designation }}){% endif %}</td></tr>
+        {% endif %}
+        {% if cdl_support.poster_summary %}<tr><th>Poster Summary</th><td>{{ cdl_support.poster_summary|linebreaksbr }}</td></tr>{% endif %}
+        {% if cdl_support.poster_design_link %}<tr><th>Poster Design Link</th><td><a href="{{ cdl_support.poster_design_link }}">{{ cdl_support.poster_design_link }}</a></td></tr>{% endif %}
         {% endif %}
         {% if cdl_support.certificates_required %}
         <tr><th>Certificates</th><td>{{ cdl_support.get_certificate_choice_display }}</td></tr>
+        {% if cdl_support.certificate_help %}<tr><th>Certificate Help</th><td>Yes</td></tr>{% endif %}
+        {% if cdl_support.certificate_design_link %}<tr><th>Certificate Design Link</th><td><a href="{{ cdl_support.certificate_design_link }}">{{ cdl_support.certificate_design_link }}</a></td></tr>{% endif %}
         {% endif %}
         {% if cdl_support.other_services %}
         <tr><th>Other Services</th><td>{{ cdl_support.other_services|join:", " }}</td></tr>

--- a/emt/tests/test_proposal_review.py
+++ b/emt/tests/test_proposal_review.py
@@ -50,13 +50,12 @@ class ProposalReviewFlowTests(TestCase):
         proposal = EventProposal.objects.get(id=pid)
         self.assertEqual(proposal.status, EventProposal.Status.SUBMITTED)
 
-    def test_review_displays_cdl_support(self):
+    def test_review_displays_all_cdl_support(self):
         resp = self.client.post(
             reverse("emt:autosave_proposal"),
             data=json.dumps(self._payload()),
             content_type="application/json",
         )
-        self.assertEqual(resp.status_code, 200)
         pid = resp.json()["proposal_id"]
         proposal = EventProposal.objects.get(id=pid)
 
@@ -65,11 +64,29 @@ class ProposalReviewFlowTests(TestCase):
             needs_support=True,
             poster_required=True,
             poster_choice=CDLSupport.PosterChoice.CDL_CREATE,
+            organization_name="OrgX",
+            poster_time="10am",
+            poster_date="2024-06-01",
+            poster_venue="Hall 1",
+            resource_person_name="Dr. Smith",
+            resource_person_designation="Professor",
+            poster_event_title="PosterTitle",
+            poster_summary="Summary text",
+            poster_design_link="http://example.com/poster",
+            certificates_required=True,
+            certificate_help=True,
+            certificate_choice=CDLSupport.CertificateChoice.CDL_CREATE,
+            certificate_design_link="http://example.com/cert",
+            other_services=["Photos"],
+            blog_content="Blog text",
         )
 
         resp = self.client.get(reverse("emt:review_proposal", args=[pid]))
-        self.assertContains(resp, "CDL Support")
-        self.assertContains(resp, "Ask CDL to make the poster")
+        self.assertContains(resp, "OrgX")
+        self.assertContains(resp, "Hall 1")
+        self.assertContains(resp, "Dr. Smith")
+        self.assertContains(resp, "Blog text")
+        self.assertContains(resp, "Photos")
 
     def test_cdl_support_review_flow(self):
         resp = self.client.post(
@@ -87,3 +104,29 @@ class ProposalReviewFlowTests(TestCase):
 
         proposal = EventProposal.objects.get(id=pid)
         self.assertEqual(proposal.status, EventProposal.Status.DRAFT)
+
+    def test_ai_generated_text_persists(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        pid = resp.json()["proposal_id"]
+
+        ai_data = {
+            **self._payload(),
+            "proposal_id": pid,
+            "need_analysis": "AI need",
+            "objectives": "AI objectives",
+            "outcomes": "AI outcomes",
+        }
+        self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(ai_data),
+            content_type="application/json",
+        )
+
+        resp2 = self.client.get(reverse("emt:review_proposal", args=[pid]))
+        self.assertContains(resp2, "AI need")
+        self.assertContains(resp2, "AI objectives")
+        self.assertContains(resp2, "AI outcomes")


### PR DESCRIPTION
## Summary
- Trigger manual autosave when AI text is inserted into proposal fields.
- Save AI-generated Need Analysis immediately.
- Expand review page with detailed CDL support information.
- Add regression tests for CDL support display and AI-text persistence.

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f00de828832c8f6c1a9a62ca6e50