### PR TITLE
Fix academic year hidden field sync

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -163,7 +163,7 @@
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
                                 <input type="text" id="academic-year-modern" value="{{ proposal.academic_year|default:'2024-2025' }}" disabled>
-                                <input type="hidden" name="academic_year" value="{{ proposal.academic_year|default:'2024-2025' }}">
+                                <input type="hidden" name="academic_year" id="academic-year-hidden" value="{{ proposal.academic_year|default:'2024-2025' }}">
                                 <div class="help-text">Academic year from proposal (not editable)</div>
                             </div>
                             <div class="input-group">

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -197,7 +197,7 @@
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
                                 <input type="text" id="academic-year-modern" value="{{ form.academic_year.value|default:'' }}" disabled>
-                                <input type="hidden" name="academic_year" value="{{ form.academic_year.value|default:'' }}">
+                                <input type="hidden" name="academic_year" id="academic-year-hidden" value="{{ form.academic_year.value|default:'' }}">
                                 <div class="help-text">Academic year for which this event is planned</div>
                             </div>
                             <div class="input-group">


### PR DESCRIPTION
## Summary
- add IDs to academic year hidden inputs so JS syncs value correctly

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at "yamanote.proxy.rlwy.net" (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68b2e7a30c88832cbf34b80260ffca55