### PR TITLE
Add field configs for AI-generated report sections

### DIFF
--- a/suite/field_config/impact_assessment.json
+++ b/suite/field_config/impact_assessment.json
@@ -1,0 +1,10 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "event_focus_type",
+    "sdg_goals",
+    "pos_pso_management",
+    "additional_context"
+  ]
+}

--- a/suite/field_config/learning_outcomes_achieved.json
+++ b/suite/field_config/learning_outcomes_achieved.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "pos_pso_management",
+    "sdg_goals",
+    "num_activities"
+  ]
+}

--- a/suite/field_config/measurable_outcomes.json
+++ b/suite/field_config/measurable_outcomes.json
@@ -1,0 +1,10 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "num_activities",
+    "student_coordinators",
+    "faculty_incharges",
+    "additional_context"
+  ]
+}

--- a/suite/field_config/student_engagement.json
+++ b/suite/field_config/student_engagement.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    "event_title",
+    "target_audience",
+    "num_activities",
+    "student_coordinators",
+    "faculty_incharges"
+  ]
+}

--- a/suite/field_config/why_event.json
+++ b/suite/field_config/why_event.json
@@ -1,0 +1,13 @@
+{
+  "fields": [
+    "organization_type",
+    "department",
+    "target_audience",
+    "event_focus_type",
+    "sdg_goals",
+    "event_title",
+    "committees_collaborations",
+    "pos_pso_management",
+    "num_activities"
+  ]
+}


### PR DESCRIPTION
## Summary
- configure AI field list for combined `why_event` generation
- add field configurations for student engagement, measurable outcomes, learning outcomes achieved, and impact assessment

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8178f4e74832ca2789f86ac686585