### PR TITLE
Fix autosave mapping for proposal text sections

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -49,6 +49,11 @@ window.AutosaveManager = (function() {
                 data[name] = value;
             }
         });
+
+        // Map generic 'content' field to a specific section if configured.
+        if (data.content !== undefined && window.AUTOSAVE_SECTION) {
+            data[window.AUTOSAVE_SECTION] = data.content;
+        }
         return data;
     }
 

--- a/emt/templates/emt/need_analysis.html
+++ b/emt/templates/emt/need_analysis.html
@@ -41,6 +41,7 @@
     window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
     window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}"; // Update if you have a specific endpoint!
     window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+    window.AUTOSAVE_SECTION = 'need_analysis';
     const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
     const aiBtn = document.getElementById('generate-ai-btn');
     const aiErr = document.getElementById('ai-error');

--- a/emt/templates/emt/objectives.html
+++ b/emt/templates/emt/objectives.html
@@ -37,6 +37,7 @@
     window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
     window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
     window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+    window.AUTOSAVE_SECTION = 'objectives';
   </script>
   <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
 {% endblock %}

--- a/emt/templates/emt/submit_expected_outcomes.html
+++ b/emt/templates/emt/submit_expected_outcomes.html
@@ -37,6 +37,7 @@
     window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
     window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
     window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+    window.AUTOSAVE_SECTION = 'outcomes';
   </script>
   <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
 {% endblock %}

--- a/emt/templates/emt/tentative_flow.html
+++ b/emt/templates/emt/tentative_flow.html
@@ -49,6 +49,7 @@
     window.PROPOSAL_ID = "{{ proposal.id|default:'' }}";
     window.AUTOSAVE_URL = "{% url 'emt:autosave_proposal' %}";
     window.AUTOSAVE_CSRF = "{{ csrf_token }}";
+    window.AUTOSAVE_SECTION = 'flow';
   </script>
   <script src="{% static 'emt/js/tentative_flow.js' %}"></script>
   <script src="{% static 'emt/js/autosave_draft.js' %}"></script>


### PR DESCRIPTION
## Summary
- Link generic content fields to specific proposal sections during autosave
- Configure Need Analysis, Objectives, Expected Outcomes, and Tentative Flow pages to declare their autosave section key

## Testing
- `python manage.py test emt.tests.test_proposal_review.ProposalReviewFlowTests.test_review_displays_all_sections -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dbddf2d4832c9a407b2fb393a94e