### PR TITLE
fix: restore speaker drafts on reload

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2055,6 +2055,22 @@ function getWhyThisEventForm() {
             });
             showEmptyState();
         } else {
+            try {
+                const saved = JSON.parse(
+                    localStorage.getItem(`proposal_draft_${window.location.pathname}_new`) || '{}'
+                );
+                const idxSet = new Set();
+                Object.keys(saved).forEach(key => {
+                    const m = key.match(/^speaker_(?:full_name|designation|affiliation|contact_email|contact_number|linkedin_url|detailed_profile)_(\d+)$/);
+                    if (m) idxSet.add(parseInt(m[1], 10));
+                });
+                if (idxSet.size) {
+                    container.empty();
+                    Array.from(idxSet).sort((a, b) => a - b).forEach(() => addSpeakerForm());
+                }
+            } catch (err) {
+                console.error('Failed to restore speakers from draft', err);
+            }
             showEmptyState();
         }
     }


### PR DESCRIPTION
## Summary
- restore previously entered speaker details from localStorage when reloading the proposal form

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b3e93f8832c864209d8f6fa950e