### PR TITLE
Improve activity log descriptions

### DIFF
--- a/core/tests/test_activity_log_auto_description.py
+++ b/core/tests/test_activity_log_auto_description.py
@@ -8,10 +8,12 @@ class ActivityLogAutoDescriptionTests(TestCase):
         user = User.objects.create_user('charlie')
         log = ActivityLog.objects.create(
             user=user,
-            action='test_action',
+            action='GET /events/123/?next=/foo',
             ip_address='1.2.3.4',
             metadata={'foo': 'bar'}
         )
-        self.assertIn('charlie test action', log.description)
-        self.assertIn('foo=bar', log.description)
-        self.assertIn('1.2.3.4', log.description)
+        # Description should be friendly and omit technical details
+        self.assertEqual(log.description, 'charlie viewed events')
+        self.assertNotIn('foo=bar', log.description)
+        self.assertNotIn('1.2.3.4', log.description)
+        self.assertNotIn('123', log.description)

--- a/core/tests/test_activity_log_middleware.py
+++ b/core/tests/test_activity_log_middleware.py
@@ -2,6 +2,7 @@ from django.test import TestCase, RequestFactory
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.http import HttpResponse
+from types import SimpleNamespace
 
 from core.middleware import ActivityLogMiddleware
 from core.models import ActivityLog
@@ -18,40 +19,43 @@ class ActivityLogMiddlewareTests(TestCase):
     def tearDown(self):
         post_save.connect(signals.create_or_update_user_profile, sender=User)
 
-    def test_creates_log_for_post_request(self):
-        request = self.factory.post('/some/path', {'foo': 'bar', 'csrfmiddlewaretoken': 'token'})
+    def test_creates_friendly_log_for_post_request(self):
+        request = self.factory.post(
+            '/contact/',
+            {'foo': 'bar', 'csrfmiddlewaretoken': 'token'}
+        )
         request.user = self.user
         request.META['REMOTE_ADDR'] = '127.0.0.1'
         request.META['HTTP_USER_AGENT'] = 'TestAgent/1.0'
+        request.resolver_match = SimpleNamespace(view_name='contact_form')
+        request.object = SimpleNamespace(title='Feedback')
 
         response = self.middleware(request)
 
         self.assertEqual(response.status_code, 200)
         log = ActivityLog.objects.get()
         self.assertEqual(log.user, self.user)
-        self.assertEqual(log.action, 'POST /some/path')
+        self.assertEqual(log.action, 'POST /contact/')
         self.assertEqual(log.ip_address, '127.0.0.1')
-        self.assertEqual(log.metadata, {'foo': 'bar'})
+        self.assertEqual(log.metadata, {'foo': 'bar', 'object_title': 'Feedback'})
         self.assertEqual(
             log.description,
-            'alice submitted data to /some/path with foo=bar from IP 127.0.0.1.'
+            'alice submitted contact form "Feedback"'
         )
 
-    def test_creates_log_for_get_request(self):
-        request = self.factory.get('/some/path', {'q': 'test'})
+    def test_creates_friendly_log_for_get_request(self):
+        request = self.factory.get('/profile/', {'q': 'test'})
         request.user = self.user
         request.META['REMOTE_ADDR'] = '127.0.0.1'
         request.META['HTTP_USER_AGENT'] = 'TestAgent/1.0'
+        request.resolver_match = SimpleNamespace(view_name='profile')
 
         response = self.middleware(request)
 
         self.assertEqual(response.status_code, 200)
         log = ActivityLog.objects.get()
         self.assertEqual(log.user, self.user)
-        self.assertEqual(log.action, 'GET /some/path')
+        self.assertEqual(log.action, 'GET /profile/')
         self.assertEqual(log.ip_address, '127.0.0.1')
         self.assertEqual(log.metadata, {'q': 'test'})
-        self.assertEqual(
-            log.description,
-            'alice viewed /some/path with q=test from IP 127.0.0.1.'
-        )
+        self.assertEqual(log.description, 'alice viewed profile')


### PR DESCRIPTION
## Summary
- Add friendly activity descriptions that map view names and HTTP verbs and include object titles where available
- Simplify ActivityLog auto-description to strip technical details
- Test middleware output and admin history table for human readable summaries

## Testing
- `python manage.py test core.tests.test_activity_log_middleware core.tests.test_activity_log_auto_description core.tests.test_admin_history -v 2` *(fails: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68a81336a0c0832c9c80a1e69631a96f