### PR TITLE
Allow text-only autosave for proposals

### DIFF
--- a/emt/tests/test_proposal_review.py
+++ b/emt/tests/test_proposal_review.py
@@ -42,6 +42,7 @@ class ProposalReviewFlowTests(TestCase):
             "organization_type": str(self.ot.id),
             "organization": str(self.org.id),
             "academic_year": "2024-2025",
+            "event_title": "Test Event",
         }
 
     def test_review_and_final_submit_flow(self):

--- a/emt/views.py
+++ b/emt/views.py
@@ -593,6 +593,15 @@ def autosave_proposal(request):
                 {"success": False, "error": "Cannot modify submitted proposal"}
             )
 
+    # If payload only has text sections, skip full form validation
+    text_keys = {"need_analysis", "objectives", "outcomes", "flow"}
+    if proposal and set(data.keys()).issubset(text_keys | {"proposal_id"}):
+        text_errors = _save_text_sections(proposal, data)
+        if text_errors:
+            logger.debug("autosave_proposal text errors: %s", text_errors)
+            return JsonResponse({"success": False, "errors": text_errors})
+        return JsonResponse({"success": True, "proposal_id": proposal.id})
+
     form = EventProposalForm(data, instance=proposal, user=request.user)
     faculty_ids = data.get("faculty_incharges") or []
     if faculty_ids:


### PR DESCRIPTION
## Summary
- Skip full EventProposalForm validation when autosave payload only includes text sections
- Persist text sections directly and return errors from `_save_text_sections`
- Cover text-section autosave path with new tests and ensure event titles in test payloads

## Testing
- `python manage.py test` *(fails: TemplateDoesNotExist: core/user_dashboard.html)*
- `DATABASE_URL=sqlite://:memory: python manage.py test emt.tests.test_existing.AutosaveProposalTests.test_autosave_and_submit_retains_faculty -v 2`
- `DATABASE_URL=sqlite://:memory: python manage.py test emt.tests.test_existing.AutosaveProposalTests.test_autosave_text_sections_only -v 2`
- `DATABASE_URL=sqlite://:memory: python manage.py test emt.tests.test_existing.AutosaveProposalTests.test_autosave_text_sections_only_errors -v 2`
- `DATABASE_URL=sqlite://:memory: python manage.py test emt.tests.test_proposal_review.ProposalReviewFlowTests.test_review_and_final_submit_flow -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b0e06ed628832c8710b28085e0cfca