### PR TITLE
Add review section edit links and persist AI text

### DIFF
--- a/emt/static/emt/css/review_proposal.css
+++ b/emt/static/emt/css/review_proposal.css
@@ -198,6 +198,23 @@ body {
   gap: 14px;
   box-shadow: 0 1px 7px rgba(36,70,120,0.06);
 }
+
+.review-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-sm);
+}
+
+.section-edit-link {
+  font-size: 0.9rem;
+  color: var(--christ-blue-primary);
+}
+
+.section-edit-link:hover,
+.section-edit-link:focus {
+  text-decoration: underline;
+}
 .speaker-profile-block .profile-aff {
   color: var(--christ-blue-primary); font-weight: 600; margin-left: 8px;
 }

--- a/emt/templates/emt/ai_generate_report.html
+++ b/emt/templates/emt/ai_generate_report.html
@@ -87,7 +87,12 @@ function aiRequest() {
     document.getElementById('generate-ai-btn').disabled = false;
     if (res.report_text) {
       document.getElementById('aiPreviewBlock').style.display = 'block';
-      document.getElementById('aiReportEditor').value = res.report_text;
+      const editor = document.getElementById('aiReportEditor');
+      editor.value = res.report_text;
+      editor.dispatchEvent(new Event('input', { bubbles: true }));
+      if (window.AutosaveManager && window.AutosaveManager.manualSave) {
+        try { window.AutosaveManager.manualSave(); } catch (e) {}
+      }
     } else {
       alert(res.error || "AI failed, try again.");
     }

--- a/emt/templates/emt/partials/review_section.html
+++ b/emt/templates/emt/partials/review_section.html
@@ -1,6 +1,11 @@
 {# Reusable section card for proposal review #}
 <div class="event-details-card">
-  <h3>{{ title }}</h3>
+  <div class="review-section-header">
+    <h3>{{ title }}</h3>
+    {% if edit_url %}
+      <a href="{{ edit_url }}" class="section-edit-link">Edit</a>
+    {% endif %}
+  </div>
   {% if body %}
     <div class="detail-block">{{ body|linebreaksbr }}</div>
   {% else %}

--- a/emt/templates/emt/review_proposal.html
+++ b/emt/templates/emt/review_proposal.html
@@ -105,14 +105,24 @@
         </form>
       </div>
     </header>
+    {% url 'emt:submit_need_analysis' proposal.id as need_edit %}
+    {% url 'emt:submit_objectives' proposal.id as obj_edit %}
+    {% url 'emt:submit_expected_outcomes' proposal.id as out_edit %}
+    {% url 'emt:submit_tentative_flow' proposal.id as flow_edit %}
+    {% url 'emt:submit_speaker_profile' proposal.id as speaker_edit %}
+    {% url 'emt:submit_expense_details' proposal.id as expense_edit %}
+    {% url 'emt:submit_cdl_support' proposal.id as cdl_edit %}
 
-    {% include "emt/partials/review_section.html" with title="Need Analysis" body=need_analysis.content %}
-    {% include "emt/partials/review_section.html" with title="Objectives" body=objectives.content %}
-    {% include "emt/partials/review_section.html" with title="Expected Outcomes" body=outcomes.content %}
-    {% include "emt/partials/review_section.html" with title="Tentative Flow" body=flow.content %}
+    {% include "emt/partials/review_section.html" with title="Need Analysis" body=need_analysis.content edit_url=need_edit %}
+    {% include "emt/partials/review_section.html" with title="Objectives" body=objectives.content edit_url=obj_edit %}
+    {% include "emt/partials/review_section.html" with title="Expected Outcomes" body=outcomes.content edit_url=out_edit %}
+    {% include "emt/partials/review_section.html" with title="Tentative Flow" body=flow.content edit_url=flow_edit %}
 
     <div class="event-details-card">
-      <h3>Speaker Profile</h3>
+      <div class="review-section-header">
+        <h3>Speaker Profile</h3>
+        <a href="{{ speaker_edit }}" class="section-edit-link">Edit</a>
+      </div>
       {% if speakers %}
         {% for sp in speakers %}
           <div class="speaker-profile-block">
@@ -126,7 +136,10 @@
     </div>
 
     <div class="event-details-card">
-      <h3>Expense Details</h3>
+      <div class="review-section-header">
+        <h3>Expense Details</h3>
+        <a href="{{ expense_edit }}" class="section-edit-link">Edit</a>
+      </div>
       {% if expenses %}
         <table class="review-table">
           <tr><th>Sl. No.</th><th>Particulars</th><th>Amount</th></tr>
@@ -140,7 +153,10 @@
     </div>
 
     <div class="event-details-card">
-      <h3>Income Details</h3>
+      <div class="review-section-header">
+        <h3>Income Details</h3>
+        <a href="{{ expense_edit }}" class="section-edit-link">Edit</a>
+      </div>
       {% if income %}
         <table class="review-table">
           <tr><th>Sl. No.</th><th>Particulars</th><th>Participants</th><th>Rate</th><th>Amount</th></tr>
@@ -155,7 +171,10 @@
 
     {% if cdl_support %}
     <div class="event-details-card">
-      <h3>CDL Support</h3>
+      <div class="review-section-header">
+        <h3>CDL Support</h3>
+        <a href="{{ cdl_edit }}" class="section-edit-link">Edit</a>
+      </div>
       <table class="review-table">
         <tr><th>Needs Support</th><td>{{ cdl_support.needs_support|yesno:"Yes,No" }}</td></tr>
         {% if cdl_support.poster_required %}

--- a/emt/views.py
+++ b/emt/views.py
@@ -429,6 +429,10 @@ def review_proposal(request, proposal_id):
             f"Proposal '{proposal.event_title}' submitted.",
         )
         return redirect("emt:proposal_status_detail", proposal_id=proposal.id)
+    else:
+        if proposal.status != EventProposal.Status.SUBMITTED:
+            proposal.status = EventProposal.Status.DRAFT
+            proposal.save(update_fields=["status"])
 
     ctx = {
         "proposal": proposal,


### PR DESCRIPTION
## Summary
- add inline edit links for each proposal section on the review page
- style review section headers and edit links
- autosave AI generated report text and keep proposal drafts until confirmation

## Testing
- `DJANGO_SETTINGS_MODULE=iqac_project.settings_test python manage.py test emt.tests.test_proposal_review -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a7f3ef09fc832c9720a795bedf1901