### PR TITLE
Fix autosave validation for 'Why This Event' section

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -18,10 +18,11 @@ window.AutosaveManager = (function() {
         }
     }
 
-    function collectFieldData() {
+    function collectFieldData(onlyFields) {
         const grouped = {};
         fields.forEach(f => {
             if (f.disabled || !f.name) return;
+            if (Array.isArray(onlyFields) && !onlyFields.includes(f.name)) return;
             (grouped[f.name] ||= []).push(f);
         });
         const data = {};
@@ -77,14 +78,14 @@ window.AutosaveManager = (function() {
         localStorage.removeItem(pageKey);
     }
 
-    function autosaveDraft() {
+    function autosaveDraft(onlyFields) {
         // Don't autosave for submitted proposals
         if (window.PROPOSAL_STATUS && window.PROPOSAL_STATUS !== 'draft') {
             clearLocal();
             return Promise.resolve();
         }
 
-        const formData = collectFieldData();
+        const formData = collectFieldData(onlyFields);
         if (proposalId) {
             formData['proposal_id'] = proposalId;
         }
@@ -207,9 +208,9 @@ window.AutosaveManager = (function() {
         }
     }
 
-    function manualSave() {
+    function manualSave(onlyFields) {
         saveLocal();
-        return autosaveDraft();
+        return autosaveDraft(onlyFields);
     }
 
     // Initial setup

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2378,7 +2378,12 @@ function getWhyThisEventForm() {
         if (validateCurrentSection()) {
             showLoadingOverlay();
             if (window.AutosaveManager && window.AutosaveManager.manualSave) {
-                window.AutosaveManager.manualSave()
+                const sectionFieldMap = {
+                    'why-this-event': ['need_analysis', 'objectives', 'outcomes'],
+                    'schedule': ['flow']
+                };
+                const fieldsToSave = sectionFieldMap[currentExpandedCard] || null;
+                window.AutosaveManager.manualSave(fieldsToSave)
                     .then((data) => {
                         hideLoadingOverlay();
                         if (data && data.errors) {


### PR DESCRIPTION
## Summary
- Allow autosave manager to send only specified fields
- Limit proposal dashboard autosave to need analysis, objectives, and outcomes for 'Why This Event' section

## Testing
- `python manage.py test` *(failed: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e2a78658832c82a3c468cc27058f