### PR TITLE
Defer participants section fill until DOM ready

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -453,12 +453,17 @@ $(document).on('click', '#ai-sdg-implementation', function(){
 
       if (sectionName === 'participants-information') {
           // Defer population until after the new DOM elements are attached
-          setTimeout(() => {
+          const initParticipantsSection = () => {
               populateSpeakersFromProposal();
               fillOrganizingCommittee();
               fillActualSpeakers();
               fillAttendanceCounts();
-          }, 0);
+          };
+          if (document.readyState === 'loading') {
+              $(initParticipantsSection);
+          } else {
+              setTimeout(initParticipantsSection, 0);
+          }
       }
 
       if (sectionName === 'event-relevance') {

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -317,6 +317,7 @@ console.log(attendanceEl.attrs['href']);
             "volunteers": ["Dan"],
             "speakers": [{"full_name": "Dr. Xavier", "organization": "Uni"}],
         }
+        existing_speakers = [{"full_name": "Dr. Xavier", "organization": "Uni"}]
         node_script = r"""
 const fs = require('fs');
 const src = fs.readFileSync('__SUBMIT_JS__', 'utf8');
@@ -353,8 +354,15 @@ function $(sel){
 }
 
 global.$ = $;
-global.document = {getElementById: id => (domReady && id === 'speakers-display') ? speakersDisplay : null};
-global.window = {PROPOSAL_DATA: __PROPOSAL_DATA__, ATTENDANCE_PRESENT: 10};
+global.document = {
+  readyState: 'complete',
+  getElementById: id => (domReady && id === 'speakers-display') ? speakersDisplay : null
+};
+global.window = {
+  PROPOSAL_DATA: __PROPOSAL_DATA__,
+  EXISTING_SPEAKERS: __EXISTING_SPEAKERS__,
+  ATTENDANCE_PRESENT: 10
+};
 
 eval(populateSpeakersFromProposal);
 eval(fillOrganizingCommittee);
@@ -376,6 +384,7 @@ setTimeout(()=>{
         node_script = (
             node_script.replace("__SUBMIT_JS__", str(submit_js))
             .replace("__PROPOSAL_DATA__", json.dumps(proposal_data))
+            .replace("__EXISTING_SPEAKERS__", json.dumps(existing_speakers))
         )
         with tempfile.TemporaryDirectory() as tmp:
             script_path = Path(tmp) / "run.js"


### PR DESCRIPTION
## Summary
- Ensure participants info fills after DOM insertion by deferring speaker/committee population in `loadSectionContent`
- Extend regression test to include existing speakers and DOM-ready logic

## Testing
- `node - <<'NODE' ... NODE`
- `python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests.test_proposal_speakers_prefilled -v 2` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests.test_proposal_speakers_prefilled -v 2` *(fails: TypeError: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68b0eeec3920832cbc80ebd121e74750