### PR TITLE
Fix outcome modal to retain selected outcomes

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1249,9 +1249,14 @@ $(document).ready(function() {
             .then(data => {
                 if (data.success) {
                     container.empty();
-                    const existing = posField.val().split('\n').map(s => s.trim());
-                    data.pos.forEach((po, idx) => { addOption(container, `PO${idx+1}: ` + po.description, existing); });
-                    data.psos.forEach((pso, idx) => { addOption(container, `PSO${idx+1}: ` + pso.description, existing); });
+                    const existing = posField.val().split('\n').map(s => s.trim()).filter(Boolean);
+                    const selectedCodes = existing.map(s => s.split(':')[0]);
+                    data.pos.forEach((po, idx) => {
+                        addOption(container, `PO${idx + 1}`, po.description, selectedCodes);
+                    });
+                    data.psos.forEach((pso, idx) => {
+                        addOption(container, `PSO${idx + 1}`, pso.description, selectedCodes);
+                    });
                 } else {
                     container.text('No data');
                 }
@@ -1259,11 +1264,11 @@ $(document).ready(function() {
             .catch(() => { container.text('Error loading'); });
     }
 
-    function addOption(container, labelText, existing) {
+    function addOption(container, code, description, selectedCodes) {
         const lbl = $('<label>');
-        const cb = $('<input type="checkbox">').val(labelText);
-        if (existing.includes(labelText)) cb.prop('checked', true);
-        lbl.append(cb).append(' ' + labelText);
+        const cb = $('<input type="checkbox">').val(code);
+        if (selectedCodes.includes(code)) cb.prop('checked', true);
+        lbl.append(cb).append(` ${code}: ${description}`);
         container.append(lbl).append('<br>');
     }
 


### PR DESCRIPTION
## Summary
- Track previously selected PO/PSO codes and pre-check them when reopening the outcome modal
- Store only PO/PSO codes while showing full descriptions in the modal

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c9634f1c832c8c4ee52fbb0ced49