### PR TITLE
Fix proposal speaker autofill timing

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -452,10 +452,13 @@ $(document).on('click', '#ai-sdg-implementation', function(){
       $('.form-grid').html(content);
 
       if (sectionName === 'participants-information') {
-          populateSpeakersFromProposal();
-          fillOrganizingCommittee();
-          fillActualSpeakers();
-          fillAttendanceCounts();
+          // Defer population until after the new DOM elements are attached
+          setTimeout(() => {
+              populateSpeakersFromProposal();
+              fillOrganizingCommittee();
+              fillActualSpeakers();
+              fillAttendanceCounts();
+          }, 0);
       }
 
       if (sectionName === 'event-relevance') {


### PR DESCRIPTION
## Summary
- defer participants section autofill until DOM elements exist
- add regression test verifying proposal speakers prefill fields

## Testing
- `python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests.test_proposal_speakers_prefilled -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e85d4594832cbbd2ad21f0170ec9