### PR TITLE
Fix report preview preview list handling

### DIFF
--- a/core/templatetags/dict_filters.py
+++ b/core/templatetags/dict_filters.py
@@ -8,3 +8,13 @@ def get_item(dictionary, key):
     if dictionary and key:
         return dictionary.get(key)
     return None
+
+
+@register.filter
+def get_list(querydict, key):
+    """Return a list of values from a QueryDict-like object."""
+    if querydict and key:
+        getlist = getattr(querydict, "getlist", None)
+        if callable(getlist):
+            return getlist(key)
+    return []

--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static dict_filters %}
 
 {% block title %}Review Event Report{% endblock %}
 
@@ -23,7 +23,7 @@
             {% endfor %}
             <ol class="report-preview-list">
                 {% for field in form.visible_fields %}
-                    {% with values=form.data.getlist(field.name) %}
+                    {% with values=form.data|get_list:field.name %}
                         <li><strong>{{ field.label }}:</strong> {{ values|join:", "|default:"—" }}</li>
                     {% endwith %}
                 {% endfor %}


### PR DESCRIPTION
## Summary
- add template filter for QueryDict.getlist
- use get_list filter in report preview template to render multi-value fields

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68add4e56100832c8116239d42e1f04a