### PR TITLE
feat: autosave dynamic activities

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -535,6 +535,23 @@ $(document).ready(function() {
                     dateLabel.setAttribute('for', `activity_date_${num}`);
                     dateLabel.textContent = `${num}. Activity Date`;
                 }
+
+                const handler = () => {
+                    if (window.AutosaveManager && window.AutosaveManager.manualSave) {
+                        window.AutosaveManager.manualSave([
+                            `activity_name_${num}`,
+                            `activity_date_${num}`
+                        ]).catch(() => {});
+                    }
+                };
+                if (nameInput) {
+                    nameInput.oninput = handler;
+                    nameInput.onchange = handler;
+                }
+                if (dateInput) {
+                    dateInput.oninput = handler;
+                    dateInput.onchange = handler;
+                }
             });
             numActivitiesInput.value = rows.length;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
@@ -570,6 +587,9 @@ $(document).ready(function() {
                     });
                 }
                 reindexActivityRows();
+                if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                    window.AutosaveManager.reinitialize();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- autosave activity rows as soon as names or dates change
- rebind autosave after rendering or removing activities
- ensure faculty selections autosave immediately

## Testing
- `npm test` *(fails: playwright: not found)*
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b33c025e40832c927c251769c01b9a