### PR TITLE
Freeze academic year field in event forms

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -475,12 +475,20 @@ $(document).ready(function() {
         }
 
         const academicYearField = $('#academic-year-modern');
-        if (academicYearField.length && !academicYearField.val()) {
-            const currentYear = new Date().getFullYear();
-            const currentMonth = new Date().getMonth();
-            const startYear = currentMonth >= 6 ? currentYear : currentYear - 1; // Assuming academic year starts in July
-            const endYear = startYear + 1;
-            academicYearField.val(`${startYear}-${endYear}`).trigger('change');
+        const academicYearHidden = $('#academic-year-hidden');
+        if (academicYearField.length) {
+            if (!academicYearField.val()) {
+                const currentYear = new Date().getFullYear();
+                const currentMonth = new Date().getMonth();
+                const startYear = currentMonth >= 6 ? currentYear : currentYear - 1; // Assuming academic year starts in July
+                const endYear = startYear + 1;
+                academicYearField.val(`${startYear}-${endYear}`);
+            }
+            academicYearField.on('change', function() {
+                if (academicYearHidden.length) {
+                    academicYearHidden.val($(this).val());
+                }
+            }).trigger('change');
         }
 
         // We add the new field IDs to the list of fields to be synced.
@@ -1477,7 +1485,8 @@ $(document).ready(function() {
                 <div class="form-row">
                     <div class="input-group">
                         <label for="academic-year-modern">Academic Year *</label>
-                        <input type="text" id="academic-year-modern" placeholder="2024-2025" required>
+                        <input type="text" id="academic-year-modern" placeholder="2024-2025" disabled>
+                        <input type="hidden" name="academic_year" id="academic-year-hidden">
                         <div class="help-text">Academic year for which this event is planned</div>
                     </div>
                     <div class="input-group">

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -827,8 +827,9 @@ $(document).on('click', '#ai-sdg-implementation', function(){
           <div class="form-row">
               <div class="input-group">
                   <label for="academic-year-modern">Academic Year *</label>
-                  <input type="text" id="academic-year-modern" name="academic_year" value="${window.PROPOSAL_DATA ? window.PROPOSAL_DATA.academic_year || '2024-2025' : '2024-2025'}">
-                  <div class="help-text">Academic year from proposal (editable)</div>
+                  <input type="text" id="academic-year-modern" value="${window.PROPOSAL_DATA ? window.PROPOSAL_DATA.academic_year || '2024-2025' : '2024-2025'}" disabled>
+                  <input type="hidden" name="academic_year" value="${window.PROPOSAL_DATA ? window.PROPOSAL_DATA.academic_year || '2024-2025' : '2024-2025'}">
+                  <div class="help-text">Academic year from proposal (not editable)</div>
               </div>
               <div class="input-group">
                   <label for="event-type-modern">Event Type *</label>

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -162,8 +162,9 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
-                                <input type="text" id="academic-year-modern" name="academic_year" value="{{ proposal.academic_year|default:'2024-2025' }}">
-                                <div class="help-text">Academic year from proposal (editable)</div>
+                                <input type="text" id="academic-year-modern" value="{{ proposal.academic_year|default:'2024-2025' }}" disabled>
+                                <input type="hidden" name="academic_year" value="{{ proposal.academic_year|default:'2024-2025' }}">
+                                <div class="help-text">Academic year from proposal (not editable)</div>
                             </div>
                             <div class="input-group">
                                 <label for="event-type-modern">Event Type *</label>


### PR DESCRIPTION
## Summary
- Disable academic year editing in proposal dashboard and sync a hidden field for submission
- Lock academic year field in event report form and template

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b9d728a8832ca20846e95f116062