### PR TITLE
Ensure event report preview captures all fields

### DIFF
--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -252,6 +252,22 @@ console.log(attendanceEl.attrs['href']);
             ["engineering_knowledge", "problem_analysis"],
         )
 
+    def test_preview_maps_frontend_field_names(self):
+        url = reverse("emt:preview_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Workshop",
+            "event_summary": "Frontend summary",
+            "event_outcomes": "Frontend outcomes",
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Frontend summary")
+        self.assertContains(response, "Frontend outcomes")
+
     def test_preview_preserves_checked_and_unchecked_fields(self):
         url = reverse("emt:preview_event_report", args=[self.proposal.id])
         data = {


### PR DESCRIPTION
## Summary
- Map `event_summary` and `event_outcomes` POST aliases to model fields so preview and submission handle them correctly
- Use mapped POST data when rendering report previews and processing submissions
- Test that preview accepts front-end field names

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ba3764e8832c8a759802065d2724