### PR TITLE
Ensure report preview includes all section data

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -294,6 +294,31 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           } else {
               showNotification('All sections completed! Review your report.', 'success');
               const form = $('#report-form');
+
+              // Remove any previously appended hidden inputs
+              form.find('input.section-state-hidden').remove();
+
+              // Append hidden inputs for all fields tracked in sectionState
+              Object.entries(sectionState).forEach(([name, value]) => {
+                  if (Array.isArray(value)) {
+                      value.forEach(v => {
+                          form.append($('<input>', {
+                              type: 'hidden',
+                              class: 'section-state-hidden',
+                              name: name,
+                              value: v
+                          }));
+                      });
+                  } else {
+                      form.append($('<input>', {
+                          type: 'hidden',
+                          class: 'section-state-hidden',
+                          name: name,
+                          value: value
+                      }));
+                  }
+              });
+
               form.attr('action', previewUrl);
               form[0].submit();
           }

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -126,3 +126,27 @@ class SubmitEventReportViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Seminar")
 
+    def test_preview_renders_multiple_sections_data(self):
+        url = reverse("emt:preview_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Workshop",
+            "summary": "Section summary text",
+            "outcomes": "Outcome details",
+            "graduate_attributes": ["engineering_knowledge", "problem_analysis"],
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        # Verify fields from multiple sections appear in the preview
+        self.assertContains(response, "Workshop")
+        self.assertContains(response, "Section summary text")
+        self.assertContains(response, "Outcome details")
+        # Multi-select values should be preserved in POST data
+        self.assertEqual(
+            response.context["form"].data.getlist("graduate_attributes"),
+            ["engineering_knowledge", "problem_analysis"],
+        )
+


### PR DESCRIPTION
## Summary
- append section state values as hidden inputs before preview submission
- cover multiple section preview rendering and multiselect preservation in tests

## Testing
- `python manage.py test emt.tests.test_event_report_view -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a839d6c2c0832cac81204a20e492e6