### PR TITLE
Fix review approval income template conditional

### DIFF
--- a/emt/templates/emt/review_approval_step.html
+++ b/emt/templates/emt/review_approval_step.html
@@ -190,14 +190,8 @@
                     <td>{{ proposal.conf_sponsorship_amount|default:"—" }}</td>
                   </tr>
                 {% endif %}
-                {% if not proposal.fest_fee_participants and
-                      not proposal.fest_fee_rate and
-                      not proposal.fest_fee_amount and
-                      not proposal.fest_sponsorship_amount and
-                      not proposal.conf_fee_participants and
-                      not proposal.conf_fee_rate and
-                      not proposal.conf_fee_amount and
-                      not proposal.conf_sponsorship_amount %}
+                {% if proposal.fest_fee_participants or proposal.fest_fee_rate or proposal.fest_fee_amount or proposal.fest_sponsorship_amount or proposal.conf_fee_participants or proposal.conf_fee_rate or proposal.conf_fee_amount or proposal.conf_sponsorship_amount %}
+                {% else %}
                   <tr>
                     <td colspan="5">—</td>
                   </tr>


### PR DESCRIPTION
## Summary
- avoid multiline `{% if %}` in review approval income table
- show placeholder row when no income-related fields provided

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL at yamanote.proxy.rlwy.net is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9879ddac832c873f9e0e181765ca