### PR TITLE
feat: refine review proposal layout

### DIFF
--- a/emt/static/emt/css/review_proposal.css
+++ b/emt/static/emt/css/review_proposal.css
@@ -116,12 +116,18 @@ body {
   padding: 0 0 14px 0;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: var(--spacing-md);
   flex-wrap: wrap;
 }
 
-.review-heading { flex: 1; text-align: center; }
+.review-heading { flex: 1; text-align: left; }
+
+.review-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
 
 .review-title {
   font-size: 2.2rem;
@@ -199,6 +205,12 @@ body {
   box-shadow: 0 1px 7px rgba(36,70,120,0.06);
 }
 
+.speaker-profile-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
 .review-section-header {
   display: flex;
   align-items: center;
@@ -207,13 +219,21 @@ body {
 }
 
 .section-edit-link {
+  display: inline-block;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 6px;
   font-size: 0.9rem;
-  color: var(--christ-blue-primary);
+  font-weight: 600;
+  color: var(--white);
+  background: var(--christ-blue-primary);
+  transition: background var(--transition-base);
+  text-decoration: none;
 }
 
 .section-edit-link:hover,
 .section-edit-link:focus {
-  text-decoration: underline;
+  background: var(--christ-blue-secondary);
+  outline: none;
 }
 .speaker-profile-block .profile-aff {
   color: var(--christ-blue-primary); font-weight: 600; margin-left: 8px;

--- a/emt/templates/emt/partials/review_section.html
+++ b/emt/templates/emt/partials/review_section.html
@@ -1,5 +1,5 @@
 {# Reusable section card for proposal review #}
-<div class="event-details-card">
+<div id="{{ title|slugify }}" class="event-details-card card-base">
   <div class="review-section-header">
     <h3>{{ title }}</h3>
     {% if edit_url %}

--- a/emt/templates/emt/review_proposal.html
+++ b/emt/templates/emt/review_proposal.html
@@ -10,7 +10,7 @@
 <div class="detail-container review-grid">
   <!-- LEFT COLUMN: Event Info Card -->
   <aside class="timeline-column review-side">
-    <div class="info-card event-details-card">
+    <div class="info-card event-details-card card-base">
       <h2>Event Information</h2>
       <table>
         <tr><th>Organization</th><td>{{ proposal.organization.name|default:"—" }}</td></tr>
@@ -118,7 +118,7 @@
     {% include "emt/partials/review_section.html" with title="Expected Outcomes" body=outcomes.content edit_url=out_edit %}
     {% include "emt/partials/review_section.html" with title="Tentative Flow" body=flow.content edit_url=flow_edit %}
 
-    <div class="event-details-card">
+    <div class="event-details-card card-base">
       <div class="review-section-header">
         <h3>Speaker Profile</h3>
         <a href="{{ speaker_edit }}" class="section-edit-link">Edit</a>
@@ -126,8 +126,8 @@
       {% if speakers %}
         <ul class="speaker-profile-list">
           {% for sp in speakers %}
-            <li>
-              <strong>{{ sp.full_name }}</strong>{% if sp.designation %} - {{ sp.designation }}{% endif %}
+            <li class="speaker-profile-block">
+              <strong>{{ sp.full_name }}</strong>{% if sp.designation %}<span class="profile-aff">{{ sp.designation }}</span>{% endif %}
             </li>
           {% endfor %}
         </ul>
@@ -136,50 +136,52 @@
       {% endif %}
     </div>
 
-    <div class="event-details-card">
-      <div class="review-section-header">
-        <h3>Expense Details</h3>
-        <a href="{{ expense_edit }}" class="section-edit-link">Edit</a>
+    <div class="fin-row">
+      <div class="fin-half event-details-card card-base">
+        <div class="review-section-header">
+          <h3>Expense Details</h3>
+          <a href="{{ expense_edit }}" class="section-edit-link">Edit</a>
+        </div>
+        {% if expenses %}
+          <table class="review-table">
+            <thead>
+              <tr><th>Sl. No.</th><th>Particulars</th><th>Amount</th></tr>
+            </thead>
+            <tbody>
+            {% for e in expenses %}
+              <tr>
+                <td>{{ e.sl_no }}</td>
+                <td>{{ e.particulars }}</td>
+                <td>{{ e.amount }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <div class="detail-block">—</div>
+        {% endif %}
       </div>
-      {% if expenses %}
-        <table class="review-table">
-          <thead>
-            <tr><th>Sl. No.</th><th>Particulars</th><th>Amount</th></tr>
-          </thead>
-          <tbody>
-          {% for e in expenses %}
-            <tr>
-              <td>{{ e.sl_no }}</td>
-              <td>{{ e.particulars }}</td>
-              <td>{{ e.amount }}</td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
-      {% else %}
-        <div class="detail-block">—</div>
-      {% endif %}
-    </div>
 
-    <div class="event-details-card">
-      <div class="review-section-header">
-        <h3>Income Details</h3>
-        <a href="{{ expense_edit }}" class="section-edit-link">Edit</a>
+      <div class="fin-half event-details-card card-base">
+        <div class="review-section-header">
+          <h3>Income Details</h3>
+          <a href="{{ expense_edit }}" class="section-edit-link">Edit</a>
+        </div>
+        {% if income %}
+          <table class="review-table">
+            <tr><th>Sl. No.</th><th>Particulars</th><th>Participants</th><th>Rate</th><th>Amount</th></tr>
+            {% for i in income %}
+              <tr><td>{{ i.sl_no }}</td><td>{{ i.particulars }}</td><td>{{ i.participants }}</td><td>{{ i.rate }}</td><td>{{ i.amount }}</td></tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <div class="detail-block">—</div>
+        {% endif %}
       </div>
-      {% if income %}
-        <table class="review-table">
-          <tr><th>Sl. No.</th><th>Particulars</th><th>Participants</th><th>Rate</th><th>Amount</th></tr>
-          {% for i in income %}
-            <tr><td>{{ i.sl_no }}</td><td>{{ i.particulars }}</td><td>{{ i.participants }}</td><td>{{ i.rate }}</td><td>{{ i.amount }}</td></tr>
-          {% endfor %}
-        </table>
-      {% else %}
-        <div class="detail-block">—</div>
-      {% endif %}
     </div>
 
     {% if cdl_support %}
-    <div class="event-details-card">
+    <div class="event-details-card card-base">
       <div class="review-section-header">
         <h3>CDL Support</h3>
         <a href="{{ cdl_edit }}" class="section-edit-link">Edit</a>


### PR DESCRIPTION
## Summary
- unify review cards with reusable card style and section anchors
- align header actions and style edit buttons
- show expenses and income side by side for easier comparison

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adeee34034832cbe7a4a88ce43d2ba