### PR TITLE
Fix org type validation in proposal dashboard

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2886,21 +2886,21 @@ function getWhyThisEventForm() {
     function validateBasicInfo() {
         let isValid = true;
 
-        // Check org type (which is now a TomSelect-backed input)
+        // Check org type (TomSelect input)
         const orgTypeInput = $('#org-type-modern-input');
+        const orgTypeValue = orgTypeInput[0]?.tomselect?.getValue();
         console.log('validateBasicInfo: orgType', {
             id: orgTypeInput.attr('id'),
             name: orgTypeInput.attr('name'),
-            value: orgTypeInput.val(),
-            tomSelectValue: orgTypeInput[0]?.tomselect?.getValue()
+            value: orgTypeValue
         });
-        if (!orgTypeInput.val() || !orgTypeInput[0].tomselect?.getValue()) {
+        if (!orgTypeValue) {
             showFieldError(orgTypeInput.parent(), 'Organization type is required');
             isValid = false;
         }
 
         // Check organization if org type is selected
-        if (orgTypeInput.val()) {
+        if (orgTypeValue) {
             // Try select (TomSelect)
             let orgField = $(`.org-specific-field:visible select`);
             if (orgField.length) {


### PR DESCRIPTION
## Summary
- handle organisation type validation using TomSelect value only to stop false errors during proposal submission

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test emt.tests.test_academic_year_submission` *(fails: AssertionError: 200 != 302)*


------
https://chatgpt.com/codex/tasks/task_e_68b2b889a924832cbe18ca2ee83377b9