### PR TITLE
Ensure event report preview lists all form fields

### DIFF
--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -21,13 +21,11 @@
             {% for key, value in post_data.items %}
                 <input type="hidden" name="{{ key }}" value="{{ value|escape }}">
             {% endfor %}
-            <div class="report-preview-list">
-                {% for key, value in post_data.items %}
-                    {% if key != 'csrfmiddlewaretoken' %}
-                        <p><strong>{{ key|capfirst }}:</strong> {{ value }}</p>
-                    {% endif %}
+            <ol class="report-preview-list">
+                {% for field in form.visible_fields %}
+                    <li><strong>{{ field.label }}:</strong> {{ field.value|default:"—" }}</li>
                 {% endfor %}
-            </div>
+            </ol>
             <button type="submit" name="final_submit" class="btn-submit">Submit Report</button>
         </form>
     </main>


### PR DESCRIPTION
## Summary
- Serialize every form control on "Save & Continue" so preview submissions include even empty or unchecked fields.
- Show a full ordered list of event report fields in the preview with labels and placeholders for missing data.
- Add tests confirming all form fields are displayed in the preview and adjust existing tests for updated markup.

## Testing
- `DATABASE_URL=sqlite://:memory: python manage.py test emt.tests.test_event_report_view -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a83ddbe004832c8c3392fe47a642c0