### PR TITLE
Allow autosave file uploads and stronger validation

### DIFF
--- a/emt/tests/test_proposal_activities.py
+++ b/emt/tests/test_proposal_activities.py
@@ -35,6 +35,7 @@ class ProposalActivityPersistenceTests(TestCase):
             "organization_type": str(self.ot.id),
             "organization": str(self.org.id),
             "academic_year": "2024-2025",
+            "event_title": "My Event",
             "num_activities": "2",
             "activity_name_1": "Orientation",
             "activity_date_1": "2024-01-01",
@@ -51,3 +52,38 @@ class ProposalActivityPersistenceTests(TestCase):
         resp2 = self.client.get(reverse("emt:submit_event_report", args=[proposal.id]))
         self.assertContains(resp2, 'name="activity_name_1" value="Orientation"', html=False)
         self.assertContains(resp2, 'name="activity_name_2" value="Workshop"', html=False)
+
+    def test_invalid_activity_submission_preserves_existing(self):
+        url = reverse("emt:submit_proposal")
+        data = {
+            "organization_type": str(self.ot.id),
+            "organization": str(self.org.id),
+            "academic_year": "2024-2025",
+            "event_title": "My Event",
+            "num_activities": "1",
+            "activity_name_1": "Orientation",
+            "activity_date_1": "2024-01-01",
+        }
+        resp = self.client.post(url, data)
+        self.assertEqual(resp.status_code, 302)
+        proposal = EventProposal.objects.get(submitted_by=self.user)
+        self.assertEqual(proposal.activities.count(), 1)
+
+        update = {
+            "organization_type": str(self.ot.id),
+            "organization": str(self.org.id),
+            "academic_year": "2024-2025",
+            "event_title": "My Event",
+            "num_activities": "1",
+            "activity_name_1": "Updated",
+            # missing date
+        }
+        resp2 = self.client.post(
+            reverse("emt:submit_proposal_with_pk", args=[proposal.id]),
+            update,
+        )
+        self.assertEqual(resp2.status_code, 200)
+        proposal.refresh_from_db()
+        activities = list(proposal.activities.all())
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].name, "Orientation")


### PR DESCRIPTION
## Summary
- Permit partial income rows with missing participants and rate
- Validate activity submissions before replacing existing entries
- Restore CSRF protection and add FormData support for autosave
- Reject unknown organizations during autosave
- Cover autosave and activity flows with new tests

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test emt.tests.test_existing.AutosaveProposalTests.test_autosave_income_optional_fields emt.tests.test_existing.AutosaveProposalTests.test_autosave_requires_csrf_token emt.tests.test_existing.AutosaveProposalTests.test_autosave_with_file_upload emt.tests.test_existing.AutosaveProposalTests.test_autosave_uses_existing_organization_by_name emt.tests.test_existing.AutosaveProposalTests.test_autosave_rejects_unknown_organization_name emt.tests.test_proposal_activities.ProposalActivityPersistenceTests.test_invalid_activity_submission_preserves_existing emt.tests.test_proposal_activities.ProposalActivityPersistenceTests.test_proposal_activities_show_on_event_report --noinput --verbosity 2`
- `DATABASE_URL=sqlite:///:memory: python manage.py test --noinput` *(fails: TemplateDoesNotExist: core/user_dashboard.html, AI backend errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cbe08bbc832c98dbf0cf1d90ff46