### PR TITLE
Improve autosave validation and triggers

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -165,7 +165,11 @@ window.AutosaveManager = (function() {
             }, 1000);
         };
         field.addEventListener('input', handler);
-        if (field.tagName === 'SELECT') {
+        if (
+            field.tagName === 'SELECT' ||
+            field.type === 'checkbox' ||
+            field.type === 'radio'
+        ) {
             field.addEventListener('change', handler);
         }
         field.dataset.autosaveBound = 'true';
@@ -256,7 +260,7 @@ async function autosave() {
                 payload[key] = value;
             }
         });
-        const res = await fetch('/suite/autosave-proposal/', {
+        const res = await fetch(window.AUTOSAVE_URL || '/suite/autosave-proposal/', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Avoid dropping existing data on invalid speaker, expense, or income rows during autosave
- Validate activity dates and always return success with detailed errors
- Debounce autosave for checkbox/radio inputs and support configurable autosave URL

## Testing
- ⚠️ `python manage.py test` *(failed: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b37812bad4832c9b68089959cf2799