### PR TITLE
Handle unchecked checkbox/radio state in event report preview

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -310,11 +310,16 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
                           }));
                       });
                   } else {
+                      const field = form.find(`[name="${name}"]`).first();
+                      let finalValue = value;
+                      if(field.length && (field.attr('type') === 'checkbox' || field.attr('type') === 'radio')){
+                          finalValue = field.prop('checked') ? field.val() : '';
+                      }
                       form.append($('<input>', {
                           type: 'hidden',
                           class: 'section-state-hidden',
                           name: name,
-                          value: value
+                          value: finalValue
                       }));
                   }
               });
@@ -623,6 +628,8 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
       const el = this;
       if(el.tagName === 'SELECT' && el.multiple){
           sectionState[el.name] = Array.from(el.selectedOptions).map(o => o.value);
+      } else if(el.type === 'checkbox' || el.type === 'radio') {
+          sectionState[el.name] = el.checked ? el.value : '';
       } else {
           sectionState[el.name] = el.value;
       }
@@ -632,6 +639,8 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
   document.querySelectorAll('form#report-form input[name], form#report-form textarea[name], form#report-form select[name]').forEach(el => {
       if(el.tagName === 'SELECT' && el.multiple){
           sectionState[el.name] = Array.from(el.selectedOptions).map(o => o.value);
+      } else if(el.type === 'checkbox' || el.type === 'radio') {
+          sectionState[el.name] = el.checked ? el.value : '';
       } else {
           sectionState[el.name] = el.value;
       }

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -150,3 +150,22 @@ class SubmitEventReportViewTests(TestCase):
             ["engineering_knowledge", "problem_analysis"],
         )
 
+    def test_preview_preserves_checked_and_unchecked_fields(self):
+        url = reverse("emt:preview_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Seminar",
+            "report_signed_date": "2024-01-10",
+            "needs_projector": "yes",  # Simulate checked checkbox
+            "needs_permission": "",    # Simulate unchecked checkbox
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["post_data"]["needs_projector"], "yes")
+        self.assertEqual(response.context["post_data"]["needs_permission"], "")
+        self.assertContains(response, "<strong>Needs_projector:</strong> yes", html=False)
+        self.assertContains(response, "<strong>Needs_permission:</strong>", html=False)
+


### PR DESCRIPTION
## Summary
- track checkbox and radio checked state in submit-event-report JavaScript
- include unchecked checkbox/radio values when packaging form data
- test preview endpoint handles checked and unchecked fields

## Testing
- `python manage.py test emt.tests.test_event_report_view -v 2` *(fails: invalid input syntax for type inet: "unknown")*


------
https://chatgpt.com/codex/tasks/task_e_68a83bad8090832c9ca99d9c2a41d518