### PR TITLE
Fix CDL support options visibility

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2188,7 +2188,8 @@ function getWhyThisEventForm() {
     // ===== CDL SUPPORT SECTION FUNCTIONALITY =====
     function setupCDLForm() {
         const needsSupport = $('#id_needs_support');
-        const cdlSections = $('#cdl-sections');
+        const cdlSections = $('#cdl-services-container');
+        const cdlEmptyState = $('#cdl-empty-state');
         const posterRequired = $('#id_poster_required');
         const posterDetails = $('#poster-details');
         const certificatesRequired = $('#id_certificates_required');
@@ -2204,8 +2205,14 @@ function getWhyThisEventForm() {
 
         // Set up all the toggle functionality
         if (needsSupport.length) {
-            needsSupport.on('change', () => toggle(cdlSections, needsSupport.prop('checked')));
-            toggle(cdlSections, needsSupport.prop('checked'));
+            needsSupport.on('change', () => {
+                const checked = needsSupport.prop('checked');
+                toggle(cdlSections, checked);
+                toggle(cdlEmptyState, !checked);
+            });
+            const initial = needsSupport.prop('checked');
+            toggle(cdlSections, initial);
+            toggle(cdlEmptyState, !initial);
         }
 
         if (posterRequired.length) {


### PR DESCRIPTION
## Summary
- Ensure CDL support options appear when support checkbox is toggled
- Hide empty state when CDL support is enabled

## Testing
- `python manage.py test` *(fails: connection to remote PostgreSQL database)*

------
https://chatgpt.com/codex/tasks/task_e_68adf32f6a3c832c95ab9c434a6e4477