### PR TITLE
Fix outcome modal parsing

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -823,7 +823,7 @@ $(document).ready(function() {
                 .get();
 
             // Replace existing content with newly selected outcomes
-            const value = selected.join('\n');
+            const value = selected.join(', ');
             posField.val(value).trigger('input').trigger('change');
 
             if (djangoPosField.length) {
@@ -1249,8 +1249,7 @@ $(document).ready(function() {
             .then(data => {
                 if (data.success) {
                     container.empty();
-                    const existing = posField.val().split('\n').map(s => s.trim()).filter(Boolean);
-                    const selectedCodes = existing.map(s => s.split(':')[0]);
+                    const selectedCodes = (posField.val().match(/\b(?:PO|PSO)\d+\b/g) || []);
                     data.pos.forEach((po, idx) => {
                         addOption(container, `PO${idx + 1}`, po.description, selectedCodes);
                     });


### PR DESCRIPTION
## Summary
- Ensure outcome selections are regex-parsed so any delimiter works
- Save outcomes joined by comma-space for consistent storage
- Keep previously selected outcomes checked when reopening modal

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce5e812c832c967a4a9028b56ad4