### PR TITLE
Handle autosave detail on direct events

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1978,7 +1978,7 @@ function initializeAutosaveIndicators() {
             indicator.removeClass('show');
         }, 2000);
 
-        const reportId = e.originalEvent && e.originalEvent.detail && e.originalEvent.detail.reportId;
+        const reportId = e.originalEvent?.detail?.reportId || e.detail?.reportId;
         if (reportId) {
             const attendanceUrl = `${window.ATTENDANCE_URL_BASE}${reportId}/attendance/upload/`;
             $('#attendance-modern')


### PR DESCRIPTION
## Summary
- Update autosave indicator listener to read `reportId` from both `e.originalEvent.detail` and `e.detail`
- Add regression test that dispatches `autosave:success` via jQuery-style trigger and confirms the attendance link updates

## Testing
- `python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests.test_attendance_link_updates_after_autosave -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aea5e62b38832c95caec105e2a72b0