### PR TITLE
Ensure all fields display in event report preview

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -324,6 +324,11 @@ class EventReportForm(forms.ModelForm):
             'attendance_notes': forms.Textarea(attrs={'class': 'ultra-input', 'rows': 2}),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.required = True
+
 class EventReportAttachmentForm(forms.ModelForm):
     class Meta:
         model = EventReportAttachment

--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -29,10 +29,8 @@
             </ol>
             <h3>Event Report Details</h3>
             <ol class="report-preview-list">
-                {% for field in form.visible_fields %}
-                    {% with values=form.data|get_list:field.name %}
-                        <li><strong>{{ field.label }}:</strong> {{ values|join:", "|default:"—" }}</li>
-                    {% endwith %}
+                {% for label, value in report_fields %}
+                    <li><strong>{{ label }}:</strong> {{ value }}</li>
                 {% endfor %}
             </ol>
             <button type="submit" name="final_submit" class="btn-submit">Submit Report</button>


### PR DESCRIPTION
## Summary
- Show every field from proposal and report forms in the review page
- Make all event report form fields required for submission

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d8f7f60832c9ec8771d0824fd87