### PR TITLE
Add academic year fallback for proposal submission

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -173,6 +173,9 @@ class EventProposalForm(forms.ModelForm):
             return self.instance.academic_year
         if self.selected_academic_year:
             return self.selected_academic_year
+        fallback_year = self.data.get("academic_year")
+        if fallback_year:
+            return fallback_year
         raise forms.ValidationError("Academic year is not set by admin")
 
 # ──────────────────────────────────────────────────────────────

--- a/emt/tests/test_academic_year_submission.py
+++ b/emt/tests/test_academic_year_submission.py
@@ -3,6 +3,8 @@ from django.test import TestCase
 from django.urls import reverse
 from django.db.models.signals import post_save
 from django.contrib.auth.signals import user_logged_in
+from django.utils import timezone
+from unittest.mock import patch
 
 from core.signals import create_or_update_user_profile, assign_role_on_login
 from core.models import OrganizationType, Organization
@@ -37,8 +39,27 @@ class AcademicYearSubmissionTests(TestCase):
             "organization": str(self.org.id),
             "academic_year": "1999-2000",
             "num_activities": "0",
+            "event_title": "Test Event",
         }
         resp = self.client.post(url, data)
         self.assertEqual(resp.status_code, 302)
         proposal = EventProposal.objects.get(submitted_by=self.user)
         self.assertEqual(proposal.academic_year, self.active_year.year)
+
+    def test_fallback_academic_year_when_admin_not_set(self):
+        url = reverse("emt:submit_proposal")
+        data = {
+            "organization_type": str(self.ot.id),
+            "organization": str(self.org.id),
+            "num_activities": "0",
+            "event_title": "Test Event",
+        }
+        with patch("transcript.models.get_active_academic_year", return_value=None):
+            resp = self.client.post(url, data)
+        self.assertEqual(resp.status_code, 302)
+        proposal = EventProposal.objects.get(submitted_by=self.user)
+        now = timezone.now()
+        start_year = now.year if now.month >= 6 else now.year - 1
+        end_year = start_year + 1
+        expected_year = f"{start_year}-{end_year}"
+        self.assertEqual(proposal.academic_year, expected_year)

--- a/emt/views.py
+++ b/emt/views.py
@@ -330,7 +330,13 @@ def submit_proposal(request, pk=None):
     from transcript.models import get_active_academic_year
 
     active_year = get_active_academic_year()
-    selected_academic_year = active_year.year if active_year else ""
+    selected_academic_year = active_year.year if active_year else None
+
+    if not selected_academic_year:
+        now = timezone.now()
+        start_year = now.year if now.month >= 6 else now.year - 1
+        end_year = start_year + 1
+        selected_academic_year = f"{start_year}-{end_year}"
 
     proposal = None
     if pk:


### PR DESCRIPTION
## Summary
- compute current academic year when no active year exists and enforce it in proposal submission
- allow proposal form to accept fallback academic year
- test academic year fallback when admin has not pre-set a year

## Testing
- `DATABASE_URL=sqlite:// python manage.py test emt.tests.test_academic_year_submission -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea7017c4832c89a67b3824b3a806