### PR TITLE
Harden academic year field against client edits

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -194,7 +194,8 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
-                                <input type="text" id="academic-year-modern" placeholder="2024-2025" value="{{ form.academic_year.value|default:'' }}" readonly style="background-color: #f8f9fa; cursor: not-allowed;" required>
+                                <input type="text" id="academic-year-modern" value="{{ form.academic_year.value|default:'' }}" disabled>
+                                <input type="hidden" name="academic_year" value="{{ form.academic_year.value|default:'' }}">
                                 <div class="help-text">Academic year for which this event is planned</div>
                             </div>
                             <div class="input-group">
@@ -288,8 +289,6 @@
                     <input type="hidden" name="committees_collaborations_ids" id="committees-collaborations-ids">
                     {{ form.sdg_goals.label_tag }}
                     {{ form.sdg_goals }}
-                    {{ form.academic_year.label_tag }}
-                    {{ form.academic_year }}
                     {{ form.student_coordinators.label_tag }}
                     {{ form.student_coordinators }}
                     {{ form.num_activities.label_tag }}

--- a/emt/tests/test_academic_year_submission.py
+++ b/emt/tests/test_academic_year_submission.py
@@ -1,0 +1,44 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.db.models.signals import post_save
+from django.contrib.auth.signals import user_logged_in
+
+from core.signals import create_or_update_user_profile, assign_role_on_login
+from core.models import OrganizationType, Organization
+from emt.models import EventProposal
+from transcript.models import get_active_academic_year
+
+
+class AcademicYearSubmissionTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="alice", password="pass")
+        self.client.force_login(self.user)
+        self.ot = OrganizationType.objects.create(name="Dept")
+        self.org = Organization.objects.create(name="Science", org_type=self.ot)
+        self.active_year = get_active_academic_year()
+
+    def test_hidden_field_cannot_override_academic_year(self):
+        url = reverse("emt:submit_proposal")
+        data = {
+            "organization_type": str(self.ot.id),
+            "organization": str(self.org.id),
+            "academic_year": "1999-2000",
+            "num_activities": "0",
+        }
+        resp = self.client.post(url, data)
+        self.assertEqual(resp.status_code, 302)
+        proposal = EventProposal.objects.get(submitted_by=self.user)
+        self.assertEqual(proposal.academic_year, self.active_year.year)

--- a/emt/views.py
+++ b/emt/views.py
@@ -332,6 +332,8 @@ def submit_proposal(request, pk=None):
 
     if request.method == "POST":
         post_data = request.POST.copy()
+        # Ignore client-supplied academic year; enforce server-side value
+        post_data["academic_year"] = selected_academic_year
         logger.debug("submit_proposal POST data: %s", post_data)
         logger.debug(
             "Faculty IDs from POST: %s", post_data.getlist("faculty_incharges")
@@ -462,6 +464,7 @@ def submit_proposal(request, pk=None):
 
     if request.method == "POST" and form.is_valid():
         proposal = form.save(commit=False)
+        proposal.academic_year = selected_academic_year
         proposal.submitted_by = request.user
         is_final = "final_submit" in request.POST
         is_review = "review_submit" in request.POST


### PR DESCRIPTION
## Summary
- Display academic year as a disabled field and submit it via hidden input
- Force proposals to use server-derived academic year regardless of client POST data
- Add regression test ensuring hidden field tampering cannot change academic year

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (35.212.82.162), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b446b45c832c8ea9e9e0e52b45d9