### PR TITLE
Default academic year for proposals

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -73,7 +73,7 @@ class EventProposalForm(forms.ModelForm):
     )
 
     def __init__(self, *args, **kwargs):
-        selected_academic_year = kwargs.pop('selected_academic_year', None)
+        self.selected_academic_year = kwargs.pop('selected_academic_year', None)
         user = kwargs.pop('user', None)
         super().__init__(*args, **kwargs)
 
@@ -118,9 +118,9 @@ class EventProposalForm(forms.ModelForm):
             self.fields['organization'].queryset = Organization.objects.filter(is_active=True)
 
         # Academic year setup
-        if selected_academic_year and not self.instance.pk:
-            self.fields['academic_year'].initial = selected_academic_year
-            self.fields['academic_year'].widget.attrs['value'] = selected_academic_year
+        if self.selected_academic_year and not self.instance.pk:
+            self.fields['academic_year'].initial = self.selected_academic_year
+            self.fields['academic_year'].widget.attrs['value'] = self.selected_academic_year
         elif not self.instance.pk:
             self.fields['academic_year'].widget.attrs['placeholder'] = 'No academic year set by admin'
 
@@ -166,6 +166,14 @@ class EventProposalForm(forms.ModelForm):
         elif org_type and organization and organization.org_type != org_type:
             self.add_error('organization', 'Selected organization does not match the chosen type.')
         return data
+
+    def clean_academic_year(self):
+        """Ensure academic year comes from admin settings, not user input."""
+        if self.instance and self.instance.pk:
+            return self.instance.academic_year
+        if self.selected_academic_year:
+            return self.selected_academic_year
+        raise forms.ValidationError("Academic year is not set by admin")
 
 # ──────────────────────────────────────────────────────────────
 #  Remaining forms (unchanged, but imports updated)

--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
+from django import forms
 
 from emt.models import (
     ApprovalStep,
@@ -941,3 +942,17 @@ class SDGGoalsFormTests(TestCase):
         names = list(form.fields["sdg_goals"].queryset.values_list("name", flat=True))
         self.assertEqual(set(names), set(SDG_GOALS))
         self.assertEqual(len(names), len(SDG_GOALS))
+
+
+class AcademicYearFormTests(TestCase):
+    def test_user_supplied_academic_year_is_ignored(self):
+        form = EventProposalForm(
+            data={"academic_year": "1999-2000"},
+            selected_academic_year="2024-2025",
+        )
+        self.assertEqual(form.clean_academic_year(), "2024-2025")
+
+    def test_missing_admin_year_raises_error(self):
+        form = EventProposalForm(data={"academic_year": "1999-2000"})
+        with self.assertRaises(forms.ValidationError):
+            form.clean_academic_year()

--- a/transcript/models.py
+++ b/transcript/models.py
@@ -45,22 +45,39 @@ IST = ZoneInfo("Asia/Kolkata")
 
 
 def get_active_academic_year():
-    """Return the currently active academic year, creating one if missing.
+    """Return the academic year covering the current date (in IST).
 
-    The active year is determined by the ``is_active`` flag. If none is set
-    active, a year covering the current date (based on IST) is created and
-    returned. This ensures all parts of the application reference a single
-    source of truth for the academic year.
+    If an admin‑configured year exists and matches the current date range it is
+    returned. Otherwise a new year is created (or activated) based on the
+    current Indian date. This ensures proposals always reference the correct
+    academic year without allowing users to modify it manually.
     """
-    ay = AcademicYear.objects.filter(is_active=True).order_by("-start_date").first()
-    if ay:
-        return ay
 
     now = timezone.now().astimezone(IST)
     start_year = now.year if now.month >= 6 else now.year - 1
     end_year = start_year + 1
     year_str = f"{start_year}-{end_year}"
-    ay, _ = AcademicYear.objects.get_or_create(year=year_str, defaults={"is_active": True})
+
+    ay = AcademicYear.objects.filter(is_active=True).order_by("-start_date").first()
+    if ay and ay.year == year_str:
+        return ay
+
+    if ay and ay.year != year_str:
+        ay.is_active = False
+        ay.save(update_fields=["is_active"])
+
+    ay, _ = AcademicYear.objects.get_or_create(
+        year=year_str,
+        defaults={
+            "is_active": True,
+            "start_date": now.date().replace(month=6, day=1),
+            "end_date": now.date().replace(year=end_year, month=5, day=31),
+        },
+    )
+    if not ay.is_active:
+        AcademicYear.objects.filter(is_active=True).update(is_active=False)
+        ay.is_active = True
+        ay.save(update_fields=["is_active"])
     return ay
 
 class School(models.Model):


### PR DESCRIPTION
## Summary
- Auto-derive active academic year using Indian timezone and activate new years as needed
- Lock academic year field in event proposal form to admin value and ignore user edits
- Add tests ensuring academic year cannot be overridden and missing admin setting is flagged

## Testing
- `python manage.py test` *(fails: connection to external PostgreSQL server is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ae3ac400832cab3ff8c48b60ee39