### PR TITLE
Fix attendance upload save flow

### DIFF
--- a/emt/static/emt/js/attendance.js
+++ b/emt/static/emt/js/attendance.js
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 })
                 .then(r => r.json())
                 .then(() => {
-                    alert('Saved');
+                    window.location.href = reportUrl;
                 })
                 .catch(() => alert('Failed to save attendance.'));
             }

--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -61,6 +61,7 @@
     const saveUrl = "{% url 'emt:attendance_save' report.id %}";
     const downloadUrl = "{% url 'emt:attendance_download' report.id %}";
     const dataUrl = "{% url 'emt:attendance_data' report.id %}";
+    const reportUrl = "{% url 'emt:submit_event_report' report.proposal.id %}";
     const downloadFilename = "student_audience_{{ report.id }}.csv";
     const csrftoken = '{{ csrf_token }}';
     const initialStudents = {{ students_group_json|default:'{}'|safe }};


### PR DESCRIPTION
## Summary
- redirect users back to the event report after saving attendance
- expose event report URL to attendance upload script

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b06ceef7c0832cbd36a3ed643e38de