### PR TITLE
Expand AI analysis word count

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -136,7 +136,7 @@ $(document).on('click', '#ai-enhance-summary', function() {
   }
 });
 
-function aiFill(target, words=80){
+function aiFill(target, words=320){
     const textarea = $(target);
     const text = generatePlaceholder(words);
     textarea.val(text);
@@ -183,7 +183,7 @@ $(document).on('click', '#ai-objective-achievement', function(){
     const btn = $(this);
     const original = btn.text();
     btn.prop('disabled', true).text('...');
-    try { aiFill('#objective-achievement-modern', 120); }
+    try { aiFill('#objective-achievement-modern', 320); }
     catch (err) { console.error(err); }
     finally { btn.prop('disabled', false).text(original); }
 });
@@ -192,7 +192,7 @@ $(document).on('click', '#ai-strengths-analysis', function(){
     const btn = $(this);
     const original = btn.text();
     btn.prop('disabled', true).text('...');
-    try { aiFill('#strengths-analysis-modern', 80); }
+    try { aiFill('#strengths-analysis-modern', 320); }
     catch (err) { console.error(err); }
     finally { btn.prop('disabled', false).text(original); }
 });
@@ -201,7 +201,7 @@ $(document).on('click', '#ai-challenges-analysis', function(){
     const btn = $(this);
     const original = btn.text();
     btn.prop('disabled', true).text('...');
-    try { aiFill('#challenges-analysis-modern', 80); }
+    try { aiFill('#challenges-analysis-modern', 320); }
     catch (err) { console.error(err); }
     finally { btn.prop('disabled', false).text(original); }
 });
@@ -210,7 +210,7 @@ $(document).on('click', '#ai-effectiveness-analysis', function(){
     const btn = $(this);
     const original = btn.text();
     btn.prop('disabled', true).text('...');
-    try { aiFill('#effectiveness-analysis-modern', 120); }
+    try { aiFill('#effectiveness-analysis-modern', 320); }
     catch (err) { console.error(err); }
     finally { btn.prop('disabled', false).text(original); }
 });
@@ -219,7 +219,7 @@ $(document).on('click', '#ai-lessons-learned', function(){
     const btn = $(this);
     const original = btn.text();
     btn.prop('disabled', true).text('...');
-    try { aiFill('#lessons-learned-modern', 150); }
+    try { aiFill('#lessons-learned-modern', 320); }
     catch (err) { console.error(err); }
     finally { btn.prop('disabled', false).text(original); }
 });


### PR DESCRIPTION
## Summary
- Increase default aiFill word target to 320 words
- Request 320 words in each analysis auto-fill button

## Testing
- `node -e "function generatePlaceholder(words=500){const corpus=['lorem','ipsum','dolor','sit','amet','consectetur','adipiscing','elit','sed','do','eiusmod','tempor','incididunt','ut','labore','et','dolore','magna','aliqua','enim','ad','minim','veniam','quis','nostrud','exercitation','ullamco','laboris','nisi','ut','aliquip','ex','ea','commodo','consequat'];const out=[];while(out.length<words) out.push(corpus[Math.floor(Math.random()*corpus.length)]);return out.join(' ');}['objective-achievement','strengths-analysis','challenges-analysis','effectiveness-analysis','lessons-learned'].forEach(f=>{const text=generatePlaceholder(320);console.log(f, text.split(/\\s+/).length);});"`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a820baf23c832c83a6b859801c453a