### PR TITLE
Redirect attendance save to report form

### DIFF
--- a/emt/static/emt/js/attendance.js
+++ b/emt/static/emt/js/attendance.js
@@ -118,9 +118,12 @@ document.addEventListener('DOMContentLoaded', function () {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
             body: JSON.stringify({ rows: rows })
-        }).then(r => r.json()).then(() => {
-            alert('Saved');
-        });
+        })
+        .then(r => r.json())
+        .then(() => {
+            window.location.href = reportUrl;
+        })
+        .catch(() => alert('Failed to save attendance.'));
     });
 
     // Allow the top "Upload" button to save when no CSV is selected.

--- a/emt/tests/test_attendance_save.py
+++ b/emt/tests/test_attendance_save.py
@@ -1,0 +1,68 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.db.models.signals import post_save
+from django.contrib.auth.signals import user_logged_in
+import json
+
+from core.signals import create_or_update_user_profile, assign_role_on_login
+from emt.models import EventProposal, EventReport
+
+
+class SaveAttendanceRowsTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client.force_login(self.user)
+        self.proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Sample Event",
+        )
+        self.report = EventReport.objects.create(proposal=self.proposal)
+
+    def test_save_attendance_updates_report(self):
+        url = reverse("emt:attendance_save", args=[self.report.id])
+        rows = [
+            {
+                "registration_no": "R1",
+                "full_name": "Bob",
+                "student_class": "CSE",
+                "absent": False,
+                "volunteer": True,
+            },
+            {
+                "registration_no": "R2",
+                "full_name": "Carol",
+                "student_class": "ECE",
+                "absent": True,
+                "volunteer": False,
+            },
+        ]
+        response = self.client.post(
+            url,
+            data=json.dumps({"rows": rows}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.num_participants, 1)
+        self.assertEqual(self.report.num_student_volunteers, 1)
+        saved = list(
+            self.report.attendance_rows.order_by("registration_no").values(
+                "registration_no", "absent", "volunteer"
+            )
+        )
+        self.assertEqual(len(saved), 2)
+        self.assertTrue(saved[0]["volunteer"])
+        self.assertTrue(saved[1]["absent"])


### PR DESCRIPTION
## Summary
- Redirect Save to Event Report button to the event report form after persisting attendance
- Add regression test ensuring attendance rows persist counts on the report

## Testing
- `python manage.py test` *(fails: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68b0744c46c0832c84ee3d665c571326