### PR TITLE
Prefill SDG implementation with proposal goals and add AI assist

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -270,7 +270,16 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
     catch (err) { console.error(err); }
     finally { btn.prop('disabled', false).text(original); }
 });
-  
+
+$(document).on('click', '#ai-sdg-implementation', function(){
+    const btn = $(this);
+    const original = btn.text();
+    btn.prop('disabled', true).text('...');
+    try { aiFill('#sdg-implementation-modern', 120); }
+    catch (err) { console.error(err); }
+    finally { btn.prop('disabled', false).text(original); }
+});
+
   // Add validation styling to form fields with errors
   $('.field-error').each(function() {
       $(this).siblings('input, select, textarea').addClass('error');
@@ -1277,10 +1286,11 @@ $(document).on('click', '#ai-contemporary-requirements', function(){
                   <div class="help-text">Explain how the event addresses employability, entrepreneurship, skill development, etc.</div>
               </div>
 
-              <div class="input-group">
+              <div class="input-group ai-input">
                   <label for="sdg-implementation-modern">SDG Implementation *</label>
                   <textarea id="sdg-implementation-modern" name="sdg_value_systems_mapping" rows="10" required
                       placeholder="Click 'Select SDG Goals' to choose from the 17 Sustainable Development Goals&#10;&#10;Selected goals will appear here and can be edited:&#10;&#10;You can modify the SDG selection or add additional context about how your event addresses these goals."></textarea>
+                  <button type="button" id="ai-sdg-implementation" class="ai-fill-btn" title="Fill with AI">AI</button>
                   <button type="button" id="sdg-select-btn" class="btn-select-sdg">Select SDG Goals</button>
                   <div class="help-text">Sustainable Development Goals addressed by this event (editable)</div>
               </div>
@@ -1356,16 +1366,21 @@ function showNotification(message, type = 'info') {
 
 // Populate fields with proposal data
 function populateProposalData() {
-    // Populate PO/PSO field when section becomes active
+    function fillEventRelevance() {
+        if ($('#pos-pso-modern').length && window.PROPOSAL_DATA && window.PROPOSAL_DATA.pos_pso) {
+            $('#pos-pso-modern').val(window.PROPOSAL_DATA.pos_pso);
+        }
+        if ($('#sdg-implementation-modern').length && window.PROPOSAL_DATA && window.PROPOSAL_DATA.sdg_goals) {
+            $('#sdg-implementation-modern').val(window.PROPOSAL_DATA.sdg_goals);
+        }
+    }
+
+    // Populate on load
+    setTimeout(fillEventRelevance, 100);
+
+    // Populate when section becomes active
     $(document).on('click', '[data-section="event-relevance"]', function() {
-        setTimeout(function() {
-            if ($('#pos-pso-modern').length && window.PROPOSAL_DATA && window.PROPOSAL_DATA.pos_pso) {
-                $('#pos-pso-modern').val(window.PROPOSAL_DATA.pos_pso);
-            }
-            if ($('#sdg-implementation-modern').length && window.PROPOSAL_DATA && window.PROPOSAL_DATA.sdg_goals) {
-                $('#sdg-implementation-modern').val(window.PROPOSAL_DATA.sdg_goals);
-            }
-        }, 100);
+        setTimeout(fillEventRelevance, 100);
     });
 
     // Populate organizing committee details when section becomes active

--- a/suite/facts.py
+++ b/suite/facts.py
@@ -7,7 +7,7 @@ BASIC_FIELDS = [
     "organization_type", "department", "committees_collaborations",
     "event_title", "target_audience", "event_focus_type", "location",
     "start_date", "end_date", "academic_year",
-    "pos_pso_management", "sdg_goals",
+    "pos_pso_management", "sdg_goals", "sdg_value_systems_mapping",
     "num_activities", "student_coordinators", "faculty_incharges",
     "additional_context",
 ]
@@ -42,6 +42,7 @@ def collect_basic_facts(request, field_names: List[str] | None = None) -> Dict[s
         "academic_year": get("academic_year", "") or "[TBD]",
         "pos_pso_management": get("pos_pso_management", get("pos_pso", "")) or "[TBD]",
         "sdg_goals": request.POST.getlist("sdg_goals[]") or request.POST.getlist("sdg_goals") or [],
+        "sdg_value_systems_mapping": get("sdg_value_systems_mapping", "") or "[TBD]",
         "num_activities": get("num_activities", "") or "[TBD]",
         "student_coordinators": request.POST.getlist("student_coordinators[]") or [],
         "faculty_incharges": request.POST.getlist("faculty_incharges[]") or [],

--- a/suite/field_config/challenges_analysis.json
+++ b/suite/field_config/challenges_analysis.json
@@ -4,6 +4,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "pos_pso_management",
     "num_activities"
   ]

--- a/suite/field_config/contemporary_requirements.json
+++ b/suite/field_config/contemporary_requirements.json
@@ -5,6 +5,7 @@
     "event_focus_type",
     "pos_pso_management",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "num_activities"
   ]
 }

--- a/suite/field_config/effectiveness_analysis.json
+++ b/suite/field_config/effectiveness_analysis.json
@@ -4,6 +4,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "pos_pso_management",
     "num_activities"
   ]

--- a/suite/field_config/impact_assessment.json
+++ b/suite/field_config/impact_assessment.json
@@ -4,6 +4,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "pos_pso_management",
     "additional_context"
   ]

--- a/suite/field_config/learning_outcomes.json
+++ b/suite/field_config/learning_outcomes.json
@@ -4,6 +4,7 @@
     "target_audience",
     "pos_pso_management",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "num_activities"
   ]
 }

