### PR TITLE
Auto-fill event report location and committee details

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1023,6 +1023,29 @@ function populateProposalData() {
             }
         }, 100);
     });
+
+    // Populate organizing committee details when section becomes active
+    $(document).on('click', '[data-section="participants-information"]', function() {
+        setTimeout(function() {
+            const field = $('#organizing-committee-modern');
+            if (field.length && field.val().trim() === '' && window.PROPOSAL_DATA) {
+                const parts = [];
+                if (window.PROPOSAL_DATA.proposer) {
+                    parts.push(`Proposer: ${window.PROPOSAL_DATA.proposer}`);
+                }
+                if (window.PROPOSAL_DATA.faculty_incharges && window.PROPOSAL_DATA.faculty_incharges.length) {
+                    parts.push(`Faculty In-Charge: ${window.PROPOSAL_DATA.faculty_incharges.join(', ')}`);
+                }
+                if (window.PROPOSAL_DATA.student_coordinators) {
+                    parts.push(`Student Coordinators: ${window.PROPOSAL_DATA.student_coordinators}`);
+                }
+                if (window.PROPOSAL_DATA.volunteers && window.PROPOSAL_DATA.volunteers.length) {
+                    parts.push(`Volunteers: ${window.PROPOSAL_DATA.volunteers.join(', ')}`);
+                }
+                field.val(parts.join('\n'));
+            }
+        }, 100);
+    });
 }
 
 // Populate speaker reference card with speakers from the original proposal

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -183,7 +183,7 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="actual-location-modern">Actual Event Location</label>
-                                <input type="text" id="actual-location-modern" name="location" value="{{ form.location.value|default:'' }}" placeholder="Enter the actual venue where event was held">
+                                <input type="text" id="actual-location-modern" name="location" value="{{ form.location.value|default:proposal.venue|default:'' }}" placeholder="Enter the actual venue where event was held">
                                 <div class="help-text">Specify the actual venue (if different from proposed venue)</div>
                                 {% if form.location.errors %}
                                     <div class="field-error">{{ form.location.errors.0 }}</div>
@@ -346,6 +346,9 @@
             target_audience: "{{ proposal.target_audience|default:'' }}",
             event_focus_type: "{{ proposal.event_focus_type|default:'' }}",
             student_coordinators: "{{ proposal.student_coordinators|default:'' }}",
+            proposer: "{{ proposal.submitted_by.get_full_name|default:'' }}",
+            faculty_incharges: {{ faculty_names_json|default:'[]'|safe }},
+            volunteers: {{ volunteer_names_json|default:'[]'|safe }},
             academic_year: "{{ proposal.academic_year|default:'2024-2025' }}",
             num_activities: "{{ proposal_activities|length }}",
             event_start_date: "{% if proposal.event_start_date %}{{ proposal.event_start_date|date:'Y-m-d' }}{% elif proposal.event_datetime %}{{ proposal.event_datetime|date:'Y-m-d' }}{% endif %}",

--- a/emt/views.py
+++ b/emt/views.py
@@ -1684,6 +1684,12 @@ def submit_event_report(request, proposal_id):
     attendance_present = attendance_qs.filter(absent=False).count()
     attendance_absent = attendance_qs.filter(absent=True).count()
     attendance_volunteers = attendance_qs.filter(volunteer=True).count()
+    volunteer_names = list(
+        attendance_qs.filter(volunteer=True).values_list('full_name', flat=True)
+    )
+    faculty_names = [
+        f.get_full_name() or f.username for f in proposal.faculty_incharges.all()
+    ]
 
     # Pre-fill context with proposal info for readonly/preview display
     context = {
@@ -1701,6 +1707,8 @@ def submit_event_report(request, proposal_id):
         "attendance_present": attendance_present,
         "attendance_absent": attendance_absent,
         "attendance_volunteers": attendance_volunteers,
+        "faculty_names_json": json.dumps(faculty_names),
+        "volunteer_names_json": json.dumps(volunteer_names),
     }
     return render(request, "emt/submit_event_report.html", context)
 


### PR DESCRIPTION
## Summary
- Prefill actual event location in report with proposal venue
- Expose proposer, faculty in-charges, student coordinators, and volunteer names to the front-end
- Auto-populate organizing committee section with fetched names

## Testing
- `python manage.py test emt` *(fails: connection to Postgres server at yamanote.proxy.rlwy.net port 25156 is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a804133310832c9a37b370ee9427f6