### PR TITLE
Send cookies with autosave requests

### DIFF
--- a/emt/static/emt/js/report_autosave.js
+++ b/emt/static/emt/js/report_autosave.js
@@ -83,6 +83,7 @@ window.ReportAutosaveManager = (function() {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': window.AUTOSAVE_CSRF
             },
+            credentials: 'same-origin',
             body: JSON.stringify(formData)
         })
         .then(async res => {


### PR DESCRIPTION
## Summary
- ensure autosave fetch requests transmit session cookies by setting `credentials: 'same-origin'`

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*
- `python - <<'PY' ...` *(autosave returns 200 when logged in)*
- `python - <<'PY' ...` *(autosave returns 302 when not logged in)*

------
https://chatgpt.com/codex/tasks/task_e_68ab34ca02fc832cbfb35f9d4d8762c9