### PR TITLE
Revert faculty dashboard layout to original design

### DIFF
--- a/static/core/css/dashboard.css
+++ b/static/core/css/dashboard.css
@@ -1,394 +1,176 @@
 :root{
-  --primary:#264487;--ink:#0f172a;--muted:#64748b;--border:#e5e7eb;
-  --surf:#ffffff;--subtle:#f8fafc;--tint:#eef2ff;--shadow:0 8px 24px rgba(2,6,23,.06);
-  --shadow-lg:0 12px 40px rgba(2,6,23,.1);
-
-  /* dynamic vars set by JS */
-  --calH:auto;
-  --contribH:auto;
-  --todoBodyH:auto;
-}
-
-/* -------- Base typography & helpers (new) -------- */
-.ems-dashboard{font-family:"Inter",system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;}
-.ems-dashboard p, .ems-dashboard li, .ems-dashboard span, .ems-dashboard input,
-.ems-dashboard select,.ems-dashboard textarea,.ems-dashboard button{line-height:1.5; letter-spacing:.01em; color:var(--ink);}
-.ems-dashboard h1,.ems-dashboard h2,.ems-dashboard h3,.ems-dashboard h4{letter-spacing:.005em; color:var(--ink); margin:0;}
-.ems-dashboard .visually-hidden{position:absolute!important;height:1px;width:1px;overflow:hidden;clip:rect(1px,1px,1px,1px);white-space:nowrap;border:0;padding:0;margin:-1px;}
-
-.ems-dashboard *{box-sizing:border-box}
-
-/* Focus visibility (accessible) */
-.ems-dashboard a:focus-visible,
-.ems-dashboard button:focus-visible,
-.ems-dashboard select:focus-visible,
-.ems-dashboard input:focus-visible,
-.ems-dashboard textarea:focus-visible{outline:3px solid rgba(38,68,135,.35); outline-offset:2px; border-radius:6px}
-
-/* Reduced motion */
-@media (prefers-reduced-motion:reduce){
-  .ems-dashboard *{animation:none!important;transition:none!important}
-}
-
-/* -------- header -------- */
-.topbar{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid var(--border);}
-.topbar h1{margin:0;font-size:28px;font-weight:700;color:var(--ink);}
-.topbar-date{color:var(--muted);font-size:14px}
-
-/* -------- TOP ROW -------- */
-.kpi-row{
-  display:grid;
-  /* KPIs narrower, Profile wider (no height changes) */
-  grid-template-columns:0.9fr 0.9fr 0.9fr 0.9fr 1.8fr;
-  gap:16px;
-  margin-bottom:16px;
-}
-@media (max-width:1400px){
-  .kpi-row{grid-template-columns:repeat(2,1fr);--kpiH:120px;--profileH:84px;}
-}
-@media (max-width:768px){
-  .kpi-row{grid-template-columns:1fr;}
-}
-
-/* KPI layout — Row 1: icon + description; Row 2: number with short underline */
-.kpi-card{
-  background:var(--surf);border:1px solid var(--border);border-radius:12px;padding:12px;
-  box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease;
-  display:grid;grid-template-columns:auto 1fr;grid-template-rows:auto auto;
-  grid-template-areas:"icon title" "value value";
-  align-items:start;gap:10px;cursor:pointer;
-}
-.kpi-card:hover{transform:translateY(-2px);box-shadow:var(--shadow-lg);}
-.kpi-card:active{transform:translateY(0);}
-
-/* Row 1 */
-.kpi-icon{
-  grid-area:icon;
-  width:48px;height:48px;border-radius:12px;
-  display:flex;align-items:center;justify-content:center;
-  color:#fff;font-size:20px;flex-shrink:0;
-}
-.kpi-content{display:contents;}
-.kpi-title{
-  grid-area:title;
-  align-self:center;
-  margin:0 0 0 10px;
-  font-size:14px;
-  font-weight:700;
-  color:var(--ink);
-  text-align:left;
-}
-
-/* Row 2 */
-.kpi-value{
-  grid-area:value;
-  justify-self:start;
-  display:inline-block;
-  font-size:40px!important;
-  font-weight:900!important;
-  line-height:1.05;
-  color:var(--ink)!important;
-  margin-top:6px;
-  position:relative;
-}
-.kpi-value::after{
-  content:"";
-  display:block;
-  height:2px;
-  width:100%;
-  margin-top:6px;
-  background:var(--bar,#94a3b8);
-  opacity:.6;
-  border-radius:1px;
-}
-
-/* hide old progress bar */
-.kpi-bar{display:none;}
-
-.kpi-card:nth-child(1){--bar:#6366f1}
-.kpi-card:nth-child(2){--bar:#0ea5e9}
-.kpi-card:nth-child(3){--bar:#fb923c}
-.kpi-card:nth-child(4){--bar:#10b981}
-
-.bg-indigo{background:#6366f1}.bg-sky{background:#0ea5e9}.bg-orange{background:#fb923c}.bg-emerald{background:#10b981}
-
-/* -------- Profile KPI -------- */
-.profile-kpi{
-  background:var(--surf);
-  border:1px solid var(--border);
-  border-radius:20px;
-  box-shadow:var(--shadow);
-  padding:12px 16px;
-  display:grid;
-  grid-template-columns: 140px 1fr;
-  align-items:center;
-  gap:14px;
-}
-.pkp-avatar{
-  width:100%;
-  height:100%;
-  border-radius:16px;
-  background:#e5e7eb;
-  overflow:hidden;
-}
-.pkp-avatar img{width:100%;height:100%;object-fit:cover;}
-.pkp-initials{
-  width:100%;height:100%;
-  display:flex;align-items:center;justify-content:center;
-  font-weight:800;font-size:28px;color:var(--primary);
-}
-.pkp-body{min-width:0;display:flex;flex-direction:column;gap:4px}
-.pkp-name{margin:0;font-size:20px;font-weight:800;color:var(--ink);line-height:1.1}
-.pkp-sub{margin:0;font-size:14px;font-weight:600;color:var(--muted)}
-.pkp-meta{margin:6px 0 0;display:flex;gap:16px;font-size:12px;font-weight:600;color:var(--muted)}
-.pkp-meta strong{color:var(--ink);font-weight:800}
-@media (max-width:1400px){
-  .profile-kpi{grid-template-columns:120px 1fr;}
-}
-@media (max-width:768px){
-  .profile-kpi{display:flex;gap:12px;}
-  .pkp-avatar{width:56px;height:56px;border-radius:12px;}
-  .pkp-initials{font-size:18px}
-  .pkp-name{font-size:16px}
-  .pkp-sub{font-size:12px}
-}
-.pkp-stats{display:flex;gap:10px;font-size:12px}
-.pkp-stats span{background:#f1f5f9;border-radius:10px;padding:6px 10px;color:#475569}
-.pkp-stats strong{color:var(--ink)!important;font-weight:700}
-
-/* Mobile: auto heights */
-@media (max-width:768px){
-  .kpi-card,.profile-kpi{height:auto;}
-}
-
-/* -------- Main Grid -------- */
-.grid-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:20px;grid-auto-rows:minmax(380px,auto)}
-@media (max-width:1200px){.grid-3{grid-template-columns:1fr;gap:16px}}
-
-@media (min-width:1201px){
-  .grid-3{
-    grid-template-columns:minmax(0,1fr) minmax(0,1fr) minmax(0,1fr);
-    gap:20px;
-    grid-template-areas:
-      "actions performance calendar"
-      "contrib contrib    eventdetails";
+    --primary:#264487;--ink:#0f172a;--muted:#64748b;--border:#e5e7eb;
+    --surf:#ffffff;--subtle:#f8fafc;--tint:#eef2ff;--shadow:0 8px 24px rgba(2,6,23,.06);
+    --shadow-lg:0 12px 40px rgba(2,6,23,.1);
+  
+    /* dynamic vars set by JS */
+    --calH:auto;
+    --contribH:auto;
+    --todoBodyH:auto;
   }
-  #cardActions{grid-area:actions;}
-  #cardPerformance{grid-area:performance;}
-  #cardCalendar{grid-area:calendar;}
-  #cardEventDetails{grid-area:eventdetails;}
-
-  /* Contribution equals Actions+Performance width */
-  #cardContribution{grid-area:contrib; grid-column:1 / span 2 !important;}
-
-  /* keep equal-heights */
-  #cardCalendar{height:var(--calH);}
-  #cardActions{height:var(--calH);}
-  #cardPerformance{height:var(--calH);}
-  #cardEventDetails{height:var(--contribH);}
-}
-
+  
+  /* container */
+  .ems-dashboard{width:100%;padding:0;max-width:none;margin:0;}
+  .ems-dashboard *{box-sizing:border-box}
+  
+  /* header */
+  .topbar{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:24px;padding-bottom:12px;border-bottom:1px solid var(--border);}
+  .topbar h1{margin:0;font-size:28px;font-weight:700;color:var(--ink);}
+  .topbar-date{color:var(--muted);font-size:14px}
+  
+  /* TOP ROW — compact */
+  .kpi-row{display:grid;grid-template-columns:repeat(4,1fr) 320px;gap:12px;margin-bottom:16px;}
+  @media (max-width:1400px){.kpi-row{grid-template-columns:repeat(2,1fr);}}
+  @media (max-width:768px){.kpi-row{grid-template-columns:1fr;}}
+  
+  /* KPI Card */
+  .kpi-card{
+    background:var(--surf);border:1px solid var(--border);border-radius:14px;padding:16px;
+    box-shadow:var(--shadow);transition:transform .2s ease,box-shadow .2s ease;
+    display:flex;align-items:center;gap:14px;min-height:96px;cursor:pointer;
+  }
+  .kpi-card:hover{transform:translateY(-2px);box-shadow:var(--shadow-lg);}
+  .kpi-icon{width:48px;height:48px;border-radius:12px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:20px;flex-shrink:0;}
+  .bg-indigo{background:#6366f1}.bg-sky{background:#0ea5e9}.bg-orange{background:#fb923c}.bg-emerald{background:#10b981}
+  .kpi-content{flex:1;display:flex;flex-direction:column}
+  .kpi-title{font-size:13px;color:var(--muted);font-weight:600;margin-bottom:6px}
+  .kpi-value{font-size:44px!important;font-weight:900!important;line-height:1;color:var(--ink)!important;margin-bottom:8px;font-family:Inter,sans-serif!important}
+  @media (max-width:768px){.kpi-value{font-size:36px!important}}
+  .kpi-bar{position:relative;height:6px;width:100%;border-radius:999px;background:#eef2f7}
+  .kpi-bar::after{content:"";position:absolute;inset:0;width:var(--pct,60%);border-radius:999px;background:var(--bar,#6366f1)}
+  .kpi-card:nth-child(1){--bar:#6366f1}.kpi-card:nth-child(2){--bar:#0ea5e9}.kpi-card:nth-child(3){--bar:#fb923c}.kpi-card:nth-child(4){--bar:#10b981}
+  
+  /* profile tile */
+  .profile-kpi{background:var(--surf);border:1px solid var(--border);border-radius:14px;padding:16px;box-shadow:var(--shadow);display:flex;align-items:center;gap:14px;min-height:96px}
+  .pkp-avatar{width:72px;height:72px;border-radius:16px;background:#e5e7eb;display:flex;align-items:center;justify-content:center;color:var(--primary);font-weight:800;font-size:22px;flex-shrink:0;overflow:hidden}
+  .pkp-avatar img{width:100%;height:100%;object-fit:cover}
+  .pkp-body{flex:1;min-width:0}
+  .pkp-name{font-weight:700!important;font-size:18px!important;color:var(--ink)!important;margin-bottom:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .pkp-sub{font-size:13px!important;color:var(--muted)!important;margin-bottom:8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .pkp-stats{display:flex;gap:16px;font-size:13px;color:var(--muted)}
+  .pkp-stats strong{color:var(--ink)!important;font-weight:600}
+  
+  /* main grid */
+  .grid-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:20px;grid-auto-rows:minmax(380px,auto)}
+  @media (max-width:1200px){.grid-3{grid-template-columns:1fr;gap:16px}}
+  
+  @media (min-width:1201px){
+    .grid-3{
+      grid-template-columns:minmax(0,1fr) minmax(0,1fr) minmax(0,1fr);
+      gap:20px;
+      grid-template-areas:
+        "actions performance calendar"
+        "contrib contrib    todo";
+    }
+    #cardActions{grid-area:actions;}
+    #cardPerformance{grid-area:performance;}
+    #cardCalendar{grid-area:calendar;}
+    #cardTodo{grid-area:todo;}
+  
+    /* Contribution must equal Actions+Performance width (includes the column gap) */
+    #cardContribution{grid-area:contrib; grid-column:1 / span 2 !important;}
+  
+    /* keep equal-heights */
+    #cardCalendar{height:var(--calH);}
+    #cardActions{height:var(--calH);}
+    #cardPerformance{height:var(--calH);}
+    #cardTodo{height:var(--contribH);}
+    #todoList{height:var(--todoBodyH);overflow-y:auto;}
+  }
+  
+     
+  /* span helpers */
 /* span helpers */
 .col-span-2{ grid-column: span 2; }
 @media (max-width:1200px){ .col-span-2{ grid-column: span 1; } }
 
-/* -------- CDL custom grid (two rows as per mock) -------- */
-.cdl-grid{display:grid; grid-template-columns: 1fr 2fr; gap:20px; grid-auto-rows:minmax(360px,auto)}
-@media (max-width:1200px){ .cdl-grid{ grid-template-columns:1fr; gap:16px } }
-@media (min-width:1201px){
-  .cdl-grid{
-    grid-template-areas:
-      "notifications workload"
-      "calendar      details";
+  /* cards */
+  .card{background:var(--surf)!important;border:1px solid var(--border)!important;border-radius:16px!important;box-shadow:var(--shadow)!important;overflow:hidden}
+  .card-header{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid var(--border);background:none!important}
+  .card-header h3{margin:0!important;font-size:16px!important;font-weight:600!important;color:var(--ink)!important;display:flex;align-items:center;gap:8px}
+  
+  @media (min-width:1201px){
+    /* Lock all three to the same row height (exact height, not min-height) */
+    #cardCalendar{height:var(--calH);}
+    #cardActions{height:var(--calH);}
+    #cardPerformance{height:var(--calH);}
+  
+    /* To‑do paired with Contribution */
+    #cardTodo{height:var(--contribH);}
+    #todoList{height:var(--todoBodyH);overflow-y:auto;}
   }
-  #cardNotifications{ grid-area: notifications; }
-  #cardTeam{ grid-area: workload; }
-  #cardCalendar{ grid-area: calendar; }
-  #cardEventDetails{ grid-area: details; }
-}
 
-/* -------- Cards -------- */
-.card{background:var(--surf)!important;border:1px solid var(--border)!important;border-radius:16px!important;box-shadow:var(--shadow)!important;overflow:hidden}
-.card-header{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid var(--border);background:none!important}
-.card-header h3{margin:0!important;font-size:16px!important;font-weight:600!important;color:var(--ink)!important;display:flex;align-items:center;gap:8px}
-
-/* -------- Lists -------- */
-.list{padding:14px 18px; max-height: calc(var(--calH) - 70px); overflow-y: auto}
-/* Ensure Notifications card list scrolls even if --calH is auto */
-#cardNotifications .list{ max-height: clamp(280px, 48vh, 520px); overflow-y: auto; padding-right: 6px }
-.empty{padding:32px 0;text-align:center;color:var(--muted);font-size:15px}
-.list-item{display:flex;gap:14px;align-items:center;padding:14px;border-radius:10px;border:1px solid var(--border);background:#fff;margin-bottom:10px}
-.bullet{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;background:#eef2ff;color:#4f46e5}
-.bullet.returned{background:#f3e8ff;color:#7c3aed}
-.bullet.under_review{background:#e0f2fe;color:#0369a1}
-.list-body{flex:1}
-.list-body h4{margin:0 0 3px 0;font-size:15px;font-weight:600}
-.list-body p{margin:0;color:var(--muted);font-size:13px}
-.chip-btn{padding:6px 12px;border:1px solid var(--border);border-radius:6px;background:#fff;font-size:12px;color:var(--ink);text-decoration:none;transition:all .2s}
-.chip-btn:hover{background:var(--subtle);border-color:var(--primary);color:var(--primary)}
-.chip-btn:focus-visible{outline:3px solid rgba(38,68,135,.3);outline-offset:2px}
-
-/* Notification item layout (to match screenshot) */
-#cardNotifications .notification-item{display:flex; align-items:flex-start; justify-content:space-between; gap:12px; padding:14px; border:1px solid var(--border); border-radius:10px; background:#fff; margin-bottom:10px}
-#cardNotifications .notification-content h4{margin:0 0 4px 0; font-size:14px; font-weight:600; color:var(--ink)}
-#cardNotifications .notification-content p{margin:0; color:var(--muted); font-size:12px}
-#cardNotifications .notification-tags{display:flex; gap:6px; margin-top:6px}
-#cardNotifications .notification-tags .tag{display:inline-block; padding:2px 6px; border-radius:10px; font-size:11px; background:#eef2ff; color:#4f46e5}
-#cardNotifications .notification-tags .tag.certificate{background:#ede9fe; color:#7c3aed}
-#cardNotifications .view-btn{padding:6px 10px; font-size:12px; border:1px solid var(--border); background:#fff; color:var(--ink); border-radius:8px; cursor:pointer}
-#cardNotifications .view-btn:hover{background:var(--subtle); border-color:var(--primary); color:var(--primary)}
-
-/* Responsive behavior for notifications: stack on narrow/zoomed screens */
-@media (max-width: 1100px){
-  #cardNotifications .notification-item{flex-direction:column; align-items:stretch}
-  #cardNotifications .view-btn{align-self:flex-start}
-}
-
-/* -------- Chart -------- */
-.chart-wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:20px;gap:16px}
-.chart-wrap.donut canvas{width:180px!important;height:180px!important}
-.chart-legend{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;width:100%;max-width:300px}
-.legend-row{display:flex;gap:8px;align-items:center;font-size:13px}
-.legend-dot{width:10px;height:10px;border-radius:50%}
-
-/* -------- Segmented Control -------- */
-.header-actions{display:flex;gap:10px;align-items:center}
-.seg{display:flex;border:1px solid var(--border);border-radius:6px;overflow:hidden}
-.seg-btn{padding:6px 12px;font-size:12px;color:var(--muted);background:#fff;border:none;cursor:pointer;transition:all .2s}
-.seg-btn:hover{background:var(--subtle);color:var(--ink)}
-.seg-btn.active{background:var(--primary);color:#fff}
-
-/* -------- Calendar -------- */
-.mini-cal{padding:16px}
-.cal-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
-#calTitle{font-weight:600;font-size:15px}
-.cal-nav{width:28px;height:28px;border:1px solid var(--border);border-radius:6px;background:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .2s,border-color .2s}
-.cal-nav:hover{background:var(--subtle);border-color:var(--primary)}
-.cal-weekdays{display:grid;grid-template-columns:repeat(7,1fr);gap:3px;font-size:11px;color:var(--muted);text-align:center;margin-bottom:6px}
-.cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:3px}
-.day{padding:6px 2px;text-align:center;border-radius:6px;font-size:13px;cursor:pointer;transition:all .2s;position:relative; height:42px}
-.day.has-event::after{content:"";position:absolute;bottom:4px;left:50%;transform:translateX(-50%);width:6px;height:6px;border-radius:50%;background:#e74c3c}
-.day.has-meeting::after{content:"";position:absolute;bottom:4px;left:50%;transform:translateX(-50%);width:6px;height:6px;border-radius:50%;background:#0ea5e9}
-.day:hover{background:var(--subtle)}
-.day.today{background:var(--primary);color:#fff;font-weight:600}
-.day.selected{outline:2px solid #93c5fd; outline-offset:0; box-shadow: inset 0 0 0 2px #bfdbfe; background:#eff6ff}
-.day.muted{opacity:.4}
-
-/* -------- Upcoming -------- */
-.upcoming{padding:14px 16px;border-top:1px solid var(--border);max-height:320px;overflow:auto}
-.u-item{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:#fff;margin-bottom:6px;font-size:13px}
-
-/* -------- To-do (kept for parity) -------- */
-.todo{list-style:none;margin:0;padding:14px 16px}
-.todo li{display:flex;align-items:center;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:#fff;margin-bottom:6px}
-.todo input[type="checkbox"]{width:14px;height:14px}
-.todo .rm{margin-left:auto;border:none;background:transparent;color:#ef4444;cursor:pointer;padding:2px}
-
-/* -------- Heatmap -------- */
+  
+  /* list */
+  .list{padding:14px 18px}
+  .empty{padding:32px 0;text-align:center;color:var(--muted);font-size:15px}
+  .list-item{display:flex;gap:14px;align-items:center;padding:14px;border-radius:10px;border:1px solid var(--border);background:#fff;margin-bottom:10px}
+  .bullet{width:36px;height:36px;border-radius:8px;display:flex;align-items:center;justify-content:center;background:#eef2ff;color:#4f46e5}
+  .bullet.returned{background:#f3e8ff;color:#7c3aed}.bullet.under_review{background:#e0f2fe;color:#0369a1}
+  .list-body{flex:1}.list-body h4{margin:0 0 3px 0;font-size:15px;font-weight:600}.list-body p{margin:0;color:var(--muted);font-size:13px}
+  .chip-btn{padding:6px 12px;border:1px solid var(--border);border-radius:6px;background:#fff;font-size:12px;color:var(--ink);text-decoration:none;transition:all .2s}
+  .chip-btn:hover{background:var(--subtle);border-color:var(--primary);color:var(--primary)}
+  
+  /* chart */
+  .chart-wrap{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:20px;gap:16px}
+  .chart-wrap.donut canvas{width:180px!important;height:180px!important}
+  .chart-legend{display:grid;grid-template-columns:repeat(2,1fr);gap:10px;width:100%;max-width:300px}
+  .legend-row{display:flex;gap:8px;align-items:center;font-size:13px}
+  .legend-dot{width:10px;height:10px;border-radius:50%}
+  
+  /* segmented */
+  .header-actions{display:flex;gap:10px;align-items:center}
+  .seg{display:flex;border:1px solid var(--border);border-radius:6px;overflow:hidden}
+  .seg-btn{padding:6px 12px;font-size:12px;color:var(--muted);background:#fff;border:none;cursor:pointer;transition:all .2s}
+  .seg-btn.active{background:var(--primary);color:#fff}
+  
+  /* calendar */
+  .mini-cal{padding:16px}
+  .cal-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
+  #calTitle{font-weight:600;font-size:15px}
+  .cal-nav{width:28px;height:28px;border:1px solid var(--border);border-radius:6px;background:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center}
+  .cal-weekdays{display:grid;grid-template-columns:repeat(7,1fr);gap:3px;font-size:11px;color:var(--muted);text-align:center;margin-bottom:6px}
+  .cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:3px}
+  .day{padding:6px 2px;text-align:center;border-radius:6px;font-size:13px;cursor:pointer;transition:all .2s}
+  .day:hover{background:var(--subtle)}.day.today{background:var(--primary);color:#fff;font-weight:600}.day.muted{opacity:.4}
+  
+  /* upcoming */
+  .upcoming{padding:14px 16px;border-top:1px solid var(--border)}
+  .u-item{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:#fff;margin-bottom:6px;font-size:13px}
+  
+  /* todo */
+  .todo{list-style:none;margin:0;padding:14px 16px}
+  .todo li{display:flex;align-items:center;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:6px;background:#fff;margin-bottom:6px}
+  .todo input[type="checkbox"]{width:14px;height:14px}
+  .todo .rm{margin-left:auto;border:none;background:transparent;color:#ef4444;cursor:pointer;padding:2px}
+  
+/* Heatmap — fill card and scale cells via CSS vars set by JS */
 #cardContribution { display: flex; flex-direction: column; }
 #cardContribution .heatmap { flex: 1; padding: 20px; }
 
-.hm-grid { display: grid; grid-auto-flow: column; grid-auto-columns: min-content; gap: var(--hm-gap, 3px); }
-.hm-col { display: grid; grid-template-rows: repeat(7, var(--hm-size, 10px)); gap: var(--hm-gap, 3px); }
-.hm-cell { width: var(--hm-size, 10px); height: var(--hm-size, 10px); border-radius: 2px; background: #e5e7eb; }
-/* Blue theme levels */
-.hm-cell.l1{ background:#bfdbfe; }
-.hm-cell.l2{ background:#93c5fd; }
-.hm-cell.l3{ background:#60a5fa; }
-.hm-cell.l4{ background:#3b82f6; }
-
-/* -------- Links & selects -------- */
-.link-muted{color:var(--muted);text-decoration:none}
-.link-muted:hover{color:var(--primary)}
-.select{border:1px solid var(--border);background:#fff;border-radius:6px;padding:6px 10px;font-size:12px}
-
-/* -------- Modals -------- */
-.modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; }
-.modal-content { background: white; border-radius: 12px; padding: 24px; width: 90%; max-width: 500px; max-height: 90vh; overflow-y: auto; box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15); }
-.modal-large { max-width: 600px; }
-.modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
-.modal-header h3 { margin: 0; font-size: 18px; font-weight: 600; color: var(--ink); }
-.modal-close { background: none; border: none; font-size: 24px; color: var(--muted); cursor: pointer; padding: 0; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: 6px; }
-.modal-close:hover { background: var(--subtle); color: var(--ink); }
-
-.form-group { margin-bottom: 16px; }
-.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
-.form-group label { display: block; margin-bottom: 6px; font-weight: 600; color: var(--ink); font-size: 14px; }
-.form-group input, .form-group select, .form-group textarea { width: 100%; padding: 8px 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 14px; background: white; transition: border-color 0.2s ease, box-shadow 0.2s ease; }
-.form-group input:focus, .form-group select:focus, .form-group textarea:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px rgba(38, 68, 135, 0.1); }
-.form-group select[multiple] { min-height: 80px; }
-.form-group small { display: block; margin-top: 4px; font-size: 12px; color: var(--muted); }
-
-.modal-actions { display: flex; gap: 12px; justify-content: flex-end; margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--border); }
-
-/* -------- Buttons (scoped; keeps Bootstrap from bleeding) -------- */
-.ems-dashboard .btn,
-.ems-dashboard .btn-primary,
-.ems-dashboard .btn-secondary{all:unset;}
-
-/* re-apply our button design */
-.btn-primary,
-.btn-secondary{
-  padding: 8px 16px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  border: 1px solid;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  line-height:1.2;
+.hm-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: min-content;
+  gap: var(--hm-gap, 3px);
 }
-.btn-primary{background: var(--primary); color: #fff; border-color: var(--primary);}
-.btn-primary:hover{background:#1e3a73; border-color:#1e3a73;}
-.btn-primary:disabled{opacity:.6; cursor:not-allowed;}
+.hm-col {
+  display: grid;
+  grid-template-rows: repeat(7, var(--hm-size, 10px));
+  gap: var(--hm-gap, 3px);
+}
+.hm-cell {
+  width: var(--hm-size, 10px);
+  height: var(--hm-size, 10px);
+  border-radius: 2px;
+  background: #e5e7eb;
+}
 
-.btn-secondary{background:#fff; color: var(--ink); border-color: var(--border);}
-.btn-secondary:hover{background: var(--subtle); border-color: var(--muted);}
-.btn-secondary:disabled{opacity:.6; cursor:not-allowed;}
-
-/* -------- Event Details -------- */
-.event-details-content { padding: 14px 16px; min-height: 120px; max-height: calc(var(--contribH) - 70px); overflow-y: auto }
-.event-detail-item .row{display:flex; align-items:center; justify-content:space-between; gap:10px;}
-.event-detail-item .actions{flex-shrink:0; display:flex; gap:8px;}
-.event-detail-item h4{margin:0; font-size:15px; font-weight:600; color:var(--ink); overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
-.event-detail-item { padding: 12px; margin-bottom: 8px; border: 1px solid var(--border); border-radius: 8px; background: white; }
-.event-detail-title { font-size: 16px; font-weight: 600; color: var(--ink); margin-bottom: 4px; }
-.event-detail-title.with-actions{display:flex; align-items:center; justify-content:space-between; gap:10px;}
-.event-detail-title .title-text{overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
-.event-detail-title .title-actions{flex-shrink:0; display:flex; gap:8px;}
-.event-detail-meta { font-size: 13px; color: var(--muted); margin-bottom: 8px; }
-.event-detail-actions { display: flex; gap: 8px; }
-
-/* -------- Proposal Tracker -------- */
-.proposal-tracker-section { margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border); max-height: calc(var(--calH) - 140px); overflow-y: auto; }
-.proposal-tracker-section h4 { margin: 0 0 12px 0; font-size: 14px; font-weight: 600; color: var(--ink); }
-.proposal-item { display: flex; align-items: center; gap: 10px; padding: 8px; margin-bottom: 6px; border: 1px solid var(--border); border-radius: 6px; background: white; font-size: 13px; }
-.proposal-status-badge { padding: 2px 6px; border-radius: 4px; font-size: 11px; font-weight: 600; text-transform: uppercase; }
-.status-submitted { background: #dbeafe; color: #1e40af; }
-.status-under_review { background: #fef3c7; color: #d97706; }
-.status-approved { background: #d1fae5; color: #059669; }
-.status-rejected { background: #fee2e2; color: #dc2626; }
-.status-returned { background: #ede9fe; color: #7c3aed; }
-
-/* -------- Tables (Assignment Manager) -------- */
-.table-wrap{width:100%; overflow:auto}
-.table{width:100%; border-collapse:separate; border-spacing:0;}
-.table thead th{position:sticky; top:0; background:#fff; z-index:1; text-align:left; font-size:12px; color:var(--muted); padding:10px 12px; border-bottom:1px solid var(--border)}
-.table.compact td{padding:10px 12px; border-bottom:1px solid var(--border); font-size:13px}
-.ta-right{text-align:right}
-.empty-row{ text-align:center; color:var(--muted); padding:18px 0; }
-.priority-badge{ display:inline-block; padding:2px 6px; border-radius:4px; font-size:11px; font-weight:700; }
-.priority-badge.normal{ background:#e2e8f0; color:#334155; }
-.status-badge{ display:inline-block; padding:2px 6px; border-radius:4px; font-size:11px; font-weight:700; }
-.status-badge.pending{ background:#fef3c7; color:#a16207; }
-.status-badge.assigned{ background:#d1fae5; color:#065f46; }
-
-/* -------- Dots legend for CDL calendar -------- */
-.cal-legend{display:flex; gap:14px; align-items:center; padding:0 16px 12px; color:var(--muted); font-size:12px}
-.cal-legend .dot{width:8px; height:8px; border-radius:50%; display:inline-block; margin-right:6px}
-.cal-legend .dot.blue{background:#0ea5e9}
-.cal-legend .dot.green{background:#10b981}
-.cal-legend .dot.red{background:#ef4444}
+  /* helpers */
+  .link-muted{color:var(--muted);text-decoration:none}
+  .link-muted:hover{color:var(--primary)}
+  .select{border:1px solid var(--border);background:#fff;border-radius:6px;padding:6px 10px;font-size:12px}
+  
+  /* neutralize bootstrap */
+  .ems-dashboard .btn,.ems-dashboard .btn-primary{all:unset}
+  

--- a/templates/core/dashboard.html
+++ b/templates/core/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}Dashboard — Event Management Suite{% endblock %}
+{% block title %}Dashboard – Event Management Suite{% endblock %}
 
 {% block head_extra %}
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
@@ -21,37 +21,37 @@
 
   <!-- TOP ROW -->
   <section class="kpi-row">
-    <button class="kpi-card" id="kpiStudents" type="button" aria-label="Students KPI">
-      <div class="kpi-icon bg-indigo" aria-hidden="true"><i class="fa-solid fa-user-graduate" aria-hidden="true"></i></div>
+    <button class="kpi-card" id="kpiStudents">
+      <div class="kpi-icon bg-indigo"><i class="fa-solid fa-user-graduate"></i></div>
       <div class="kpi-content">
-        <span class="kpi-title">Students</span>
+        <span class="kpi-title">No. of Students</span>
         <span class="kpi-value">{{ mentee_count|default:0 }}</span>
         <span class="kpi-bar" style="--pct:60%"></span>
       </div>
     </button>
 
-    <button class="kpi-card" id="kpiClasses" type="button" aria-label="Classes KPI">
-      <div class="kpi-icon bg-sky" aria-hidden="true"><i class="fa-solid fa-chalkboard-user" aria-hidden="true"></i></div>
+    <button class="kpi-card" id="kpiClasses">
+      <div class="kpi-icon bg-sky"><i class="fa-solid fa-chalkboard-user"></i></div>
       <div class="kpi-content">
-        <span class="kpi-title">Classes</span>
+        <span class="kpi-title">No. of Classes</span>
         <span class="kpi-value">{{ classes_count|default:0 }}</span>
         <span class="kpi-bar" style="--pct:55%"></span>
       </div>
     </button>
 
-    <button class="kpi-card" id="kpiOrgEvents" type="button" aria-label="Organized events KPI">
-      <div class="kpi-icon bg-orange" aria-hidden="true"><i class="fa-solid fa-calendar-check" aria-hidden="true"></i></div>
+    <button class="kpi-card" id="kpiOrgEvents">
+      <div class="kpi-icon bg-orange"><i class="fa-solid fa-calendar-check"></i></div>
       <div class="kpi-content">
-        <span class="kpi-title">Organized Events</span>
+        <span class="kpi-title">Events Organized</span>
         <span class="kpi-value">{{ organized_events_count|default:0 }}</span>
         <span class="kpi-bar" style="--pct:45%"></span>
       </div>
     </button>
 
-    <button class="kpi-card" id="kpiPartEvents" type="button" aria-label="Participated events KPI">
-      <div class="kpi-icon bg-emerald" aria-hidden="true"><i class="fa-solid fa-people-group" aria-hidden="true"></i></div>
+    <button class="kpi-card" id="kpiPartEvents">
+      <div class="kpi-icon bg-emerald"><i class="fa-solid fa-people-group"></i></div>
       <div class="kpi-content">
-        <span class="kpi-title">Participated Events</span>
+        <span class="kpi-title">Events Participated</span>
         <span class="kpi-value">{{ participated_events_count|default:0 }}</span>
         <span class="kpi-bar" style="--pct:65%"></span>
       </div>
@@ -63,27 +63,17 @@
         {% if user.profile and user.profile.photo %}
           <img src="{{ user.profile.photo.url }}" alt="{{ user.get_full_name|default:user.username }}">
         {% else %}
-          <span class="pkp-initials" aria-hidden="true">
+          <span>
             {% if user.first_name %}{{ user.first_name.0|upper }}{% if user.last_name %}{{ user.last_name.0|upper }}{% endif %}{% else %}{{ user.username.0|upper }}{% endif %}
           </span>
         {% endif %}
       </div>
       <div class="pkp-body">
-        <h1 class="pkp-name">{{ user.get_full_name|default:user.username }}</h1>
-        <h2 class="pkp-sub">{{ user.email }}</h2>
-        <h3 class="pkp-meta">
-          <span>Rank: <strong>{{ user.rank|default:"—" }}</strong></span>
-          <span>Classes: <strong>{{ classes_count|default:0 }}</strong></span>
-        </h3>
-        <div class="pkp-actions">
-          <a href="{% url 'my_profile' %}?from_dashboard=true" class="btn btn-profile-primary" aria-label="View profile">
-            <i class="fas fa-user-cog" aria-hidden="true"></i>
-            <span>View Profile</span>
-          </a>
-          <a href="{% url 'my_profile' %}?from_dashboard=true&tab=edit" class="btn btn-profile-secondary" aria-label="Edit profile">
-            <i class="fas fa-edit" aria-hidden="true"></i>
-            <span>Edit Profile</span>
-          </a>
+        <div class="pkp-name">{{ user.get_full_name|default:user.username }}</div>
+        <div class="pkp-sub">{{ user.email }}</div>
+        <div class="pkp-stats">
+          <span>Rank:&nbsp;<strong>{{ user.rank|default:"—" }}</strong></span>
+          <span>Classes:&nbsp;<strong>{{ classes_count|default:0 }}</strong></span>
         </div>
       </div>
     </div>
@@ -94,202 +84,100 @@
     <!-- Actions (col 1) -->
     <section class="card eq" id="cardActions">
       <div class="card-header">
-        <h3><i class="fa-solid fa-inbox" aria-hidden="true"></i> Actions &amp; Proposals</h3>
-        <a class="link-muted" href="#" data-go-tab="events" aria-label="View all proposals">View all</a>
+        <h3><i class="fa-solid fa-inbox"></i> Actions</h3>
+        <a class="link-muted" href="#" data-go-tab="events">View all</a>
       </div>
-      <div class="list" id="actionsList">
-        <!-- Dynamic: populated by /api/user/proposals -->
-        <div class="proposal-tracker-section" id="proposalTracker">
-          <h4><i class="fa-solid fa-file-lines" aria-hidden="true"></i> My Proposals</h4>
-          <div id="proposalsList"><div class="empty">Loading…</div></div>
-        </div>
+      <div class="list">
+        {% with actionable=user_proposals %}
+          {% if actionable %}
+            {% for proposal in actionable %}
+              {% if proposal.status == 'submitted' or proposal.status == 'under_review' or proposal.status == 'returned' %}
+              <article class="list-item">
+                <div class="bullet {{ proposal.status|lower }}">
+                  {% if proposal.status == 'under_review' %}<i class="fa-regular fa-clock"></i>
+                  {% elif proposal.status == 'returned' %}<i class="fa-solid fa-rotate-left"></i>
+                  {% else %}<i class="fa-regular fa-file-lines"></i>{% endif %}
+                </div>
+                <div class="list-body">
+                  <h4>{{ proposal.event_title }}</h4>
+                  <p>{{ proposal.get_status_display }}</p>
+                </div>
+                <a href="{% url 'emt:proposal_status_detail' proposal.id %}" class="chip-btn"><i class="fa-regular fa-eye"></i> Open</a>
+              </article>
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            <div class="empty">Nothing needs attention.</div>
+          {% endif %}
+        {% endwith %}
       </div>
     </section>
 
     <!-- Performance (col 2) -->
     <section class="card eq" id="cardPerformance">
       <div class="card-header">
-        <h3><i class="fa-solid fa-chart-pie" aria-hidden="true"></i> <span id="perfTitle">Student Performance</span></h3>
+        <h3><i class="fa-solid fa-chart-pie"></i> <span id="perfTitle">Student Performance</span></h3>
         <div class="header-actions">
-          <div class="seg" role="tablist" aria-label="Performance views">
-            <button class="seg-btn active" data-view="performance" type="button" role="tab" aria-selected="true">Performance</button>
-            <button class="seg-btn" data-view="contribution" type="button" role="tab" aria-selected="false">Contribution</button>
+          <div class="seg">
+            <button class="seg-btn active" data-view="performance">Performance</button>
+            <button class="seg-btn" data-view="contribution">Contribution</button>
           </div>
         </div>
       </div>
-      <div class="chart-wrap donut" id="chartContainer" style="cursor: pointer;">
-        <canvas id="donutChart" aria-label="Performance donut chart" role="img"></canvas>
-        <div class="chart-legend" id="donutLegend" aria-live="polite"></div>
-        <div class="chart-click-hint" style="text-align:center;font-size:12px;color:#666;margin-top:10px;">
-          <i class="fa-solid fa-hand-pointer" aria-hidden="true"></i> Click to view proposal tracking
-        </div>
+      <div class="chart-wrap donut">
+        <canvas id="donutChart"></canvas>
+        <div class="chart-legend" id="donutLegend"></div>
       </div>
     </section>
 
     <!-- Calendar (col 3, row 1) -->
     <section class="card eq" id="cardCalendar">
       <div class="card-header">
-        <h3><i class="fa-regular fa-calendar" aria-hidden="true"></i> Calendar</h3>
+        <h3><i class="fa-regular fa-calendar"></i> Calendar</h3>
         <div class="header-actions">
-          <label for="visibilitySelect" class="visually-hidden">Visibility</label>
-          <a href="/suite/submit/?via=dashboard" class="chip-btn" id="addEventBtn" aria-label="Create a new event"><i class="fa-solid fa-plus" aria-hidden="true"></i> New Event</a>
+          <select id="visibilitySelect" class="select">
+            <option value="all">All</option>
+            <option value="private">Private</option>
+            <option value="staff">Teachers</option>
+          </select>
+          <a href="/suite/submit/?via=dashboard" class="chip-btn" id="addEventBtn"><i class="fa-solid fa-plus"></i> Add</a>
         </div>
       </div>
-      <div class="mini-cal" id="miniCalendar" aria-live="polite">
+      <div class="mini-cal" id="miniCalendar">
         <div class="cal-head">
-          <button class="cal-nav" id="calPrev" aria-label="Previous month"><i class="fa-solid fa-chevron-left" aria-hidden="true"></i></button>
-          <div id="calTitle" aria-live="polite">Month YYYY</div>
-          <button class="cal-nav" id="calNext" aria-label="Next month"><i class="fa-solid fa-chevron-right" aria-hidden="true"></i></button>
+          <button class="cal-nav" id="calPrev" aria-label="Previous month"><i class="fa-solid fa-chevron-left"></i></button>
+          <div id="calTitle">Month YYYY</div>
+          <button class="cal-nav" id="calNext" aria-label="Next month"><i class="fa-solid fa-chevron-right"></i></button>
         </div>
-        <div class="cal-weekdays" aria-hidden="true">
+        <div class="cal-weekdays">
           <span>S</span><span>M</span><span>T</span><span>W</span><span>T</span><span>F</span><span>S</span>
         </div>
-        <div class="cal-grid" id="calGrid" role="grid" aria-label="Monthly calendar"></div>
+        <div class="cal-grid" id="calGrid"></div>
       </div>
-      <div id="upcomingWrap" class="upcoming" aria-live="polite"></div>
+      <div id="upcomingWrap" class="upcoming"></div>
     </section>
 
+    <!-- Contribution (col 1–2, row 2) -->
     <!-- Contribution (span same width as Actions + Performance) -->
     <section class="card" id="cardContribution">
-      <div class="card-header"><h3><i class="fa-solid fa-fire" aria-hidden="true"></i> Yearly Contribution</h3></div>
-      <div id="heatmapContainer" class="heatmap" role="img" aria-label="Contribution heatmap"></div>
-    </section>
+        <div class="card-header"><h3><i class="fa-solid fa-fire"></i> Yearly Contribution</h3></div>
+        <div id="heatmapContainer" class="heatmap"></div>
+      </section>      
 
-    <!-- Event Details Viewer (col 3, row 2) -->
-    <section class="card eq" id="cardEventDetails">
+    <!-- To‑do (col 3, row 2) -->
+    <section class="card eq" id="cardTodo">
       <div class="card-header">
-        <h3><i class="fa-regular fa-calendar-days" aria-hidden="true"></i> Event Details</h3>
-        <button class="chip-btn" id="clearEventDetails" type="button" style="display: none;">
-          <i class="fa-solid fa-times" aria-hidden="true"></i> Clear
-        </button>
+        <h3><i class="fa-regular fa-square-check"></i> To-do</h3>
+        <button class="chip-btn" id="addTodo"><i class="fa-solid fa-plus"></i> Add</button>
       </div>
-      <div id="eventDetailsContent" class="event-details-content">
-        <div class="empty">Click an event in the calendar to view details</div>
-      </div>
+      <ul id="todoList" class="todo"></ul>
     </section>
   </main>
 
   {{ calendar_events|json_script:"calendarEventsJson" }}
   <script>
-    try {
-      window.DASHBOARD_EVENTS = JSON.parse(document.getElementById('calendarEventsJson').textContent);
-    } catch {
-      window.DASHBOARD_EVENTS = [];
-    }
+    try{window.DASHBOARD_EVENTS=JSON.parse(document.getElementById('calendarEventsJson').textContent);}catch{window.DASHBOARD_EVENTS=[];}
   </script>
-
-  <!-- Confirmation Modal -->
-  <div id="confirmationModal" class="modal-overlay" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
-    <div class="modal-content">
-      <h3 id="confirmTitle"><i class="fa-solid fa-question-circle" aria-hidden="true"></i> Open in Google Calendar?</h3>
-      <p>Do you want to open this event in Google Calendar?</p>
-      <div class="modal-actions">
-        <button class="btn-secondary" id="cancelConfirm" type="button">No, stay here</button>
-        <button class="btn-primary" id="confirmOpen" type="button">Yes, open Google Calendar</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Faculty Meeting Form Modal -->
-  <div id="facultyMeetingModal" class="modal-overlay" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="facultyModalTitle">
-    <div class="modal-content modal-large">
-      <div class="modal-header">
-        <h3 id="facultyModalTitle"><i class="fa-solid fa-calendar-plus" aria-hidden="true"></i> Schedule Faculty Meeting</h3>
-        <button class="modal-close" id="closeFacultyModal" type="button" aria-label="Close">&times;</button>
-      </div>
-      <form id="facultyMeetingForm" method="post" novalidate>
-        {% csrf_token %}
-        <div class="form-group">
-          <label for="meetingTitle">Meeting title *</label>
-          <input type="text" id="meetingTitle" required aria-required="true" placeholder="Enter meeting title">
-        </div>
-
-        <div class="form-row">
-          <div class="form-group">
-            <label for="meetingDate">Date *</label>
-            <input type="date" id="meetingDate" required aria-required="true">
-          </div>
-          <div class="form-group">
-            <label for="meetingTime">Time *</label>
-            <input type="time" id="meetingTime" required aria-required="true" value="09:00">
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label for="meetingPlace">Place/Venue</label>
-          <select id="meetingPlace">
-            <option value="">Select venue…</option>
-          </select>
-        </div>
-
-        <div class="form-group">
-          <label for="meetingParticipants">Participants</label>
-          <select id="meetingParticipants" multiple aria-describedby="participantsHelp">
-            <option value="">Loading participants…</option>
-          </select>
-          <small id="participantsHelp">Hold Ctrl (Windows) or Cmd (macOS) to select multiple participants.</small>
-        </div>
-
-        <div class="form-group">
-          <label for="meetingNotes">Additional notes</label>
-          <textarea id="meetingNotes" rows="3" placeholder="Add agenda or notes…"></textarea>
-        </div>
-
-        <div class="modal-actions">
-          <button type="button" class="btn-secondary" id="cancelMeeting">Cancel</button>
-          <button type="submit" class="btn-primary">
-            <i class="fa-solid fa-calendar-plus" aria-hidden="true"></i> Schedule meeting
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
-
-  <!-- Event Creation Modal -->
-  <div id="eventCreationModal" class="modal-overlay" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="eventModalTitle">
-    <div class="modal-content modal-large">
-      <div class="modal-header">
-        <h3 id="eventModalTitle"><i class="fa-solid fa-calendar-plus" aria-hidden="true"></i> Create New Event</h3>
-        <button class="modal-close" id="closeEventModal" type="button" aria-label="Close">&times;</button>
-      </div>
-      <form id="eventCreationForm" novalidate>
-        <div class="form-group">
-          <label for="eventTitle">Event title *</label>
-          <input type="text" id="eventTitle" required aria-required="true" placeholder="Enter event title">
-        </div>
-
-        <div class="form-group">
-          <label for="eventDescription">Description</label>
-          <textarea id="eventDescription" rows="3" placeholder="Add a short description…"></textarea>
-        </div>
-
-        <div class="form-row">
-          <div class="form-group">
-            <label for="eventDate">Date *</label>
-            <input type="date" id="eventDate" required aria-required="true">
-          </div>
-          <div class="form-group">
-            <label for="eventTime">Time *</label>
-            <input type="time" id="eventTime" required aria-required="true">
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label for="eventVenue">Venue</label>
-          <select id="eventVenue">
-            <option value="">Select venue…</option>
-          </select>
-        </div>
-
-        <div class="modal-actions">
-          <button type="button" class="btn-secondary" id="cancelEvent">Cancel</button>
-          <button type="submit" class="btn-primary">
-            <i class="fa-solid fa-calendar-plus" aria-hidden="true"></i> Create event
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Revert faculty dashboard template to original layout with fixed-width KPI row and classic profile card
- Restore legacy dashboard styling including compact KPI cards and profile tile rules

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b37fd04fb8832cb9b674a59b01291e