### PR TITLE
Cache event report drafts in session and add report autosave

### DIFF
--- a/emt/static/emt/js/report_autosave.js
+++ b/emt/static/emt/js/report_autosave.js
@@ -1,0 +1,191 @@
+// ReportAutosaveManager handles autosaving event reports including dynamic fields
+// and exposing hooks for reinitializing field listeners and manual saves.
+
+window.ReportAutosaveManager = (function() {
+    let reportId = window.REPORT_ID || '';
+    const proposalId = window.PROPOSAL_ID || '';
+    let timeoutId = null;
+    let fields = [];
+
+    let storageKey = `report_draft_${reportId || proposalId || 'new'}`;
+
+    function getSavedData() {
+        try {
+            return JSON.parse(localStorage.getItem(storageKey) || '{}');
+        } catch (e) {
+            console.error('Error parsing saved draft:', e);
+            return {};
+        }
+    }
+
+    function collectFieldData() {
+        const grouped = {};
+        fields.forEach(f => {
+            if (f.disabled || !f.name) return;
+            (grouped[f.name] ||= []).push(f);
+        });
+        const data = {};
+        Object.entries(grouped).forEach(([name, inputs]) => {
+            const field = inputs[0];
+            if (field.type === 'checkbox') {
+                if (inputs.length > 1) {
+                    data[name] = inputs.filter(i => i.checked).map(i => i.value);
+                } else {
+                    data[name] = field.checked;
+                }
+            } else if (field.type === 'radio') {
+                const checked = inputs.find(i => i.checked);
+                if (checked) data[name] = checked.value;
+            } else if (field.multiple) {
+                data[name] = Array.from(field.selectedOptions).map(o => o.value);
+            } else {
+                const preferred = inputs.find(i => i.type !== 'hidden' && i.value.trim() !== '')
+                    || inputs.find(i => i.type !== 'hidden')
+                    || inputs.find(i => i.value.trim() !== '')
+                    || field;
+                data[name] = preferred.value;
+            }
+        });
+        return data;
+    }
+
+    function saveLocal() {
+        const data = collectFieldData();
+        if (reportId) {
+            data._report_id = reportId;
+        }
+        localStorage.setItem(storageKey, JSON.stringify(data));
+    }
+
+    function clearLocal() {
+        localStorage.removeItem(storageKey);
+    }
+
+    function autosaveDraft() {
+        if (window.REPORT_STATUS && window.REPORT_STATUS !== 'draft') {
+            clearLocal();
+            return Promise.resolve();
+        }
+
+        const formData = collectFieldData();
+        if (proposalId) {
+            formData['proposal_id'] = proposalId;
+        }
+        if (reportId) {
+            formData['report_id'] = reportId;
+        }
+
+        document.dispatchEvent(new Event('autosave:start'));
+
+        return fetch(window.AUTOSAVE_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': window.AUTOSAVE_CSRF
+            },
+            body: JSON.stringify(formData)
+        })
+        .then(async res => {
+            let data = null;
+            try {
+                data = await res.json();
+            } catch (e) {}
+            if (!res.ok) {
+                return Promise.reject(data || res.status);
+            }
+            return data;
+        })
+        .then(data => {
+            if (data && data.success && data.report_id) {
+                if (!reportId || reportId !== data.report_id) {
+                    const old = getSavedData();
+                    clearLocal();
+                    reportId = data.report_id;
+                    storageKey = `report_draft_${reportId}`;
+                    old._report_id = reportId;
+                    localStorage.setItem(storageKey, JSON.stringify(old));
+                    window.REPORT_ID = reportId;
+                } else {
+                    saveLocal();
+                }
+                document.dispatchEvent(new CustomEvent('autosave:success', {detail: {reportId: data.report_id}}));
+                return data;
+            }
+            return Promise.reject(data);
+        })
+        .catch(err => {
+            document.dispatchEvent(new CustomEvent('autosave:error', {detail: err}));
+            return Promise.reject(err);
+        });
+    }
+
+    function bindField(field) {
+        if (field.dataset.autosaveBound) return;
+        const handler = () => {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(() => {
+                autosaveDraft().catch(() => {});
+                saveLocal();
+            }, 1000);
+        };
+        field.addEventListener('input', handler);
+        if (field.tagName === 'SELECT') {
+            field.addEventListener('change', handler);
+        }
+        field.dataset.autosaveBound = 'true';
+    }
+
+    function reinitialize() {
+        fields = Array.from(document.querySelectorAll('input[name], textarea[name], select[name]'));
+        const saved = getSavedData();
+        fields.forEach(f => {
+            if (saved.hasOwnProperty(f.name)) {
+                const val = saved[f.name];
+                if (f.type === 'checkbox') {
+                    if (Array.isArray(val)) {
+                        f.checked = val.includes(f.value);
+                    } else {
+                        f.checked = !!val;
+                    }
+                } else if (f.type === 'radio') {
+                    f.checked = val === f.value;
+                } else if (f.multiple) {
+                    const values = Array.isArray(val) ? val : [val];
+                    Array.from(f.options).forEach(o => { o.selected = values.includes(o.value); });
+                } else if (!f.value) {
+                    f.value = val;
+                }
+            }
+            bindField(f);
+        });
+
+        if (saved._report_id && !reportId) {
+            reportId = saved._report_id;
+            storageKey = `report_draft_${reportId}`;
+            window.REPORT_ID = reportId;
+        }
+
+        if (window.REPORT_STATUS && window.REPORT_STATUS !== 'draft') {
+            clearLocal();
+        }
+    }
+
+    function manualSave() {
+        saveLocal();
+        return autosaveDraft();
+    }
+
+    reinitialize();
+
+    const formEl = document.querySelector('form');
+    if (formEl) {
+        formEl.addEventListener('submit', clearLocal);
+    }
+
+    return {
+        reinitialize,
+        manualSave,
+        autosaveDraft,
+        clearLocal
+    };
+})();

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -355,8 +355,8 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           }
       };
 
