### PR TITLE
fix: show speakers from available data

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1424,9 +1424,14 @@ function populateSpeakersFromProposal() {
         return;
     }
 
-    const speakers = (window.PROPOSAL_DATA && window.PROPOSAL_DATA.speakers) || window.EXISTING_SPEAKERS || [];
+    let speakers = [];
+    if (window.PROPOSAL_DATA && Array.isArray(window.PROPOSAL_DATA.speakers) && window.PROPOSAL_DATA.speakers.length) {
+        speakers = window.PROPOSAL_DATA.speakers;
+    } else if (Array.isArray(window.EXISTING_SPEAKERS) && window.EXISTING_SPEAKERS.length) {
+        speakers = window.EXISTING_SPEAKERS;
+    }
     console.log('Speakers data:', speakers);
-    
+
     if (!speakers.length) {
         container.innerHTML = '<div class="no-speakers-message">No speakers were defined in the original proposal</div>';
         return;


### PR DESCRIPTION
## Summary
- ensure event report displays speaker names by preferring any available speaker data

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d99920c8832ca137889745ae4835