### PR TITLE
Refactor attendance page display

### DIFF
--- a/emt/static/emt/js/attendance.js
+++ b/emt/static/emt/js/attendance.js
@@ -6,6 +6,12 @@ document.addEventListener('DOMContentLoaded', function () {
     let facultyGrouped = initialFaculty || {};
 
     const tableBody = document.querySelector('#attendance-table tbody');
+    const summaryEl = document.getElementById('summary');
+    const tableEl = document.getElementById('attendance-table');
+    const groupedSectionsEl = document.getElementById('grouped-sections');
+    const actionsEl = document.getElementById('actions');
+    const studentsSectionTitle = document.getElementById('students-section-title');
+    const facultySectionTitle = document.getElementById('faculty-section-title');
     const totalEl = document.getElementById('total-count');
     const presentEl = document.getElementById('present-count');
     const absentEl = document.getElementById('absent-count');
@@ -13,6 +19,22 @@ document.addEventListener('DOMContentLoaded', function () {
     const loadingEl = document.getElementById('loading');
     const studentsGroupEl = document.getElementById('students-group');
     const facultyGroupEl = document.getElementById('faculty-group');
+
+    function updateVisibility() {
+        const hasRows = rows.length > 0;
+        summaryEl.classList.toggle('d-none', !hasRows);
+        tableEl.classList.toggle('d-none', !hasRows);
+        actionsEl.classList.toggle('d-none', !hasRows);
+
+        const studentKeys = Object.keys(studentsGrouped || {});
+        const facultyKeys = Object.keys(facultyGrouped || {});
+        const hasStudentGroups = studentKeys.length > 0;
+        const hasFacultyGroups = facultyKeys.length > 0;
+
+        studentsSectionTitle.style.display = hasStudentGroups ? '' : 'none';
+        facultySectionTitle.style.display = hasFacultyGroups ? '' : 'none';
+        groupedSectionsEl.classList.toggle('d-none', !hasStudentGroups && !hasFacultyGroups);
+    }
 
     function renderTable() {
         tableBody.innerHTML = '';
@@ -30,6 +52,7 @@ document.addEventListener('DOMContentLoaded', function () {
             tableBody.appendChild(tr);
         });
         updateCounts();
+        updateVisibility();
     }
 
     function updateCounts() {
@@ -75,6 +98,7 @@ document.addEventListener('DOMContentLoaded', function () {
             div.appendChild(ul);
             facultyGroupEl.appendChild(div);
         });
+        updateVisibility();
     }
 
     tableBody.addEventListener('change', function (e) {

--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -21,7 +21,7 @@
         <button type="submit" class="btn btn-primary">Upload</button>
     </form>
 
-    <div id="summary" class="summary">
+    <div id="summary" class="summary d-none">
         <span>Total: <span id="total-count">{{ counts.total }}</span></span>
         <span>Present: <span id="present-count">{{ counts.present }}</span></span>
         <span>Absent: <span id="absent-count">{{ counts.absent }}</span></span>
@@ -30,7 +30,7 @@
 
     <div id="loading" class="loading">Loading...</div>
 
-    <table id="attendance-table" class="table table-sm mt-3">
+    <table id="attendance-table" class="table table-sm mt-3 d-none">
         <thead>
             <tr>
                 <th>Registration No</th>
@@ -43,14 +43,14 @@
         <tbody></tbody>
     </table>
 
-    <div id="grouped-sections" class="mt-4">
-        <h2>Students (Class-wise)</h2>
+    <div id="grouped-sections" class="mt-4 d-none">
+        <h2 id="students-section-title">Students (Class-wise)</h2>
         <div id="students-group"></div>
-        <h2 class="mt-3">Faculty (Organization-wise)</h2>
+        <h2 id="faculty-section-title" class="mt-3">Faculty (Organization-wise)</h2>
         <div id="faculty-group"></div>
     </div>
 
-    <div class="actions">
+    <div id="actions" class="actions d-none">
         <button id="save-event-report" class="btn btn-primary">Save to Event Report</button>
         <button id="download-csv" class="btn btn-secondary">Download CSV</button>
     </div>


### PR DESCRIPTION
## Summary
- hide summary, grouped sections, and action buttons until attendance data is present
- dynamically reveal group headings when student or faculty data exists

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b071001e34832ca9a430b518bfeaf5