### PR TITLE
Add event report preview page

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -35,6 +35,8 @@ document.addEventListener('DOMContentLoaded', function(){
       'event-relevance': false
   };
 
+  const previewUrl = $('#report-form').data('preview-url');
+
   // Rehydrate progress from server-rendered classes (if editing existing draft)
   document.querySelectorAll('.nav-link').forEach(link => {
       if(link.classList.contains('completed')){
@@ -290,7 +292,10 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
               activateSection(nextSection);
               showNotification('Section saved! Moving to next section', 'success');
           } else {
-              showNotification('All sections completed!', 'success');
+              showNotification('All sections completed! Review your report.', 'success');
+              const form = $('#report-form');
+              form.attr('action', previewUrl);
+              form[0].submit();
           }
       } else {
           showNotification('Please fill in all required fields', 'error');

--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Review Event Report{% endblock %}
+
+{% block content %}
+<div class="proposal-layout">
+    <nav class="proposal-nav">
+        <div class="nav-header">
+            <h2 class="nav-title">Review Event Report</h2>
+            <p class="nav-subtitle">Confirm details before submission</p>
+        </div>
+    </nav>
+    <main class="proposal-content">
+        <div class="content-header">
+            <h1 class="content-title">{{ proposal.event_title|default:"Event Report" }}</h1>
+            <p class="content-subtitle">Please verify the information below.</p>
+        </div>
+        <form method="post" action="{% url 'emt:submit_event_report' proposal.id %}">
+            {% csrf_token %}
+            {% for key, value in post_data.items %}
+                <input type="hidden" name="{{ key }}" value="{{ value|escape }}">
+            {% endfor %}
+            <div class="report-preview-list">
+                {% for key, value in post_data.items %}
+                    {% if key != 'csrfmiddlewaretoken' %}
+                        <p><strong>{{ key|capfirst }}:</strong> {{ value }}</p>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <button type="submit" name="final_submit" class="btn-submit">Submit Report</button>
+        </form>
+    </main>
+</div>
+{% endblock %}

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -92,7 +92,7 @@
             </div>
         {% endif %}
 
-        <form method="post" enctype="multipart/form-data" id="report-form" autocomplete="off">
+        <form method="post" enctype="multipart/form-data" id="report-form" autocomplete="off" action="{% url 'emt:submit_event_report' proposal.id %}" data-preview-url="{% url 'emt:preview_event_report' proposal.id %}">
             {% csrf_token %}
             <textarea name="event_summary" hidden>{{ event_summary.content|default_if_none:'' }}</textarea>
             <textarea name="event_outcomes" hidden>{{ event_outcomes.content|default_if_none:'' }}</textarea>

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -112,3 +112,17 @@ class SubmitEventReportViewTests(TestCase):
             html=False,
         )
 
+    def test_preview_event_report(self):
+        url = reverse("emt:preview_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Seminar",
+            "report_signed_date": "2024-01-10",
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Seminar")
+

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -57,6 +57,7 @@ urlpatterns = [
     path("suite/my-approvals/", views.my_approvals, name="my_approvals"),
     path("suite/review-approval/<int:step_id>/", views.review_approval_step, name="review_approval_step"),
     path('cdl/my-requests/', views.my_requests_view, name='cdl_my_requests'),
+    path('report/preview/<int:proposal_id>/', views.preview_event_report, name='preview_event_report'),
     path('report/submit/<int:proposal_id>/', views.submit_event_report, name='submit_event_report'),
 
     # AI Report Generation

--- a/emt/views.py
+++ b/emt/views.py
@@ -1724,6 +1724,30 @@ def submit_event_report(request, proposal_id):
 
 
 @login_required
+def preview_event_report(request, proposal_id):
+    """Display a summary of the event report before final submission."""
+    proposal = get_object_or_404(
+        EventProposal,
+        id=proposal_id,
+        submitted_by=request.user,
+    )
+
+    if request.method != "POST":
+        return redirect("emt:submit_event_report", proposal_id=proposal.id)
+
+    form = EventReportForm(request.POST)
+    if not form.is_valid():
+        logger.debug("Preview form invalid for proposal %s: %s", proposal.id, form.errors)
+
+    context = {
+        "proposal": proposal,
+        "form": form,
+        "post_data": request.POST,
+    }
+    return render(request, "emt/report_preview.html", context)
+
+
+@login_required
 def download_audience_csv(request, proposal_id):
     """Provide CSV templates for marking attendance separately for students and faculty."""
     proposal = get_object_or_404(


### PR DESCRIPTION
## Summary
- add preview view and URL to review event report before final submit
- pass form data to new review page and submit to existing handler
- redirect final Save & Continue to preview via JavaScript
- include basic test for preview page

## Testing
- `python manage.py test` *(fails: OperationalError: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a836072a2c832c9b7a067113abd256