### PR TITLE
Prefill SDG and PO/PSO data on event report

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -356,7 +356,7 @@
             activities: {{ proposal_activities_json|default:'[]'|safe }},
             speakers: {{ speakers_json|default:'[]'|safe }},
             pos_pso: "{{ proposal.pos_pso|default:'' }}",
-            sdg_goals: "{{ proposal.sdg_goals|default:'' }}"
+            sdg_goals: "{{ proposal_sdg_goals|default:'' }}"
         };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>

--- a/emt/views.py
+++ b/emt/views.py
@@ -1691,6 +1691,15 @@ def submit_event_report(request, proposal_id):
         f.get_full_name() or f.username for f in proposal.faculty_incharges.all()
     ]
 
+    # Prepare SDG goal data for modal and proposal prefill
+    sdg_goals_list = [
+        {"id": goal.id, "title": goal.name}
+        for goal in SDGGoal.objects.all()
+    ]
+    proposal_sdg_goals = ", ".join(
+        f"SDG{goal.id}: {goal.name}" for goal in proposal.sdg_goals.all()
+    )
+
     # Pre-fill context with proposal info for readonly/preview display
     context = {
         "proposal": proposal,
@@ -1699,7 +1708,8 @@ def submit_event_report(request, proposal_id):
         "proposal_activities": proposal_activities,
         "proposal_activities_json": json.dumps(proposal_activities),
         "speakers_json": json.dumps(speakers_json),
-        "sdg_goals_list": [],  # Add SDG goals if needed
+        "sdg_goals_list": sdg_goals_list,
+        "proposal_sdg_goals": proposal_sdg_goals,
         "event_summary": event_summary,
         "event_outcomes": event_outcomes,
         "analysis": analysis,


### PR DESCRIPTION
## Summary
- Populate SDG goal options and prefill selected goals in the event report form.
- Include proposal's SDG and PO/PSO data when rendering the report page.

## Testing
- ⚠️ `python manage.py test emt` *(failed: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a823c25828832cbcae29eafa5fd630