### PR TITLE
feat: add confirm step for target audience selection

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -858,7 +858,6 @@ $(document).ready(function() {
             : [];
 
         modal.addClass('show');
-        $('#audienceSave').hide();
 
         let available = [];
         let selected = [];
@@ -908,6 +907,7 @@ $(document).ready(function() {
                 <div class="audience-custom">
                     <select id="audienceCustomInput" placeholder="Add custom audience"></select>
                 </div>
+                <button type="button" id="audienceAddSelection" class="btn-continue">Add</button>
                 <button type="button" id="audienceBack" class="btn-continue">Back</button>
             </div>
         `);
@@ -921,6 +921,7 @@ $(document).ready(function() {
         const step1 = container.find('#audienceStep1');
         const step2 = container.find('#audienceStep2');
         const continueBtn = container.find('#audienceContinue');
+        const addBtn = container.find('#audienceAddSelection');
         const backBtn = container.find('#audienceBack');
 
         let classStudentMap = {};
@@ -1065,7 +1066,7 @@ $(document).ready(function() {
             listContainer.show();
             continueBtn.show();
             step2.hide();
-            $('#audienceSave').hide();
+            addBtn.hide();
             renderLists();
             loadAvailable('');
         });
@@ -1114,14 +1115,23 @@ $(document).ready(function() {
             step1.hide();
             step2.show();
             continueBtn.hide();
-            $('#audienceSave').show();
+            addBtn.show();
         });
 
         backBtn.on('click', function() {
             step2.hide();
             step1.show();
             continueBtn.show();
-            $('#audienceSave').hide();
+            addBtn.hide();
+        });
+
+        addBtn.on('click', function() {
+            step2.hide();
+            step1.show();
+            listContainer.hide();
+            continueBtn.hide();
+            addBtn.hide();
+            currentType = null;
         });
 
         const customTS = new TomSelect('#audienceCustomInput', {
@@ -1199,7 +1209,7 @@ $(document).ready(function() {
             container.find('button[data-type="students"]').click();
         }
 
-        $('#audienceSave').off('click').on('click', () => {
+        $('#audienceConfirm').off('click').on('click', () => {
             const groupNames = selectedStudents.concat(selectedFaculty).map(it => it.name);
             const userNames = userSelected.map(u => u.name);
             const names = groupNames.concat(userNames);

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -340,7 +340,7 @@
         <div id="audienceOptions"></div>
         <div class="modal-actions">
             <button type="button" id="audienceCancel" class="btn-cancel">Cancel</button>
-            <button type="button" id="audienceSave" class="btn-save">Add</button>
+            <button type="button" id="audienceConfirm" class="btn-save">Confirm</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add confirm button to target audience modal to finalize selections
- allow adding multiple student or faculty groups before confirming

## Testing
- `python manage.py test` (fails: connection to server at "yamanote.proxy.rlwy.net" failed)

------
https://chatgpt.com/codex/tasks/task_e_68b26b013510832cb296dd3e03e0e3a8