### PR TITLE
Make academic year read-only on proposal submission form

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -194,7 +194,7 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
-                                <input type="text" id="academic-year-modern" placeholder="2024-2025" required>
+                                <input type="text" id="academic-year-modern" placeholder="2024-2025" value="{{ form.academic_year.value|default:'' }}" readonly style="background-color: #f8f9fa; cursor: not-allowed;" required>
                                 <div class="help-text">Academic year for which this event is planned</div>
                             </div>
                             <div class="input-group">


### PR DESCRIPTION
## Summary
- Prevent editing of academic year in proposal submission form by rendering the field read-only and non-interactive

## Testing
- `python manage.py test emt.tests.test_proposal_review -v 2` *(fails: connection to remote PostgreSQL database is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b128816c832cb54eb92748fd575d