### PR TITLE
Allow impersonation of inactive users

### DIFF
--- a/core/tests/test_impersonation.py
+++ b/core/tests/test_impersonation.py
@@ -34,3 +34,10 @@ class ImpersonationTests(TestCase):
         self.client.get(reverse('stop_impersonation'))
         log.refresh_from_db()
         self.assertIsNotNone(log.ended_at)
+
+    def test_impersonate_inactive_user(self):
+        """Inactive users should still be impersonatable without 404."""
+        inactive = User.objects.create_user('bob', 'bob@example.com', 'pass', is_active=False)
+        response = self.client.get(reverse('admin_impersonate_user', args=[inactive.id]))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.client.session['impersonate_user_id'], inactive.id)

--- a/core/views.py
+++ b/core/views.py
@@ -4832,7 +4832,12 @@ def stop_impersonation(request):
 @user_passes_test(is_admin)
 def admin_impersonate_user(request, user_id):
     """Start impersonating a user from admin pages."""
-    target_user = get_object_or_404(User, id=user_id, is_active=True)
+    # Allow impersonation of any existing user regardless of ``is_active`` status.
+    # Previously we restricted to ``is_active=True`` which resulted in a 404
+    # when attempting to impersonate inactive users from the user management
+    # page. By removing that filter the view will locate the user record and
+    # proceed with impersonation.
+    target_user = get_object_or_404(User, id=user_id)
     request.session['impersonate_user_id'] = target_user.id
     request.session['original_user_id'] = request.user.id
 


### PR DESCRIPTION
## Summary
- Permit admins to impersonate users even if their accounts are inactive
- Add regression test ensuring inactive users can be impersonated without 404s

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0770a78b0832c9d7f758f59e2e5d4