### PR TITLE
Fix preview to show all proposal data

### DIFF
--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -286,6 +286,22 @@ console.log(attendanceEl.attrs['href']);
                 response, f"<strong>{field.label}:</strong>", html=False
             )
 
+    def test_preview_shows_faculty_incharges(self):
+        fac = User.objects.create_user(username="facultya")
+        self.proposal.faculty_incharges.add(fac)
+        url = reverse("emt:preview_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Seminar",
+            "report_signed_date": "2024-01-10",
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "facultya")
+
     def test_proposal_speakers_prefilled(self):
         SpeakerProfile.objects.create(
             proposal=self.proposal,

--- a/emt/views.py
+++ b/emt/views.py
@@ -2096,10 +2096,26 @@ def preview_event_report(request, proposal_id):
         raw_value = bound_field.value()
         field_def = bound_field.field
         if isinstance(field_def, forms.ModelMultipleChoiceField):
-            objs = field_def.queryset.filter(pk__in=raw_value) if raw_value else []
+            if raw_value:
+                if field_def.queryset.exists():
+                    objs = field_def.queryset.filter(pk__in=raw_value)
+                elif hasattr(proposal, name):
+                    objs = getattr(proposal, name).all()
+                else:
+                    objs = []
+            else:
+                objs = []
             display = ", ".join(str(obj) for obj in objs) or "—"
         elif isinstance(field_def, forms.ModelChoiceField):
-            obj = field_def.queryset.filter(pk=raw_value).first()
+            if raw_value:
+                if field_def.queryset.exists():
+                    obj = field_def.queryset.filter(pk=raw_value).first()
+                elif hasattr(proposal, name):
+                    obj = getattr(proposal, name)
+                else:
+                    obj = None
+            else:
+                obj = None
             display = str(obj) if obj else "—"
         else:
             display = raw_value or "—"


### PR DESCRIPTION
## Summary
- Ensure preview falls back to model data when form fields have empty querysets
- Cover faculty incharge display with new test

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1794ea808832ca6dc654f02e53c52