### PR TITLE
Ensure proposal form syncs hidden fields

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2438,8 +2438,8 @@ function getWhyThisEventForm() {
                     baseName = 'flow';
                 }
                 let djangoField = $(`#django-forms [name="${baseName}"]`);
-                if (!djangoField.length && baseName === 'flow') {
-                    djangoField = $(`textarea[name="flow"]`);
+                if (!djangoField.length) {
+                    djangoField = $(`[name="${baseName}"]`);
                 }
                 if (djangoField.length) {
                     djangoField.val($(this).val());


### PR DESCRIPTION
## Summary
- Sync modern form inputs to hidden Django fields by falling back to global field search

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b2c704f894832cb3b136a58ba0d1e8