### PR TITLE
fix: restore organization field in proposal form

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -121,22 +121,27 @@
                             <h3>Organization Details</h3>
                         </div>
                         
-                        <div class="form-row">
+                        <div class="form-row full-width">
                             <div class="input-group">
-                              <label for="org-type-modern-input">Type of Organisation *</label>
-                              <select id="org-type-modern-input" required>
-                                <option value="">Select Organization Type</option>
-                              </select>
-                              <div class="help-text">Choose the type of organization hosting this event</div>
+                                <label for="org-type-modern-input">Type of Organisation *</label>
+                                <div id="org-type-modern">
+                                    <select required>
+                                        <option value="">Select Organization Type</option>
+                                    </select>
+                                </div>
+                                <div class="help-text">Choose the type of organization hosting this event</div>
                             </div>
-                          
+                        </div>
+
+                        <!-- Dynamic organization field will be inserted here -->
+
+                        <div class="form-row full-width">
                             <div class="input-group">
-                              <label for="committees-collaborations-modern">Committees & Collaborations</label>
-                              <textarea id="committees-collaborations-modern" rows="3"
-                                placeholder="List committees and external collaborations involved"></textarea>
-                              <div class="help-text">Mention internal committees and external partners involved</div>
+                                <label for="committees-collaborations-modern">Committees & Collaborations</label>
+                                <select id="committees-collaborations-modern" multiple placeholder="Type or select organizations..."></select>
+                                <div class="help-text">Mention internal committees and external partners involved</div>
                             </div>
-                          </div>                          
+                        </div>
 
                         <!-- Event Information Section -->
                         <div class="form-section-header">


### PR DESCRIPTION
## Summary
- ensure basic information section includes organization selector container for dynamic field
- convert committees & collaborations to multi-select to match JS expectations

## Testing
- `python manage.py test` *(failed: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b28ec40e90832ca3fa4d075766257b