### PR TITLE
Fix CDL review submit flow

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3750,7 +3750,7 @@ function addSubmitSection() {
     <div class="submit-section">
       <h5 class="mb-3" style="color: var(--primary-blue); font-weight: 600;">Submit Proposal</h5>
       <div class="d-flex gap-3 justify-content-center">
-        <button type="submit" class="btn-submit" name="review_submit" id="submit-proposal-btn" disabled>Submit Proposal</button>
+        <button type="submit" class="btn-submit" name="final_submit" id="submit-proposal-btn" disabled>Submit Proposal</button>
       </div>
       <p class="submit-help-text">Review all sections before final submission</p>
     </div>

--- a/emt/tests/test_proposal_review.py
+++ b/emt/tests/test_proposal_review.py
@@ -130,6 +130,23 @@ class ProposalReviewFlowTests(TestCase):
         proposal = EventProposal.objects.get(id=pid)
         self.assertEqual(proposal.status, EventProposal.Status.DRAFT)
 
+    def test_cdl_support_final_submit_flow(self):
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        pid = resp.json()["proposal_id"]
+
+        post_data = {"needs_support": "on", "final_submit": "1"}
+        resp2 = self.client.post(
+            reverse("emt:submit_cdl_support", args=[pid]), post_data
+        )
+        self.assertEqual(resp2.status_code, 302)
+
+        proposal = EventProposal.objects.get(id=pid)
+        self.assertEqual(proposal.status, EventProposal.Status.SUBMITTED)
+
     def test_ai_generated_text_persists(self):
         resp = self.client.post(
             reverse("emt:autosave_proposal"),


### PR DESCRIPTION
## Summary
- Ensure CDL support step distinguishes between review and final submission
- Rename dashboard submit button to use `final_submit`
- Add regression test for submitting proposal from CDL step

## Testing
- `DATABASE_URL=sqlite:////tmp/test.db?sslmode=disable python manage.py test emt.tests.test_proposal_review` *(fails: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68b3709ee9ec832c813cf28036272027