### PR TITLE
feat: add AI summary enhancement

### DIFF
--- a/ai/client_ollama.py
+++ b/ai/client_ollama.py
@@ -1,0 +1,58 @@
+import logging
+import os
+from typing import List, Dict, Optional
+
+import requests
+from django.conf import settings as django_settings
+
+logger = logging.getLogger(__name__)
+
+
+class AIError(Exception):
+    """Raised when the Ollama backend fails."""
+    pass
+
+
+def chat(
+    messages: List[Dict[str, str]],
+    system: Optional[str] = None,
+    model: Optional[str] = None,
+    temperature: float = 0.2,
+    timeout: Optional[int] = None,
+    options: Optional[Dict] = None,
+    settings=django_settings,
+) -> str:
+    """Send a chat completion request to the configured Ollama backend."""
+    base = getattr(settings, "OLLAMA_BASE", os.getenv("OLLAMA_BASE", "http://127.0.0.1:11434"))
+    timeout = int(timeout or getattr(settings, "AI_HTTP_TIMEOUT", os.getenv("AI_HTTP_TIMEOUT", 120)))
+    model_name = model or getattr(settings, "OLLAMA_GEN_MODEL", os.getenv("OLLAMA_GEN_MODEL", "llama3"))
+
+    payload: Dict = {
+        "model": model_name,
+        "messages": ([{"role": "system", "content": system}] if system else []) + messages,
+        "temperature": temperature,
+        "stream": False,
+    }
+    opts = {"num_predict": 300}
+    if isinstance(options, dict):
+        opts.update(options)
+    payload["options"] = opts
+
+    try:
+        resp = requests.post(
+            f"{base}/v1/chat/completions",
+            json=payload,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+    except requests.Timeout as exc:
+        logger.error("Ollama request timed out after %ss", timeout)
+        raise AIError(f"Ollama request timed out after {timeout}s") from exc
+    except requests.RequestException as exc:
+        logger.error("Ollama request failed: %s", exc)
+        raise AIError(f"Ollama request failed: {exc}") from exc
+    except (KeyError, IndexError, ValueError) as exc:
+        logger.error("Invalid Ollama response: %s", exc)
+        raise AIError(f"Invalid Ollama response: {exc}") from exc

--- a/ai/enhance_summary.py
+++ b/ai/enhance_summary.py
@@ -1,0 +1,38 @@
+import logging
+from django.views.decorators.http import require_POST
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
+
+from .client_ollama import chat, AIError
+
+logger = logging.getLogger(__name__)
+
+
+@login_required
+@require_POST
+def enhance_summary(request):
+    text = request.POST.get('text', '').strip()
+    title = request.POST.get('title', '').strip()
+    department = request.POST.get('department', '').strip()
+    start = request.POST.get('start_date', '').strip()
+    end = request.POST.get('end_date', '').strip()
+
+    if not text:
+        return JsonResponse({'ok': False, 'error': 'No summary provided'}, status=400)
+
+    prompt = (
+        f"Title: {title}\n"
+        f"Department: {department}\n"
+        f"Start Date: {start}\nEnd Date: {end}\n"
+        f"Summary:\n{text}\n\n"
+        "Enhance and polish this event summary while keeping facts intact."
+    )
+    try:
+        result = chat([{"role": "user", "content": prompt}])
+        return JsonResponse({'ok': True, 'summary': result.strip()})
+    except AIError as e:
+        logger.error('enhance_summary failed: %s', e)
+        return JsonResponse({'ok': False, 'error': str(e)}, status=503)
+    except Exception as e:
+        logger.exception('enhance_summary unexpected error')
+        return JsonResponse({'ok': False, 'error': f'Unexpected error: {e}'}, status=500)

--- a/emt/tests/test_enhance_summary.py
+++ b/emt/tests/test_enhance_summary.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from unittest.mock import patch
+from ai import client_ollama
+
+
+class EnhanceSummaryTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('u', 'u@example.com', 'p')
+        self.client.force_login(self.user)
+
+    @patch('ai.enhance_summary.chat')
+    def test_enhance_summary_success(self, mock_chat):
+        mock_chat.return_value = 'improved'
+        resp = self.client.post(reverse('emt:enhance_summary'), {
+            'text': 'original',
+            'title': 'T',
+            'department': 'D',
+            'start_date': '2024-01-01',
+            'end_date': '2024-01-02'
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['summary'], 'improved')
+
+    @patch('ai.enhance_summary.chat')
+    def test_enhance_summary_error(self, mock_chat):
+        mock_chat.side_effect = client_ollama.AIError('down')
+        resp = self.client.post(reverse('emt:enhance_summary'), {'text': 't'})
+        self.assertEqual(resp.status_code, 503)
+        data = resp.json()
+        self.assertFalse(data['ok'])
+        self.assertIn('down', data['error'])

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from . import views
 from suite import views as suite_views
+from ai import enhance_summary as ai_views
 
 app_name = 'emt'
 
@@ -70,6 +71,7 @@ urlpatterns = [
     path('generate-need-analysis/', suite_views.generate_need_analysis, name='generate_need_analysis'),
     path('generate-objectives/', suite_views.generate_objectives, name='generate_objectives'),
     path('generate-expected-outcomes/', suite_views.generate_learning_outcomes, name='generate_expected_outcomes'),
+    path('ai/enhance-summary/', ai_views.enhance_summary, name='enhance_summary'),
     path('api/organization-types/', views.api_organization_types, name='api_organization_types'),
     path('api/outcomes/<int:org_id>/', views.api_outcomes, name='api_outcomes'),
 


### PR DESCRIPTION
## Summary
- add Ollama client and summary enhancement endpoint
- wire up Enhance with AI button on event report summary textarea
- cover new endpoint with tests

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a80d5af740832c8ba58a024882911e