### PR TITLE
Handle multi-value fields in event report preview

### DIFF
--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -23,7 +23,9 @@
             {% endfor %}
             <ol class="report-preview-list">
                 {% for field in form.visible_fields %}
-                    <li><strong>{{ field.label }}:</strong> {{ field.value|default:"—" }}</li>
+                    {% with values=form.data.getlist(field.name) %}
+                        <li><strong>{{ field.label }}:</strong> {{ values|join:", "|default:"—" }}</li>
+                    {% endwith %}
                 {% endfor %}
             </ol>
             <button type="submit" name="final_submit" class="btn-submit">Submit Report</button>


### PR DESCRIPTION
## Summary
- Render multi-select/checkbox fields correctly on the event report preview page

## Testing
- `python manage.py test` *(fails: 'sslmode' is an invalid keyword argument for Connection())*


------
https://chatgpt.com/codex/tasks/task_e_68add319d9e0832cb637152970099869