### PR TITLE
Handle partial autosave updates

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -93,7 +93,7 @@ window.AutosaveManager = (function() {
         const formEl = document.querySelector('form');
         const hasFile = formEl && Array.from(formEl.querySelectorAll('input[type="file"]')).some(f => f.files.length > 0);
 
-        document.dispatchEvent(new Event('autosave:start'));
+        document.dispatchEvent(new CustomEvent('autosave:start', { detail: { fields: onlyFields }}));
 
         const headers = { 'X-CSRFToken': window.AUTOSAVE_CSRF };
         const options = {
@@ -141,14 +141,16 @@ window.AutosaveManager = (function() {
                 window.PROPOSAL_ID = data.proposal_id;
                 saveLocal();
                 document.dispatchEvent(new CustomEvent('autosave:success', {
-                    detail: { proposalId: data.proposal_id, errors: data.errors }
+                    detail: { proposalId: data.proposal_id, errors: data.errors, fields: onlyFields }
                 }));
                 return data;
             }
             return Promise.reject(data);
         })
         .catch(err => {
-            document.dispatchEvent(new CustomEvent('autosave:error', {detail: err}));
+            const detail = (err && typeof err === 'object') ? { ...err } : { error: err };
+            detail.fields = onlyFields;
+            document.dispatchEvent(new CustomEvent('autosave:error', {detail}));
             return Promise.reject(err);
         });
     }

--- a/emt/tests/test_autosave_partial_update.py
+++ b/emt/tests/test_autosave_partial_update.py
@@ -1,0 +1,74 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+import json
+
+from core.models import OrganizationType, Organization, OrganizationRole, RoleAssignment
+from emt.models import EventProposal, EventActivity
+
+
+class AutosavePartialUpdateTests(TestCase):
+    def setUp(self):
+        self.ot = OrganizationType.objects.create(name="Dept")
+        self.org = Organization.objects.create(name="Science", org_type=self.ot)
+        self.faculty_role = OrganizationRole.objects.create(
+            organization=self.org, name="Faculty"
+        )
+        self.user = User.objects.create(username="u1", first_name="Test", email="u1@example.com")
+        RoleAssignment.objects.create(user=self.user, role=self.faculty_role, organization=self.org)
+        self.faculty = User.objects.create(username="fac1", first_name="Fac", email="fac@example.com")
+        RoleAssignment.objects.create(user=self.faculty, role=self.faculty_role, organization=self.org)
+        self.client.force_login(self.user)
+
+    def _payload(self):
+        return {
+            "organization_type": str(self.ot.id),
+            "organization": str(self.org.id),
+            "academic_year": "2024-2025",
+        }
+
+    def test_autosave_single_activity_no_other_errors(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        pid = resp.json()["proposal_id"]
+
+        payload = {"proposal_id": pid, "activity_name_1": "Intro", "activity_date_1": "2024-01-01"}
+        resp2 = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        data2 = resp2.json()
+        self.assertTrue(data2["success"])
+        self.assertNotIn("event_title", data2.get("errors", {}))
+        self.assertNotIn("activities", data2.get("errors", {}))
+        proposal = EventProposal.objects.get(id=pid)
+        activities = list(EventActivity.objects.filter(proposal=proposal))
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].name, "Intro")
+
+    def test_autosave_faculty_incharge_persists(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        pid = resp.json()["proposal_id"]
+
+        payload = {"proposal_id": pid, "faculty_incharges": [str(self.faculty.id)]}
+        resp2 = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        data2 = resp2.json()
+        self.assertTrue(data2["success"])
+        self.assertNotIn("event_title", data2.get("errors", {}))
+        proposal = EventProposal.objects.get(id=pid)
+        self.assertEqual(list(proposal.faculty_incharges.values_list("id", flat=True)), [self.faculty.id])
+
+        get_resp = self.client.get(reverse("emt:submit_proposal_with_pk", args=[pid]))
+        self.assertContains(get_resp, f'value="{self.faculty.id}" selected')


### PR DESCRIPTION
## Summary
- Filter autosave errors to submitted fields and allow partial updates for activities and faculty incharge
- Pass manual save field list through autosave events and display validation for touched inputs only
- Add regression tests for partial autosave of activities and faculty selection

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b33fdb6254832cbcc4c48c437f8c08