-      const savePromise = (window.AutosaveManager && window.AutosaveManager.manualSave)
-          ? window.AutosaveManager.manualSave()
+      const savePromise = (window.ReportAutosaveManager && window.ReportAutosaveManager.manualSave)
+          ? window.ReportAutosaveManager.manualSave()
           : Promise.resolve();
 
       savePromise.then(proceed).catch(() => {
@@ -1505,8 +1505,8 @@ function initAttachments(){
       removeBtn.style.display = 'none';
       const del = block.querySelector('input[name$="-DELETE"]');
       if(del) del.checked = true;
-      if (window.AutosaveManager) {
-        AutosaveManager.reinitialize();
+      if (window.ReportAutosaveManager) {
+        ReportAutosaveManager.reinitialize();
       }
     });
   }
@@ -1522,8 +1522,8 @@ function initAttachments(){
     list.appendChild(block);
     totalInput.value = idx + 1;
     bind(block);
-    if (window.AutosaveManager) {
-      AutosaveManager.reinitialize();
+    if (window.ReportAutosaveManager) {
+      ReportAutosaveManager.reinitialize();
     }
     block.querySelector('.file-input').click();
   });
@@ -1674,8 +1674,8 @@ function initializeSectionSpecificHandlers() {
         `;
 
         container.append(memberHtml);
-        if (window.AutosaveManager) {
-            AutosaveManager.reinitialize();
+        if (window.ReportAutosaveManager) {
+            ReportAutosaveManager.reinitialize();
         }
     });
 
@@ -1687,8 +1687,8 @@ function initializeSectionSpecificHandlers() {
         $('#committee-members-container .committee-member-group').each(function(index) {
             $(this).find('h6').text(`Committee Member ${index + 1}`);
         });
-        if (window.AutosaveManager) {
-            AutosaveManager.reinitialize();
+        if (window.ReportAutosaveManager) {
+            ReportAutosaveManager.reinitialize();
         }
     });
 }
@@ -1759,8 +1759,8 @@ function setupDynamicActivities() {
         });
         numInput.value = activities.length;
         console.log('Activities rendered successfully, count:', activities.length);
-        if (window.AutosaveManager) {
-            AutosaveManager.reinitialize();
+        if (window.ReportAutosaveManager) {
+            ReportAutosaveManager.reinitialize();
         }
     }
 
@@ -1971,8 +1971,8 @@ $(document).ready(function() {
     initializeSectionSpecificHandlers();
     setupDynamicActivities();
     setupAttendanceModal();
-    if (window.AutosaveManager) {
-        AutosaveManager.reinitialize();
+    if (window.ReportAutosaveManager) {
+        ReportAutosaveManager.reinitialize();
     }
     initializeAutosaveIndicators();
 });

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -358,7 +358,6 @@
         window.REPORT_ACTUAL_EVENT_TYPE = "{{ form.actual_event_type.value|default:'' }}";
         window.AUTOSAVE_URL = "{% url 'emt:autosave_event_report' %}";
         window.AUTOSAVE_CSRF = "{{ csrf_token }}";
-        window.PROPOSAL_STATUS = window.REPORT_STATUS;
         window.API_ORGANIZATIONS = "#"; // TODO: Add API URLs
         window.API_CLASSES_BASE = "{% url 'emt:api_classes' 0 %}".split('0/')[0];
         window.API_FACULTY = "{% url 'emt:api_faculty' %}";
@@ -389,6 +388,6 @@
         };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
-    <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
+    <script src="{% static 'emt/js/report_autosave.js' %}"></script>
     <script src="{% static 'emt/js/submit_event_report.js' %}"></script>
 {% endblock %}

--- a/emt/tests/test_event_report_session.py
+++ b/emt/tests/test_event_report_session.py
@@ -1,0 +1,59 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.db.models.signals import post_save
+from django.contrib.auth.signals import user_logged_in
+
+from core.signals import create_or_update_user_profile, assign_role_on_login
+from emt.models import EventProposal
+
+
+class EventReportSessionTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="bob", password="pass")
+        self.client.force_login(self.user)
+        self.proposal = EventProposal.objects.create(submitted_by=self.user, event_title="Session Test")
+
+    def _management_data(self):
+        return {
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+
+    def test_session_persists_and_prefills(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        post_data = {"location": "Hall"}
+        post_data.update(self._management_data())
+        self.client.post(url, post_data)
+
+        session = self.client.session.get("event_report_draft", {})
+        self.assertIn(str(self.proposal.id), session)
+        self.assertEqual(session[str(self.proposal.id)]["location"], "Hall")
+
+        resp = self.client.get(url)
+        self.assertContains(resp, 'name="location" value="Hall"', html=False)
+
+    def test_session_cleared_after_submission(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        post_data = {"location": "Hall"}
+        post_data.update(self._management_data())
+        self.client.post(url, post_data)
+
+        resp = self.client.post(url, post_data)
+        self.assertEqual(resp.status_code, 302)
+        session = self.client.session.get("event_report_draft", {})
+        self.assertNotIn(str(self.proposal.id), session)

--- a/emt/views.py
+++ b/emt/views.py
@@ -21,6 +21,7 @@ from .models import (
     EventReportAttachment, CDLSupport, CDLCertificateRecipient, CDLMessage, Student,
     AttendanceRow,
 )
+from types import SimpleNamespace
 from .forms import (
     EventProposalForm, NeedAnalysisForm, ExpectedOutcomesForm,
     ObjectivesForm, TentativeFlowForm, SpeakerProfileForm,
@@ -1260,11 +1261,17 @@ def autosave_event_report(request):
         return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
 
     proposal_id = data.get("proposal_id")
+    report_id = data.get("report_id")
+
     proposal = EventProposal.objects.filter(id=proposal_id, submitted_by=request.user).first()
     if not proposal:
         return JsonResponse({"success": False, "error": "Invalid proposal"}, status=400)
 
-    report, _ = EventReport.objects.get_or_create(proposal=proposal)
+    report = None
+    if report_id:
+        report = EventReport.objects.filter(id=report_id, proposal=proposal).first()
+    if not report:
+        report, _ = EventReport.objects.get_or_create(proposal=proposal)
 
     # Map section fields to model fields
     summary_content = data.pop("event_summary", None)
@@ -1288,7 +1295,7 @@ def autosave_event_report(request):
 
     _save_activities(proposal, data)
 
-    return JsonResponse({"success": True, "proposal_id": proposal.id})
+    return JsonResponse({"success": True, "report_id": report.id})
 
 @login_required
 def api_organizations(request):
@@ -1660,42 +1667,69 @@ def submit_event_report(request, proposal_id):
         submitted_by=request.user,
     )
 
-    # Only allow if no report exists yet
-    report, created = EventReport.objects.get_or_create(proposal=proposal)
-    AttachmentFormSet = modelformset_factory(EventReportAttachment, form=EventReportAttachmentForm, extra=2, can_delete=True)
+    report = EventReport.objects.filter(proposal=proposal).first()
+    AttachmentFormSet = modelformset_factory(
+        EventReportAttachment, form=EventReportAttachmentForm, extra=2, can_delete=True
+    )
+
+    drafts = request.session.setdefault("event_report_draft", {})
+    draft = drafts.get(str(proposal_id), {})
 
     if request.method == "POST":
+        drafts[str(proposal_id)] = {
+            key: request.POST.getlist(key) if len(request.POST.getlist(key)) > 1 else request.POST.get(key)
+            for key in request.POST.keys()
+        }
+        request.session.modified = True
+
         form = EventReportForm(request.POST, instance=report)
-        formset = AttachmentFormSet(request.POST, request.FILES, queryset=report.attachments.all())
+        attachments_qs = report.attachments.all() if report else EventReportAttachment.objects.none()
+        formset = AttachmentFormSet(request.POST, request.FILES, queryset=attachments_qs)
         if form.is_valid() and formset.is_valid() and _save_activities(proposal, request.POST, form):
             report = form.save(commit=False)
             report.proposal = proposal
             report.save()
             form.save_m2m()
 
-            # Save attachments
             instances = formset.save(commit=False)
             for obj in instances:
                 obj.report = report
                 obj.save()
             for obj in formset.deleted_objects:
                 obj.delete()
-            messages.success(request, "Report submitted successfully! Starting AI generation...")
-            # Directly redirect to streaming AI progress page
-            return redirect('emt:ai_report_progress', proposal_id=proposal.id)
-    else:
-        form = EventReportForm(instance=report)
-        formset = AttachmentFormSet(queryset=report.attachments.all())
 
-    # Fetch activities for editing in the report form
+            drafts.pop(str(proposal_id), None)
+            request.session.modified = True
+
+            messages.success(
+                request, "Report submitted successfully! Starting AI generation..."
+            )
+            return redirect("emt:ai_report_progress", proposal_id=proposal.id)
+    else:
+        form = EventReportForm(initial=draft, instance=report)
+        attachments_qs = report.attachments.all() if report else EventReportAttachment.objects.none()
+        formset = AttachmentFormSet(queryset=attachments_qs)
+
     activities_qs = EventActivity.objects.filter(proposal=proposal)
     proposal_activities = [
         {
-            "activity_name": a.name, 
-            "activity_date": a.date.strftime('%Y-%m-%d') if a.date else ''
+            "activity_name": a.name,
+            "activity_date": a.date.strftime("%Y-%m-%d") if a.date else ""
         }
         for a in activities_qs
     ]
+    if draft:
+        num_act = int(draft.get("num_activities", 0) or 0)
+        session_acts = []
+        for i in range(1, num_act + 1):
+            session_acts.append(
+                {
+                    "activity_name": draft.get(f"activity_name_{i}", ""),
+                    "activity_date": draft.get(f"activity_date_{i}", ""),
+                }
+            )
+        if session_acts:
+            proposal_activities = session_acts
 
     # Fetch speakers data for editing
     speakers_qs = SpeakerProfile.objects.filter(proposal=proposal)
@@ -1712,20 +1746,26 @@ def submit_event_report(request, proposal_id):
     # Get or create content sections for the report
     try:
         event_summary = report.event_summary
-    except:
+    except Exception:
         event_summary = None
-        
+    if draft.get("event_summary"):
+        event_summary = SimpleNamespace(content=draft.get("event_summary"))
+
     try:
         event_outcomes = report.event_outcomes
-    except:
+    except Exception:
         event_outcomes = None
-        
+    if draft.get("event_outcomes"):
+        event_outcomes = SimpleNamespace(content=draft.get("event_outcomes"))
+
     try:
         analysis = report.analysis
-    except:
+    except Exception:
         analysis = None
+    if draft.get("analysis"):
+        analysis = SimpleNamespace(content=draft.get("analysis"))
 
-    attendance_qs = report.attendance_rows.all()
+    attendance_qs = report.attendance_rows.all() if report else AttendanceRow.objects.none()
     attendance_present = attendance_qs.filter(absent=False).count()
     attendance_absent = attendance_qs.filter(absent=True).count()
     attendance_volunteers = attendance_qs.filter(volunteer=True).count()


### PR DESCRIPTION
## Summary
- Stage event report form data in `event_report_draft` session cache, pre-filling fields on reload and clearing after successful submission.
- Introduce `ReportAutosaveManager` to persist drafts via `report_draft_<id>` localStorage keys and send autosave requests with `report_id`.
- Wire autosave manager into dynamic form actions and update autosave endpoint to accept and return `report_id`.

## Testing
- `python manage.py test emt` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab315d444c832c8aba2645d61b43aa