### PR TITLE
Fix autosave mapping and CSRF handling for draft proposals

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -52,6 +52,9 @@ window.AutosaveManager = (function() {
             }
         });
 
+        // CSRF token is sent via header; exclude it from payload
+        delete data.csrfmiddlewaretoken;
+
         // Map generic 'content' field to a specific section if configured.
         if (data.content !== undefined && window.AUTOSAVE_SECTION) {
             data[window.AUTOSAVE_SECTION] = data.content;

--- a/emt/static/emt/js/json_sync.js
+++ b/emt/static/emt/js/json_sync.js
@@ -14,9 +14,9 @@ document.addEventListener("DOMContentLoaded", function () {
         "student-coordinators-modern": "student_coordinators",
         "faculty-select": "faculty_incharges",
         "committees-collaborations-modern": "committees_collaborations",
-        "id_need_analysis": "need_analysis",
-        "id_objectives": "objectives",
-        "id_learning_outcomes": "outcomes",
+        "need-analysis-modern": "need_analysis",
+        "objectives-modern": "objectives",
+        "outcomes-modern": "outcomes",
         "id_flow": "flow"
     };
 


### PR DESCRIPTION
## Summary
- exclude CSRF token from autosave payload to allow text-only saves
- map modern proposal fields to hidden Django fields so AI/manual text persists

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e0d495c0832cb6b9ad1d22eed4ab