### PR TITLE
Preserve proposal drafts until final submission

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -214,7 +214,12 @@ window.AutosaveManager = (function() {
 
     const formEl = document.querySelector('form');
     if (formEl) {
-        formEl.addEventListener('submit', clearLocal);
+        formEl.addEventListener('submit', (e) => {
+            const submitter = e.submitter || {};
+            if (submitter.name === 'final_submit') {
+                clearLocal();
+            }
+        });
     }
 
     // Expose helpers globally for legacy code

--- a/emt/templates/emt/review_proposal.html
+++ b/emt/templates/emt/review_proposal.html
@@ -256,3 +256,24 @@
   </div>
 </div>
 {% endblock %}
+
+{% block scripts %}
+{{ block.super }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.querySelector('.review-header form');
+  if (form) {
+    form.addEventListener('submit', function(e) {
+      const submitter = e.submitter || {};
+      if (submitter.name === 'final_submit') {
+        Object.keys(localStorage).forEach(function(key) {
+          if (key.startsWith('proposal_draft_')) {
+            localStorage.removeItem(key);
+          }
+        });
+      }
+    });
+  }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Ensure autosave drafts persist when navigating to review, clearing only on final submit
- Clear stored draft data when confirming submission on the review page

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dd4fc15c832ca81565c4970ec66b