### PR TITLE
Auto-populate participants information from proposal data

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -454,6 +454,8 @@ $(document).on('click', '#ai-sdg-implementation', function(){
       if (sectionName === 'participants-information') {
           populateSpeakersFromProposal();
           fillOrganizingCommittee();
+          fillActualSpeakers();
+          fillAttendanceCounts();
       }
 
       if (sectionName === 'event-relevance') {
@@ -1399,11 +1401,43 @@ function fillOrganizingCommittee() {
     }
 }
 
+function fillActualSpeakers() {
+    const field = $('#actual-speakers-modern');
+    if (
+        field.length &&
+        field.val().trim() === '' &&
+        window.PROPOSAL_DATA &&
+        Array.isArray(window.PROPOSAL_DATA.speakers) &&
+        window.PROPOSAL_DATA.speakers.length
+    ) {
+        const lines = window.PROPOSAL_DATA.speakers.map((sp, idx) => {
+            const name = sp.full_name || sp.name || '';
+            const designation = sp.designation ? ` - ${sp.designation}` : '';
+            const org = sp.organization || sp.affiliation ? ` - ${(sp.organization || sp.affiliation)}` : '';
+            return `• ${name}${designation}${org}`;
+        });
+        field.val(lines.join('\n'));
+    }
+}
+
+function fillAttendanceCounts() {
+    const totalField = $('#total-participants-modern');
+    if (
+        totalField.length &&
+        totalField.val().trim() === '' &&
+        typeof window.ATTENDANCE_PRESENT !== 'undefined'
+    ) {
+        totalField.val(window.ATTENDANCE_PRESENT);
+    }
+}
+
 function populateProposalData() {
     // Initial fill if fields exist
     setTimeout(function() {
         fillEventRelevance();
         fillOrganizingCommittee();
+        fillActualSpeakers();
+        fillAttendanceCounts();
     }, 100);
 
     // Populate when sections become active
@@ -1411,7 +1445,11 @@ function populateProposalData() {
         setTimeout(fillEventRelevance, 100);
     });
     $(document).on('click', '[data-section="participants-information"]', function() {
-        setTimeout(fillOrganizingCommittee, 100);
+        setTimeout(function() {
+            fillOrganizingCommittee();
+            fillActualSpeakers();
+            fillAttendanceCounts();
+        }, 100);
     });
 }
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -355,6 +355,9 @@
         window.SDG_GOALS = {{ sdg_goals_list|default:'[]'|safe }};
         window.PROPOSAL_ACTIVITIES = {{ proposal_activities_json|safe }};
         window.EXISTING_SPEAKERS = {{ speakers_json|default:'[]'|safe }};
+        window.ATTENDANCE_PRESENT = {{ attendance_present|default:0 }};
+        window.ATTENDANCE_ABSENT = {{ attendance_absent|default:0 }};
+        window.ATTENDANCE_VOLUNTEERS = {{ attendance_volunteers|default:0 }};
         window.PROPOSAL_DATA = {
             department: "{{ proposal.organization.name|default:'' }}",
             venue: "{{ proposal.venue|default:'' }}",


### PR DESCRIPTION
## Summary
- Add attendance counts and proposal data globals for easier prefill
- Prefill organizing committee, speakers, and participant totals from proposal and attendance data

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e551e75c832c8f7a58bb2c481bf1