### PR TITLE
Use path-based key for report autosave

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1616,8 +1616,11 @@ function updateSpeakerDisplay() {
             </div>
         `;
     });
-    
+
     speakersDisplay.innerHTML = html;
+    if (window.ReportAutosaveManager) {
+        ReportAutosaveManager.reinitialize();
+    }
 }
 
 // Function to handle dynamic content updates when sections are loaded


### PR DESCRIPTION
## Summary
- Use stable pathname-based localStorage key for report autosave and keep `_report_id` inside saved payload
- Reinitialize autosave manager on dynamically added speaker fields

## Testing
- `node manual_test.js`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab371d1e38832c92accacc00856d23