### PR TITLE
Separate student and faculty attendance display

### DIFF
--- a/emt/static/emt/js/attendance.js
+++ b/emt/static/emt/js/attendance.js
@@ -2,6 +2,8 @@ document.addEventListener('DOMContentLoaded', function () {
     let rows = initialRows || [];
     const perPage = 100;
     let currentPage = 1;
+    let studentsGrouped = initialStudents || {};
+    let facultyGrouped = initialFaculty || {};
 
     const tableBody = document.querySelector('#attendance-table tbody');
     const totalEl = document.getElementById('total-count');
@@ -9,6 +11,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const absentEl = document.getElementById('absent-count');
     const volunteerEl = document.getElementById('volunteer-count');
     const loadingEl = document.getElementById('loading');
+    const studentsGroupEl = document.getElementById('students-group');
+    const facultyGroupEl = document.getElementById('faculty-group');
 
     function renderTable() {
         tableBody.innerHTML = '';
@@ -37,6 +41,40 @@ document.addEventListener('DOMContentLoaded', function () {
         presentEl.textContent = present;
         absentEl.textContent = absent;
         volunteerEl.textContent = volunteers;
+    }
+
+    function renderGroups() {
+        studentsGroupEl.innerHTML = '';
+        Object.keys(studentsGrouped).forEach(cls => {
+            const div = document.createElement('div');
+            const h = document.createElement('h4');
+            h.textContent = cls;
+            div.appendChild(h);
+            const ul = document.createElement('ul');
+            studentsGrouped[cls].forEach(name => {
+                const li = document.createElement('li');
+                li.textContent = name;
+                ul.appendChild(li);
+            });
+            div.appendChild(ul);
+            studentsGroupEl.appendChild(div);
+        });
+
+        facultyGroupEl.innerHTML = '';
+        Object.keys(facultyGrouped).forEach(org => {
+            const div = document.createElement('div');
+            const h = document.createElement('h4');
+            h.textContent = org;
+            div.appendChild(h);
+            const ul = document.createElement('ul');
+            facultyGrouped[org].forEach(name => {
+                const li = document.createElement('li');
+                li.textContent = name;
+                ul.appendChild(li);
+            });
+            div.appendChild(ul);
+            facultyGroupEl.appendChild(div);
+        });
     }
 
     tableBody.addEventListener('change', function (e) {
@@ -113,7 +151,10 @@ document.addEventListener('DOMContentLoaded', function () {
             .then(r => r.json())
             .then(data => {
                 rows = data.rows || [];
+                studentsGrouped = data.students || {};
+                facultyGrouped = data.faculty || {};
                 renderTable();
+                renderGroups();
             })
             .finally(() => {
                 loadingEl.style.display = 'none';
@@ -125,5 +166,6 @@ document.addEventListener('DOMContentLoaded', function () {
         fetchRows();
     } else {
         renderTable();
+        renderGroups();
     }
 });

--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -43,6 +43,13 @@
         <tbody></tbody>
     </table>
 
+    <div id="grouped-sections" class="mt-4">
+        <h2>Students (Class-wise)</h2>
+        <div id="students-group"></div>
+        <h2 class="mt-3">Faculty (Organization-wise)</h2>
+        <div id="faculty-group"></div>
+    </div>
+
     <div class="actions">
         <button id="save-event-report" class="btn btn-primary">Save to Event Report</button>
         <button id="download-csv" class="btn btn-secondary">Download CSV</button>
@@ -56,6 +63,8 @@
     const dataUrl = "{% url 'emt:attendance_data' report.id %}";
     const downloadFilename = "student_audience_{{ report.id }}.csv";
     const csrftoken = '{{ csrf_token }}';
+    const initialStudents = {{ students_group_json|default:'{}'|safe }};
+    const initialFaculty = {{ faculty_group_json|default:'{}'|safe }};
 </script>
 <script src="{% static 'emt/js/attendance.js' %}"></script>
 {% endblock %}

--- a/emt/tests/test_attendance_data_view.py
+++ b/emt/tests/test_attendance_data_view.py
@@ -14,6 +14,10 @@ class AttendanceDataViewTests(TestCase):
             submitted_by=self.user, event_title="Sample"
         )
         self.report = EventReport.objects.create(proposal=proposal)
+        bob_user = User.objects.create_user("bobuser", password="pass", first_name="Bob")
+        eve_user = User.objects.create_user("eveuser", password="pass", first_name="Eve")
+        Student.objects.create(user=bob_user, registration_number="R1")
+        Student.objects.create(user=eve_user, registration_number="R2")
         AttendanceRow.objects.create(
             event_report=self.report,
             registration_no="R1",
@@ -39,6 +43,9 @@ class AttendanceDataViewTests(TestCase):
         self.assertEqual(len(data["rows"]), 2)
         self.assertEqual(data["counts"]["absent"], 1)
         self.assertEqual(data["counts"]["volunteers"], 1)
+        self.assertIn("CSE", data["students"])
+        self.assertListEqual(sorted(data["students"]["CSE"]), ["Bob", "Eve"])
+        self.assertEqual(data["faculty"], {})
 
     def test_returns_target_audience_when_no_rows(self):
         proposal = EventProposal.objects.create(
@@ -68,4 +75,6 @@ class AttendanceDataViewTests(TestCase):
         self.assertEqual(rows_by_name["Carol"]["registration_no"], "R2")
         self.assertEqual(data["counts"]["total"], 2)
         self.assertEqual(data["counts"]["present"], 2)
+        self.assertIn("CSE", data["students"])
+        self.assertListEqual(sorted(data["students"]["CSE"]), ["Bob", "Carol"])
 


### PR DESCRIPTION
## Summary
- Group attendance rows into students by class and faculty by organization
- Expose grouped data in upload view and JSON API
- Render grouped lists on the attendance upload page and expand tests

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9da39efc832c92419d03f672f39a