### PR TITLE
Remove draft saving buttons from event report form

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1,4 +1,4 @@
-/* Save as Draft button styling - matches Save & Continue */
+/* Secondary action button styling - matches Save & Continue */
 .btn-draft-section, .btn-draft {
   background: var(--primary-blue);
   color: #fff;

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -809,7 +809,6 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           <div class="form-row full-width">
               <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
                   <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                  <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                   <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
               </div>
           </div>
@@ -893,7 +892,6 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           <div class="form-row full-width">
               <div class="save-section-container">
                   <button type="button" class="btn-save-section">Save & Continue</button>
-                  <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                   <div class="save-help-text">Complete this section to unlock the next one</div>
               </div>
           </div>
@@ -946,7 +944,6 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           <div class="form-row full-width">
               <div class="save-section-container">
                   <button type="button" class="btn-save-section">Save & Continue</button>
-                  <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                   <div class="save-help-text">Complete this section to unlock the next one</div>
               </div>
           </div>
@@ -1011,7 +1008,6 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           <div class="form-row full-width">
               <div class="save-section-container">
                   <button type="button" class="btn-save-section">Save & Continue</button>
-                  <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                   <div class="save-help-text">Complete this section to unlock the next one</div>
               </div>
           </div>
@@ -1096,7 +1092,6 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           <div class="form-row full-width">
               <div class="save-section-container">
                   <button type="button" class="btn-save-section">Save & Continue</button>
-                  <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                   <div class="save-help-text">Complete this section to unlock the next one</div>
               </div>
           </div>
@@ -1168,7 +1163,6 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
           <div class="form-row full-width">
               <div class="save-section-container">
                   <button type="button" class="btn-save-section">Save & Continue</button>
-                  <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                   <div class="save-help-text">Complete this section to unlock the next one</div>
               </div>
           </div>

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -278,7 +278,6 @@
                         <div class="form-row full-width">
                             <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
                                 <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                                <button type="submit" name="save_draft" class="btn-draft-section">Save as Draft</button>
                                 <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
                             </div>
                         </div>
@@ -288,7 +287,6 @@
 
             <div class="submit-section hidden">
                 <button type="submit" name="final_submit" class="btn-submit" id="submit-report-btn" disabled>Submit Report</button>
-                <button type="submit" name="save_draft" class="btn-draft" id="save-draft-btn">Save as Draft</button>
                 <div class="submit-help-text">Complete all sections above to enable submission</div>
             </div>
 


### PR DESCRIPTION
## Summary
- remove manual "Save as Draft" buttons from event report form and dynamic sections
- rely on existing autosave to persist input changes automatically
- adjust secondary button styling comment

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad75c6bcb0832cb7347e65bcb73b2c