### PR TITLE
Show proposal fields in report preview

### DIFF
--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -21,6 +21,13 @@
             {% for key, value in post_data.items %}
                 <input type="hidden" name="{{ key }}" value="{{ value|escape }}">
             {% endfor %}
+            <h3>Event Proposal Details</h3>
+            <ol class="report-preview-list">
+                {% for label, value in proposal_fields %}
+                    <li><strong>{{ label }}:</strong> {{ value }}</li>
+                {% endfor %}
+            </ol>
+            <h3>Event Report Details</h3>
             <ol class="report-preview-list">
                 {% for field in form.visible_fields %}
                     {% with values=form.data|get_list:field.name %}


### PR DESCRIPTION
## Summary
- Display submitted event proposal details alongside report fields in report preview
- Build proposal field list in `preview_event_report` view for template use

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade2ee8018832c8d959351d6e7a571