### PR TITLE
Improve faculty search in audience modal

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1136,7 +1136,11 @@ $(document).ready(function() {
 
         container.on('input', '#audienceAvailableSearch', function() {
             const term = $(this).val().trim();
-            if (currentType) loadAvailable(term);
+            if (currentType === 'students') {
+                loadAvailable(term);
+            } else if (currentType === 'faculty') {
+                filterOptions($(this), availableSelect);
+            }
         });
 
         container.on('input', '#audienceSelectedSearch', function() {


### PR DESCRIPTION
## Summary
- handle faculty search locally in target-audience modal

## Testing
- `python manage.py test emt.tests.test_audience_csv.AudienceCSVViewTests.test_api_faculty_returns_department -v 2` *(fails: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68b1c42472f8832c8d61b05541452cae