### PR TITLE
Fix autosave on participants section

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -421,6 +421,9 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
       // Restore field values if switching back to a section
       setTimeout(() => {
           restoreFieldValues(sectionName);
+          if (window.ReportAutosaveManager) {
+              ReportAutosaveManager.reinitialize();
+          }
       }, 100);
   }
   


### PR DESCRIPTION
## Summary
- Reinitialize autosave manager after restoring section fields to keep draft saving working when switching sections

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad79498374832cab74e87bad1072c4