### PR TITLE
Allow autosave drafts to persist with validation warnings

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -112,7 +112,9 @@ window.AutosaveManager = (function() {
                 proposalId = data.proposal_id;
                 window.PROPOSAL_ID = data.proposal_id;
                 saveLocal();
-                document.dispatchEvent(new CustomEvent('autosave:success', {detail: {proposalId: data.proposal_id}}));
+                document.dispatchEvent(new CustomEvent('autosave:success', {
+                    detail: { proposalId: data.proposal_id, errors: data.errors }
+                }));
                 return data;
             }
             return Promise.reject(data);

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2375,8 +2375,11 @@ function getWhyThisEventForm() {
             showLoadingOverlay();
             if (window.AutosaveManager && window.AutosaveManager.manualSave) {
                 window.AutosaveManager.manualSave()
-                    .then(() => {
+                    .then((data) => {
                         hideLoadingOverlay();
+                        if (data && data.errors) {
+                            handleAutosaveErrors(data);
+                        }
                         markSectionComplete(currentExpandedCard);
                         showNotification('Section saved successfully!', 'success');
 
@@ -3072,6 +3075,7 @@ function getWhyThisEventForm() {
     function handleAutosaveErrors(errorData) {
         const errors = errorData?.errors || errorData;
         if (!errors) return;
+        showNotification('Draft saved with validation warnings. Please review highlighted fields.', 'info');
         clearValidationErrors();
         firstErrorField = null;
 
@@ -3221,6 +3225,9 @@ function getWhyThisEventForm() {
                 window.PROPOSAL_ID = detail.proposalId;
                 updateCdlNavLink(detail.proposalId);
                 $('#reset-draft-btn').prop('disabled', false).removeAttr('disabled');
+            }
+            if (detail && detail.errors) {
+                handleAutosaveErrors({errors: detail.errors});
             }
             const indicator = $('#autosave-indicator');
             indicator.removeClass('saving error').addClass('saved');


### PR DESCRIPTION
## Summary
- Persist proposal drafts even when required fields fail validation
- Surface autosave warnings while keeping the saved state visible
- Test that draft data saves despite missing required fields and errors are returned

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b27ac7ec34832c9c3e88b89039a6c6