### PR TITLE
feat: add collapsible sections to report preview

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -3247,17 +3247,37 @@ textarea {
     background: #fff;
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    padding: 1.5rem;
     margin: 0 auto 2rem;
     max-width: 1200px;
+    overflow: hidden;
 }
 
-.report-section h3 {
-    margin-top: 0;
-    margin-bottom: 1rem;
+.report-section > summary {
+    padding: 1.5rem;
     font-size: 1.25rem;
     font-weight: 600;
     color: var(--primary-blue);
+    cursor: pointer;
+    list-style: none;
+}
+
+.report-section[open] > summary {
+    border-bottom: 1px solid var(--border-color);
+}
+
+.report-section summary::-webkit-details-marker {
+    display: none;
+}
+
+.report-section > summary::after {
+    content: '\25BC';
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    transition: transform 0.2s ease;
+}
+
+.report-section[open] > summary::after {
+    transform: rotate(180deg);
 }
 
 .report-preview-list {
@@ -3267,6 +3287,10 @@ textarea {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 1rem;
+}
+
+.report-section .report-preview-list {
+    padding: 1.5rem;
 }
 
 .report-preview-list .field-item {

--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -25,8 +25,8 @@
             {% for key, value in post_data.items %}
                 <input type="hidden" name="{{ key }}" value="{{ value|escape }}">
             {% endfor %}
-            <div class="report-section">
-                <h3>Event Proposal Details</h3>
+            <details class="report-section" open>
+                <summary>Event Proposal Details</summary>
                 <ol class="report-preview-list">
                     {% for label, value in proposal_fields %}
                         <li class="field-item">
@@ -35,9 +35,9 @@
                         </li>
                     {% endfor %}
                 </ol>
-            </div>
-            <div class="report-section">
-                <h3>Event Report Details</h3>
+            </details>
+            <details class="report-section">
+                <summary>Event Report Details</summary>
                 <ol class="report-preview-list">
                     {% for label, value in report_fields %}
                         <li class="field-item">
@@ -46,7 +46,7 @@
                         </li>
                     {% endfor %}
                 </ol>
-            </div>
+            </details>
             <div class="content-actions">
                 <button type="submit" name="final_submit" class="btn-submit">Submit Report</button>
             </div>


### PR DESCRIPTION
## Summary
- use HTML `details` elements to split report preview into collapsible sections
- style the new accordion headers and lists for a cleaner look

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b44181e0832caee64fcfb499fab8