### PR TITLE
Handle autosave data param for attendance link

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1970,7 +1970,7 @@ function initializeAutosaveIndicators() {
         indicator.find('.indicator-text').text('Saving...');
     });
 
-    $(document).on('autosave:success', function(e) {
+    $(document).on('autosave:success', function(e, data) {
         const indicator = $('#autosave-indicator');
         indicator.removeClass('saving error').addClass('saved');
         indicator.find('.indicator-text').text('Saved');
@@ -1978,7 +1978,7 @@ function initializeAutosaveIndicators() {
             indicator.removeClass('show');
         }, 2000);
 
-        const reportId = e.originalEvent?.detail?.reportId || e.detail?.reportId;
+        const reportId = data?.reportId || e.originalEvent?.detail?.reportId || e.detail?.reportId;
         if (reportId) {
             const attendanceUrl = `${window.ATTENDANCE_URL_BASE}${reportId}/attendance/upload/`;
             $('#attendance-modern')

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -150,7 +150,7 @@ class SubmitEventReportViewTests(TestCase):
         base_url = reverse("emt:attendance_upload", args=[0]).rsplit("0/", 1)[0]
 
         # Run a tiny Node script that loads initializeAutosaveIndicators, dispatches
-        # autosave:success via $(document).trigger, and prints the updated link.
+        # autosave:success via $(document).trigger and prints the updated link.
         import tempfile
         import subprocess
         from pathlib import Path
@@ -170,7 +170,7 @@ const initCode = extract('initializeAutosaveIndicators');
 const handlers={};
 const document={};
 function $(sel){
- if(sel===document) return {on:(ev,fn)=>{(handlers[ev]=handlers[ev]||[]).push(fn);}, trigger:(ev)=>{(handlers[ev.type]||[]).forEach(fn=>fn(ev));}, off:()=>{}};
+ if(sel===document) return {on:(ev,fn)=>{(handlers[ev]=handlers[ev]||[]).push(fn);}, trigger:(ev,data)=>{(handlers[ev]||[]).forEach(fn=>fn({type:ev}, data));}, off:()=>{}};
  if(sel==='#attendance-modern') return attendanceEl;
  if(sel==='#autosave-indicator') return indicatorEl;
 }
@@ -180,8 +180,7 @@ function setupAttendanceLink(){}
 const window={ATTENDANCE_URL_BASE:'__BASE_URL__'};
 eval(initCode);
 initializeAutosaveIndicators();
-const event={type:'autosave:success', detail:{reportId:__REPORT_ID__}};
-$(document).trigger(event);
+$(document).trigger('autosave:success', {reportId:__REPORT_ID__});
 console.log(attendanceEl.attrs['data-attendance-url']);
 '''
         node_script = node_script.replace('__SUBMIT_JS__', str(submit_js)).replace('__BASE_URL__', base_url).replace('__REPORT_ID__', str(report_id))


### PR DESCRIPTION
## Summary
- Update autosave success handler to accept extra data and update attendance link accordingly
- Adjust test to trigger autosave with data payload and verify attendance link

## Testing
- `python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests.test_attendance_link_updates_after_autosave -v 2` *(failed: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaac45a48832c803599fcf3808161