### PR TITLE
Handle missing report for attendance CSV link

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -204,7 +204,11 @@
                                 <label for="attendance-modern">Attendance *</label>
                                 <input type="text" id="attendance-modern" readonly value="Present: {{ attendance_present }}, Absent: {{ attendance_absent }}, Volunteers: {{ attendance_volunteers }}">
                                 <input type="hidden" id="num-participants-modern" name="num_participants" value="{{ attendance_present }}">
+                                {% if report %}
                                 <div class="help-text"><a href="{% url 'emt:attendance_upload' report.id %}">Manage via CSV</a></div>
+                                {% else %}
+                                <div class="help-text">Save report to manage attendance via CSV</div>
+                                {% endif %}
                                 {% if form.num_participants.errors %}
                                     <div class="field-error">{{ form.num_participants.errors.0 }}</div>
                                 {% endif %}

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -109,6 +109,22 @@ class SubmitEventReportViewTests(TestCase):
             html=False,
         )
 
+    def test_attendance_link_requires_report(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Manage via CSV", html=False)
+
+        report = EventReport.objects.create(proposal=self.proposal)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Manage via CSV", html=False)
+        self.assertContains(
+            response,
+            reverse("emt:attendance_upload", args=[report.id]),
+            html=False,
+        )
+
     def test_autosave_indicator_present(self):
         response = self.client.get(
             reverse("emt:submit_event_report", args=[self.proposal.id])


### PR DESCRIPTION
## Summary
- avoid NoReverseMatch by only showing the attendance upload link when a report exists
- test that CSV link appears only after report creation

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test` *(fails: `'sslmode' is an invalid keyword argument for Connection()`)*
- `pre-commit run --files emt/templates/emt/submit_event_report.html emt/tests/test_event_report_view.py` *(fails: `.pre-commit-config.yaml is not a file`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9fadcd2c832caaddabffd3c844e1