### PR TITLE
Remove missing command-center stylesheet

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,6 @@
   <!-- Styles -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <link rel="stylesheet" href="{% static 'core/css/base.css' %}">
-  <link rel="stylesheet" href="{% static 'core/css/command-center.css' %}">
   {% block extra_css %}{% endblock %}
   
   {% block head_extra %}{% endblock %}


### PR DESCRIPTION
## Summary
- remove reference to old command-center.css to stop 404 errors

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e5de87bc832cae4d63c3d17b5bbf