### PR TITLE
Enhance report preview layout with responsive field cards

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -3248,7 +3248,8 @@ textarea {
     border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 1.5rem;
-    margin-bottom: 2rem;
+    margin: 0 auto 2rem;
+    max-width: 1200px;
 }
 
 .report-section h3 {
@@ -3263,25 +3264,27 @@ textarea {
     list-style: none;
     padding: 0;
     margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1rem;
 }
 
-.report-preview-list li {
+.report-preview-list .field-item {
+    background: #f8fafc;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
     display: flex;
-    gap: 0.5rem;
-    padding: 0.5rem 0;
-    border-bottom: 1px solid var(--border-color);
-    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
-.report-preview-list li:last-child {
-    border-bottom: none;
+.report-preview-list .field-label {
+    font-weight: 600;
+    color: var(--primary-blue);
 }
 
-.report-preview-list strong {
-    min-width: 220px;
+.report-preview-list .field-value {
     color: var(--text-dark);
-}
-
-.report-preview-list span {
-    color: var(--text-muted);
+    word-break: break-word;
 }

--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -29,7 +29,10 @@
                 <h3>Event Proposal Details</h3>
                 <ol class="report-preview-list">
                     {% for label, value in proposal_fields %}
-                        <li><strong>{{ label }}:</strong> <span>{{ value }}</span></li>
+                        <li class="field-item">
+                            <span class="field-label">{{ label }}</span>
+                            <span class="field-value">{{ value }}</span>
+                        </li>
                     {% endfor %}
                 </ol>
             </div>
@@ -37,7 +40,10 @@
                 <h3>Event Report Details</h3>
                 <ol class="report-preview-list">
                     {% for label, value in report_fields %}
-                        <li><strong>{{ label }}:</strong> <span>{{ value }}</span></li>
+                        <li class="field-item">
+                            <span class="field-label">{{ label }}</span>
+                            <span class="field-value">{{ value }}</span>
+                        </li>
                     {% endfor %}
                 </ol>
             </div>


### PR DESCRIPTION
## Summary
- Redesign event report preview fields into responsive grid-based cards for better readability
- Expand report section width and styling to maximize page space

## Testing
- `python manage.py test` *(fails: connection to remote PostgreSQL database)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b1c70a98832ca4addf4ecd0419d6