### PR TITLE
Ensure faculty in-charge selections autosave

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -634,6 +634,9 @@ $(document).ready(function() {
             });
             djangoFacultySelect.trigger('change');
             clearFieldError(facultySelect);
+            if (window.AutosaveManager) {
+                window.AutosaveManager.manualSave(['faculty_incharges']).catch(() => {});
+            }
         });
 
         const initialValues = djangoFacultySelect.val();


### PR DESCRIPTION
## Summary
- trigger manual draft save when faculty in-charge TomSelect changes

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b33946f6e4832c951916fdb80b18d0