### PR TITLE
Fix template conditional for empty income rows

### DIFF
--- a/emt/templates/emt/review_approval_step.html
+++ b/emt/templates/emt/review_approval_step.html
@@ -190,7 +190,14 @@
                     <td>{{ proposal.conf_sponsorship_amount|default:"—" }}</td>
                   </tr>
                 {% endif %}
-                {% if not (proposal.fest_fee_participants or proposal.fest_fee_rate or proposal.fest_fee_amount or proposal.fest_sponsorship_amount or proposal.conf_fee_participants or proposal.conf_fee_rate or proposal.conf_fee_amount or proposal.conf_sponsorship_amount) %}
+                {% if not proposal.fest_fee_participants and
+                      not proposal.fest_fee_rate and
+                      not proposal.fest_fee_amount and
+                      not proposal.fest_sponsorship_amount and
+                      not proposal.conf_fee_participants and
+                      not proposal.conf_fee_rate and
+                      not proposal.conf_fee_amount and
+                      not proposal.conf_sponsorship_amount %}
                   <tr>
                     <td colspan="5">—</td>
                   </tr>


### PR DESCRIPTION
## Summary
- fix income section in review approval template to avoid invalid conditional

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adfc7b4df4832c8ecc91b32224e9f8