### PR TITLE
Fix stray character in json_sync.js causing autosave failures

### DIFF
--- a/emt/static/emt/js/json_sync.js
+++ b/emt/static/emt/js/json_sync.js
@@ -208,4 +208,3 @@ document.addEventListener("DOMContentLoaded", function () {
         reader.readAsText(file);
     });
 });
-f


### PR DESCRIPTION
## Summary
- remove unintended trailing character at end of json_sync.js that caused ReferenceError in browser and broke autosave

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b27153d1b8832ca2aa1e8979c17be2