--- a/suite/field_config/learning_outcomes_achieved.json
+++ b/suite/field_config/learning_outcomes_achieved.json
@@ -4,6 +4,7 @@
     "target_audience",
     "pos_pso_management",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "num_activities"
   ]
 }

--- a/suite/field_config/lessons_learned.json
+++ b/suite/field_config/lessons_learned.json
@@ -4,6 +4,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "pos_pso_management",
     "num_activities"
   ]

--- a/suite/field_config/measurable_outcomes.json
+++ b/suite/field_config/measurable_outcomes.json
@@ -5,6 +5,7 @@
     "num_activities",
     "student_coordinators",
     "faculty_incharges",
-    "additional_context"
+    "additional_context",
+    "sdg_value_systems_mapping"
   ]
 }

--- a/suite/field_config/need_analysis.json
+++ b/suite/field_config/need_analysis.json
@@ -4,6 +4,7 @@
     "department",
     "target_audience",
     "event_focus_type",
-    "sdg_goals"
+    "sdg_goals",
+    "sdg_value_systems_mapping"
   ]
 }

--- a/suite/field_config/objective_achievement.json
+++ b/suite/field_config/objective_achievement.json
@@ -4,6 +4,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "pos_pso_management",
     "num_activities"
   ]

--- a/suite/field_config/objectives.json
+++ b/suite/field_config/objectives.json
@@ -3,6 +3,7 @@
     "event_title",
     "event_focus_type",
     "committees_collaborations",
-    "pos_pso_management"
+    "pos_pso_management",
+    "sdg_value_systems_mapping"
   ]
 }

--- a/suite/field_config/pos_pso.json
+++ b/suite/field_config/pos_pso.json
@@ -5,6 +5,7 @@
     "event_focus_type",
     "pos_pso_management",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "num_activities"
   ]
 }

--- a/suite/field_config/strengths_analysis.json
+++ b/suite/field_config/strengths_analysis.json
@@ -4,6 +4,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "pos_pso_management",
     "num_activities"
   ]

--- a/suite/field_config/student_engagement.json
+++ b/suite/field_config/student_engagement.json
@@ -4,6 +4,7 @@
     "target_audience",
     "num_activities",
     "student_coordinators",
-    "faculty_incharges"
+    "faculty_incharges",
+    "sdg_value_systems_mapping"
   ]
 }

--- a/suite/field_config/why_event.json
+++ b/suite/field_config/why_event.json
@@ -5,6 +5,7 @@
     "target_audience",
     "event_focus_type",
     "sdg_goals",
+    "sdg_value_systems_mapping",
     "event_title",
     "committees_collaborations",
     "pos_pso_management",


### PR DESCRIPTION
## Summary
- Auto-populate SDG Implementation field with goals chosen in the proposal and expose an AI helper for enhancements.
- Include SDG implementation text in suite's collected facts and required field configuration.

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8a65e2b4832c9b6d88e8efde29fc