### PR TITLE
Make activity log history human-readable

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -123,20 +123,25 @@ class ActivityLogMiddleware:
                 params = {
                     k: v for k, v in params.items() if k.lower() != "csrfmiddlewaretoken"
                 }
-                params_str = ", ".join(f"{k}={v}" for k, v in params.items()) or "none"
+                params_str = ", ".join(f"{k}={v}" for k, v in params.items())
                 ip = request.META.get("REMOTE_ADDR", "unknown")
-                ua = request.META.get("HTTP_USER_AGENT", "unknown")
-                status = getattr(response, "status_code", "unknown")
-                referrer = request.META.get("HTTP_REFERER", "unknown")
                 view_name = (
                     getattr(getattr(request, "resolver_match", None), "view_name", None)
                     or request.path
                 )
-                description = (
-                    f"User {request.user.username} performed {request.method} {request.path}. "
-                    f"View: {view_name}. Params: {params_str}. IP: {ip}. "
-                    f"User-Agent: {ua}. Status: {status}. Referrer: {referrer}"
-                )
+                user_display = request.user.get_full_name() or request.user.username
+                verb_map = {
+                    "GET": "viewed",
+                    "POST": "submitted data to",
+                    "PUT": "updated",
+                    "PATCH": "updated",
+                    "DELETE": "deleted",
+                }
+                verb = verb_map.get(request.method, request.method.lower())
+                description = f"{user_display} {verb} {view_name}"
+                if params_str:
+                    description += f" with {params_str}"
+                description += f" from IP {ip}."
                 ActivityLog.objects.create(
                     user=request.user,
                     action=f"{request.method} {request.path}",

--- a/core/tests/test_activity_log_auto_description.py
+++ b/core/tests/test_activity_log_auto_description.py
@@ -12,6 +12,6 @@ class ActivityLogAutoDescriptionTests(TestCase):
             ip_address='1.2.3.4',
             metadata={'foo': 'bar'}
         )
-        self.assertIn('User charlie performed test_action', log.description)
-        self.assertIn('Params: foo=bar', log.description)
-        self.assertIn('IP: 1.2.3.4', log.description)
+        self.assertIn('charlie test action', log.description)
+        self.assertIn('foo=bar', log.description)
+        self.assertIn('1.2.3.4', log.description)

--- a/core/tests/test_activity_log_middleware.py
+++ b/core/tests/test_activity_log_middleware.py
@@ -34,8 +34,7 @@ class ActivityLogMiddlewareTests(TestCase):
         self.assertEqual(log.metadata, {'foo': 'bar'})
         self.assertEqual(
             log.description,
-            'User alice performed POST /some/path. View: /some/path. Params: foo=bar. '
-            'IP: 127.0.0.1. User-Agent: TestAgent/1.0. Status: 200. Referrer: unknown'
+            'alice submitted data to /some/path with foo=bar from IP 127.0.0.1.'
         )
 
     def test_creates_log_for_get_request(self):
@@ -54,6 +53,5 @@ class ActivityLogMiddlewareTests(TestCase):
         self.assertEqual(log.metadata, {'q': 'test'})
         self.assertEqual(
             log.description,
-            'User alice performed GET /some/path. View: /some/path. Params: q=test. '
-            'IP: 127.0.0.1. User-Agent: TestAgent/1.0. Status: 200. Referrer: unknown'
+            'alice viewed /some/path with q=test from IP 127.0.0.1.'
         )


### PR DESCRIPTION
## Summary
- Generate friendly activity log descriptions without technical jargon
- Log middleware now writes plain language summaries
- Adjust tests for new description format

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a811031ad4832c8427c430dab795c6