### PR TITLE
Guard autosave for dynamic proposal activities

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -537,11 +537,23 @@ $(document).ready(function() {
                 }
 
                 const handler = () => {
-                    if (window.AutosaveManager && window.AutosaveManager.manualSave) {
-                        window.AutosaveManager.manualSave([
-                            `activity_name_${num}`,
-                            `activity_date_${num}`
-                        ]).catch(() => {});
+                    if (!(window.AutosaveManager && window.AutosaveManager.manualSave)) {
+                        return;
+                    }
+
+                    const fieldsToSave = [];
+                    const nameValue = nameInput ? nameInput.value.trim() : '';
+                    const dateValue = dateInput ? dateInput.value : '';
+
+                    if (nameValue) {
+                        fieldsToSave.push(`activity_name_${num}`);
+                    }
+                    if (dateValue) {
+                        fieldsToSave.push(`activity_date_${num}`);
+                    }
+
+                    if (fieldsToSave.length) {
+                        window.AutosaveManager.manualSave(fieldsToSave).catch(() => {});
                     }
                 };
                 if (nameInput) {


### PR DESCRIPTION
## Summary
- Prevent autosave from validating empty dynamic activity fields by only saving populated inputs

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at yamanote.proxy.rlwy.net: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b33dd81f28832cb3cac852cdb135be