### PR TITLE
Filter noisy admin logging and normalize historical entries

### DIFF
--- a/core/management/commands/normalize_activity_logs.py
+++ b/core/management/commands/normalize_activity_logs.py
@@ -1,0 +1,33 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from core.models import ActivityLog
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Normalize existing ActivityLog descriptions using generate_description()"
+
+    def handle(self, *args, **options):
+        patterns = [
+            "performed GET",
+            "performed POST",
+            "performed PUT",
+            "performed PATCH",
+            "performed DELETE",
+        ]
+        query = Q()
+        for pattern in patterns:
+            query |= Q(description__icontains=pattern)
+
+        count = 0
+        for log in ActivityLog.objects.filter(query):
+            new_desc = log.generate_description()
+            if new_desc != log.description:
+                log.description = new_desc
+                log.save(update_fields=["description"])
+                count += 1
+        self.stdout.write(self.style.SUCCESS(f"Normalized {count} activity logs."))


### PR DESCRIPTION
## Summary
- avoid logging translation/static admin views
- map common admin view names to friendly descriptions
- add command to regenerate friendly descriptions for legacy logs
- test admin activity logging and history rendering

## Testing
- `python manage.py test core.tests.test_activity_log_middleware core.tests.test_admin_history --settings=iqac_project.settings_test`
- `python manage.py test --settings=iqac_project.settings_test` *(fails: django.template.exceptions.TemplateDoesNotExist: core/user_dashboard.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a8160af4cc832c853cd61c8ba41844