### PR TITLE
Improve autosave error handling in proposal form

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3073,8 +3073,11 @@ function getWhyThisEventForm() {
     }
 
     function handleAutosaveErrors(errorData) {
-        const errors = errorData?.errors || errorData;
-        if (!errors) return;
+        const errors = (errorData && typeof errorData === 'object') ? (errorData.errors || errorData) : null;
+        if (!errors || typeof errors !== 'object') {
+            showNotification('Autosave failed. Please try again.', 'error');
+            return;
+        }
         showNotification('Draft saved with validation warnings. Please review highlighted fields.', 'info');
         clearValidationErrors();
         firstErrorField = null;


### PR DESCRIPTION
## Summary
- Show a clear error message when autosave fails without field-level validation errors
- Avoid misleading "warnings" notification for network or unknown autosave failures

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2882cc78c832cba03e09518fc1afa