### PR TITLE
Ensure autosave requests include session credentials

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -92,6 +92,7 @@ window.AutosaveManager = (function() {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': window.AUTOSAVE_CSRF
             },
+            credentials: 'same-origin',
             body: JSON.stringify(formData)
         })
         .then(async res => {
@@ -224,6 +225,7 @@ async function autosave() {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': window.AUTOSAVE_CSRF,
             },
+            credentials: 'same-origin',
             body: JSON.stringify(payload),
         });
         if (!res.ok) {


### PR DESCRIPTION
## Summary
- send session cookies with proposal autosave requests so drafts persist

## Testing
- `python manage.py test` (fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)
- `npm test` (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b26dbb7d54832cbdd4a49ace5a0d43