### PR TITLE
Auto-save support for event reports

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1736,6 +1736,9 @@ function setupDynamicActivities() {
         });
         numInput.value = activities.length;
         console.log('Activities rendered successfully, count:', activities.length);
+        if (window.AutosaveManager) {
+            AutosaveManager.reinitialize();
+        }
     }
 
     container.addEventListener('click', (e) => {
@@ -1918,5 +1921,8 @@ $(document).ready(function() {
     initializeSectionSpecificHandlers();
     setupDynamicActivities();
     setupAttendanceModal();
+    if (window.AutosaveManager) {
+        AutosaveManager.reinitialize();
+    }
 });
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -328,8 +328,9 @@
         window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
         window.REPORT_STATUS = "{{ report.status|default:'draft' }}";
         window.REPORT_ACTUAL_EVENT_TYPE = "{{ form.actual_event_type.value|default:'' }}";
-        window.AUTOSAVE_URL = "#"; // TODO: Add autosave URL for reports
+        window.AUTOSAVE_URL = "{% url 'emt:autosave_event_report' %}";
         window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+        window.PROPOSAL_STATUS = window.REPORT_STATUS;
         window.API_ORGANIZATIONS = "#"; // TODO: Add API URLs
         window.API_CLASSES_BASE = "{% url 'emt:api_classes' 0 %}".split('0/')[0];
         window.API_FACULTY = "{% url 'emt:api_faculty' %}";
@@ -360,5 +361,6 @@
         };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+    <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
     <script src="{% static 'emt/js/submit_event_report.js' %}"></script>
 {% endblock %}

--- a/emt/tests/test_autosave_event_report.py
+++ b/emt/tests/test_autosave_event_report.py
@@ -1,0 +1,59 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.db.models.signals import post_save
+from django.contrib.auth.signals import user_logged_in
+import json
+
+from core.signals import create_or_update_user_profile, assign_role_on_login
+from emt.models import EventProposal, EventReport, EventActivity
+
+
+class AutosaveEventReportTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client.force_login(self.user)
+        self.proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Sample Event",
+        )
+
+    def test_autosave_creates_report_and_saves_fields(self):
+        url = reverse("emt:autosave_event_report")
+        payload = {
+            "proposal_id": self.proposal.id,
+            "location": "Main Hall",
+            "event_summary": "Summary text",
+            "event_outcomes": "Outcome text",
+            "num_activities": "1",
+            "activity_name_1": "Intro",
+            "activity_date_1": "2024-01-01",
+        }
+        resp = self.client.post(url, data=json.dumps(payload), content_type="application/json")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data.get("success"))
+        report = EventReport.objects.get(proposal=self.proposal)
+        self.assertEqual(report.location, "Main Hall")
+        self.assertEqual(report.summary, "Summary text")
+        self.assertEqual(report.outcomes, "Outcome text")
+        activities = list(EventActivity.objects.filter(proposal=self.proposal))
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].name, "Intro")
+
+    def test_autosave_invalid_json(self):
+        url = reverse("emt:autosave_event_report")
+        resp = self.client.post(url, data="not json", content_type="application/json")
+        self.assertEqual(resp.status_code, 400)

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('autosave-proposal/', views.autosave_proposal, name='autosave_proposal'),
     path('reset-proposal-draft/', views.reset_proposal_draft, name='reset_proposal_draft'),
     path('autosave-need-analysis/', views.autosave_need_analysis, name='autosave_need_analysis'),
+    path('autosave-event-report/', views.autosave_event_report, name='autosave_event_report'),
     path('pending-reports/', views.pending_reports, name='pending_reports'),
     path('generate-report/<int:proposal_id>/', views.generate_report, name='generate_report'),
     path('report-success/<int:proposal_id>/', views.report_success, name='report_success'),


### PR DESCRIPTION
## Summary
- add backend endpoint to persist event report sections during editing
- wire event report template and JS to autosave changes
- cover event report autosave with regression tests

## Testing
- `python manage.py test emt.tests.test_autosave_event_report -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1fa10014832cada56a65c39ea67f