### PR TITLE
style: unify proposal form inputs

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -245,6 +245,23 @@
     color: #9ca3af;
   }
   .proposal-content .input-group textarea { resize: vertical; min-height: 100px; }
+
+  /* Reusable proposal input */
+  .proposal-input {
+    background-color: #f8f9fa !important;
+    border: 1px solid #ced4da !important;
+    border-radius: 0.25rem !important;
+    padding: 0.5rem 0.75rem !important;
+    transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+  }
+  .proposal-input:hover {
+    border-color: #adb5bd !important;
+  }
+  .proposal-input:focus {
+    outline: none !important;
+    border-color: #0d6efd !important;
+    box-shadow: 0 0 0 0.25rem rgba(13,110,253,.25) !important;
+  }
   
   /* Help text */
   .proposal-content .help-text { font-size: .75rem; color: var(--text-muted); margin-top: .25rem; }

--- a/emt/templates/emt/cdl_support.html
+++ b/emt/templates/emt/cdl_support.html
@@ -32,8 +32,8 @@
       <!-- CDL Support Toggle (Always visible) -->
       <div class="cdl-support-toggle">
         <div class="input-group">
-          <label for="{{ form.needs_support.id_for_label }}" class="cdl-toggle-label">
-            <input type="checkbox" id="{{ form.needs_support.id_for_label }}" name="{{ form.needs_support.name }}" {% if form.needs_support.value %}checked{% endif %}>
+            <label for="{{ form.needs_support.id_for_label }}" class="cdl-toggle-label">
+              <input type="checkbox" id="{{ form.needs_support.id_for_label }}" name="{{ form.needs_support.name }}" class="proposal-input" {% if form.needs_support.value %}checked{% endif %}>
             <span class="cdl-toggle-text">I need CDL support for this event</span>
           </label>
           <div class="help-text">Check this box to access Content Development Lab services</div>
@@ -49,7 +49,7 @@
             <h3 class="cdl-service-title"><i class="fa-solid fa-paintbrush"></i> Poster Support</h3>
             <div class="cdl-service-toggle">
               <label>
-                <input type="checkbox" id="{{ form.poster_required.id_for_label }}" name="{{ form.poster_required.name }}" {% if form.poster_required.value %}checked{% endif %}>
+                <input type="checkbox" id="{{ form.poster_required.id_for_label }}" name="{{ form.poster_required.name }}" class="proposal-input" {% if form.poster_required.value %}checked{% endif %}>
                 <span>Enable</span>
               </label>
             </div>
@@ -59,52 +59,52 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.poster_choice.id_for_label }}">Poster Choice</label>
-                {{ form.poster_choice }}
+                  {{ form.poster_choice.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Select your preferred poster style</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.organization_name.id_for_label }}">Organization Name</label>
-                {{ form.organization_name }}
+                  {{ form.organization_name.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Name of organizing body</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_time.id_for_label }}">Event Time</label>
-                {{ form.poster_time }}
+                  {{ form.poster_time.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Time for the event</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_date.id_for_label }}">Event Date</label>
-                {{ form.poster_date }}
+                  {{ form.poster_date.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Date of the event</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_venue.id_for_label }}">Event Venue</label>
-                {{ form.poster_venue }}
+                  {{ form.poster_venue.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Location where event will be held</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.resource_person_name.id_for_label }}">Resource Person Name</label>
-                {{ form.resource_person_name }}
+                  {{ form.resource_person_name.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Name of the main speaker/presenter</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.resource_person_designation.id_for_label }}">Resource Person Designation</label>
-                {{ form.resource_person_designation }}
+                  {{ form.resource_person_designation.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Title/position of the resource person</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_event_title.id_for_label }}">Event Title for Poster</label>
-                {{ form.poster_event_title }}
+                  {{ form.poster_event_title.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Title as it should appear on poster</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_summary.id_for_label }}">Event Summary</label>
-                {{ form.poster_summary }}
+                  {{ form.poster_summary.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Brief description for the poster</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_design_link.id_for_label }}">Design Link/Reference</label>
-                {{ form.poster_design_link }}
+                  {{ form.poster_design_link.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Link to design references or requirements</div>
               </div>
             </div>
@@ -121,7 +121,7 @@
             <h3 class="cdl-service-title"><i class="fa-solid fa-trophy"></i> Certificate Support</h3>
             <div class="cdl-service-toggle">
               <label>
-                <input type="checkbox" id="{{ form.certificates_required.id_for_label }}" name="{{ form.certificates_required.name }}" {% if form.certificates_required.value %}checked{% endif %}>
+                  <input type="checkbox" id="{{ form.certificates_required.id_for_label }}" name="{{ form.certificates_required.name }}" class="proposal-input" {% if form.certificates_required.value %}checked{% endif %}>
                 <span>Enable</span>
               </label>
             </div>
@@ -131,7 +131,7 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.certificate_help.id_for_label }}">Certificate Design Help</label>
-                <input type="checkbox" id="{{ form.certificate_help.id_for_label }}" name="{{ form.certificate_help.name }}" {% if form.certificate_help.value %}checked{% endif %}>
+                  <input type="checkbox" id="{{ form.certificate_help.id_for_label }}" name="{{ form.certificate_help.name }}" class="proposal-input" {% if form.certificate_help.value %}checked{% endif %}>
                 <div class="help-text">Do you need design assistance for certificates?</div>
               </div>
             </div>
@@ -140,12 +140,12 @@
               <div class="cdl-form-grid">
                 <div class="input-group">
                   <label for="{{ form.certificate_choice.id_for_label }}">Certificate Choice</label>
-                  {{ form.certificate_choice }}
+                    {{ form.certificate_choice.as_widget(attrs={'class': 'proposal-input'}) }}
                   <div class="help-text">Select your preferred certificate style</div>
                 </div>
                 <div class="input-group">
                   <label for="{{ form.certificate_design_link.id_for_label }}">Design Link/Reference</label>
-                  {{ form.certificate_design_link }}
+                    {{ form.certificate_design_link.as_widget(attrs={'class': 'proposal-input'}) }}
                   <div class="help-text">Link to design references or requirements</div>
                 </div>
               </div>
@@ -167,7 +167,7 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.other_services.id_for_label }}">Additional Services</label>
-                {{ form.other_services }}
+                  {{ form.other_services.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Describe any other CDL services you need</div>
               </div>
             </div>
@@ -184,7 +184,7 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.blog_content.id_for_label }}">Blog Content</label>
-                {{ form.blog_content }}
+                  {{ form.blog_content.as_widget(attrs={'class': 'proposal-input'}) }}
                 <div class="help-text">Provide up to 150 words for blog content</div>
               </div>
             </div>

--- a/emt/templates/emt/expense_details.html
+++ b/emt/templates/emt/expense_details.html
@@ -28,11 +28,11 @@
         {% for form in formset %}
           <div class="section expense-form">
             <h4>Expense {{ forloop.counter }}</h4>
-            <div class="input-group">{{ form.sl_no.label_tag }} {{ form.sl_no }}</div>
-            <div class="input-group">{{ form.particulars.label_tag }} {{ form.particulars }}</div>
-            <div class="input-group">{{ form.amount.label_tag }} {{ form.amount }}</div>
+            <div class="input-group">{{ form.sl_no.label_tag }} {{ form.sl_no.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.particulars.label_tag }} {{ form.particulars.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.amount.label_tag }} {{ form.amount.as_widget(attrs={'class': 'proposal-input'}) }}</div>
             {% if form.DELETE %}
-              <div class="input-group">{{ form.DELETE }} Remove this expense</div>
+              <div class="input-group">{{ form.DELETE.as_widget(attrs={'class': 'proposal-input'}) }} Remove this expense</div>
             {% endif %}
           </div>
           <hr>

--- a/emt/templates/emt/speaker_profile.html
+++ b/emt/templates/emt/speaker_profile.html
@@ -23,16 +23,16 @@
         {% for form in formset %}
           <div class="section speaker-form">
             <h4>Speaker {{ forloop.counter }}</h4>
-            <div class="input-group">{{ form.full_name.label_tag }} {{ form.full_name }}</div>
-            <div class="input-group">{{ form.designation.label_tag }} {{ form.designation }}</div>
-            <div class="input-group">{{ form.affiliation.label_tag }} {{ form.affiliation }}</div>
-            <div class="input-group">{{ form.contact_email.label_tag }} {{ form.contact_email }}</div>
-            <div class="input-group">{{ form.contact_number.label_tag }} {{ form.contact_number }}</div>
-            <div class="input-group">{{ form.linkedin_url.label_tag }} {{ form.linkedin_url }}</div>
-            <div class="input-group">{{ form.photo.label_tag }} {{ form.photo }}<img class="linkedin-photo" style="max-width:100px; display:none;"/></div>
-            <div class="input-group">{{ form.detailed_profile.label_tag }} {{ form.detailed_profile }}</div>
+            <div class="input-group">{{ form.full_name.label_tag }} {{ form.full_name.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.designation.label_tag }} {{ form.designation.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.affiliation.label_tag }} {{ form.affiliation.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.contact_email.label_tag }} {{ form.contact_email.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.contact_number.label_tag }} {{ form.contact_number.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.linkedin_url.label_tag }} {{ form.linkedin_url.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            <div class="input-group">{{ form.photo.label_tag }} {{ form.photo.as_widget(attrs={'class': 'proposal-input'}) }}<img class="linkedin-photo" style="max-width:100px; display:none;"/></div>
+            <div class="input-group">{{ form.detailed_profile.label_tag }} {{ form.detailed_profile.as_widget(attrs={'class': 'proposal-input'}) }}</div>
             {% if form.DELETE %}
-              <div class="input-group">{{ form.DELETE }} Remove this speaker</div>
+              <div class="input-group">{{ form.DELETE.as_widget(attrs={'class': 'proposal-input'}) }} Remove this speaker</div>
             {% endif %}
           </div>
           <hr>

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -108,10 +108,10 @@
 
         <form method="post" enctype="multipart/form-data" id="proposal-form" autocomplete="off">
             {% csrf_token %}
-            <textarea id="id_need_analysis" name="need_analysis" hidden>{{ need_analysis.content|default_if_none:'' }}</textarea>
-            <textarea id="id_objectives" name="objectives" hidden>{{ objectives.content|default_if_none:'' }}</textarea>
-            <textarea id="id_learning_outcomes" name="outcomes" hidden>{{ outcomes.content|default_if_none:'' }}</textarea>
-            <textarea name="flow" hidden>{{ flow.content|default_if_none:'' }}</textarea>
+            <textarea id="id_need_analysis" name="need_analysis" class="proposal-input" hidden>{{ need_analysis.content|default_if_none:'' }}</textarea>
+            <textarea id="id_objectives" name="objectives" class="proposal-input" hidden>{{ objectives.content|default_if_none:'' }}</textarea>
+            <textarea id="id_learning_outcomes" name="outcomes" class="proposal-input" hidden>{{ outcomes.content|default_if_none:'' }}</textarea>
+            <textarea name="flow" class="proposal-input" hidden>{{ flow.content|default_if_none:'' }}</textarea>
 
             <div class="form-panel" id="form-panel">
                 <div class="form-panel-content" id="form-panel-content">
@@ -151,13 +151,13 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="event-title-modern">Event Title *</label>
-                                <input type="text" id="event-title-modern" required placeholder="Enter a descriptive event title">
+                                <input type="text" id="event-title-modern" class="proposal-input" required placeholder="Enter a descriptive event title">
                                 <div class="help-text">Provide a clear and engaging title for your event</div>
                             </div>
                             <div class="input-group">
                                 <label for="target-audience-modern">Target Audience *</label>
-                                <input type="text" id="target-audience-modern" required readonly placeholder="Select target audience">
-                                <input type="hidden" name="target_audience_class_ids" id="target-audience-class-ids">
+                                <input type="text" id="target-audience-modern" class="proposal-input" required readonly placeholder="Select target audience">
+                <input type="hidden" name="target_audience_class_ids" id="target-audience-class-ids" class="proposal-input">
                                 <div class="help-text">Specify who this event is intended for</div>
                             </div>
                         </div>
@@ -165,12 +165,12 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="event-focus-type-modern">Event Focus Type</label>
-                                <input type="text" id="event-focus-type-modern" placeholder="Enter event focus">
+                                <input type="text" id="event-focus-type-modern" class="proposal-input" placeholder="Enter event focus">
                                 <div class="help-text">Specify the primary focus of your event</div>
                             </div>
                             <div class="input-group">
                                 <label for="venue-modern">Location</label>
-                                <input type="text" id="venue-modern" placeholder="e.g., Main Auditorium, Online">
+                                <input type="text" id="venue-modern" class="proposal-input" placeholder="e.g., Main Auditorium, Online">
                                 <div class="help-text">Specify where the event will take place</div>
                             </div>
                         </div>
@@ -183,12 +183,12 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="event-start-date">Start Date *</label>
-                                <input type="date" id="event-start-date" required>
+                                <input type="date" id="event-start-date" class="proposal-input" required>
                                 <div class="help-text">When does your event begin?</div>
                             </div>
                             <div class="input-group">
                                 <label for="event-end-date">End Date *</label>
-                                <input type="date" id="event-end-date" required>
+                                <input type="date" id="event-end-date" class="proposal-input" required>
                                 <div class="help-text">When does your event end?</div>
                             </div>
                         </div>
@@ -196,13 +196,13 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
-                                <input type="text" id="academic-year-modern" value="{{ form.academic_year.value|default:'' }}" disabled>
-                                <input type="hidden" name="academic_year" id="academic-year-hidden" value="{{ form.academic_year.value|default:'' }}">
+                                <input type="text" id="academic-year-modern" class="proposal-input" value="{{ form.academic_year.value|default:'' }}" disabled>
+                                <input type="hidden" name="academic_year" id="academic-year-hidden" class="proposal-input" value="{{ form.academic_year.value|default:'' }}">
                                 <div class="help-text">Academic year for which this event is planned</div>
                             </div>
                             <div class="input-group">
                                 <label for="pos-pso-modern">POS & PSO Management</label>
-                                <textarea id="pos-pso-modern" name="pos_pso" rows="2" placeholder="e.g., PO1, PSO2"></textarea>
+                                <textarea id="pos-pso-modern" name="pos_pso" class="proposal-input" rows="2" placeholder="e.g., PO1, PSO2"></textarea>
                                 <div class="help-text">Program outcomes and specific outcomes addressed</div>
                             </div>
                         </div>
@@ -215,7 +215,7 @@
                         <div class="form-row full-width">
                             <div class="input-group">
                                 <label for="sdg-goals-modern">Aligned SDG Goals</label>
-                                <input type="text" id="sdg-goals-modern" placeholder="Select SDG goals">
+                                <input type="text" id="sdg-goals-modern" class="proposal-input" placeholder="Select SDG goals">
                                 <div class="help-text">Specify which Sustainable Development Goals this event addresses</div>
                             </div>
                         </div>
@@ -228,7 +228,7 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="num-activities-modern">Number of Activities</label>
-                                <input type="number" id="num-activities-modern" name="num_activities" min="1" max="50" placeholder="Enter number of activities">
+                                <input type="number" id="num-activities-modern" name="num_activities" class="proposal-input" min="1" max="50" placeholder="Enter number of activities">
                                 <div class="help-text">How many activities will your event include?</div>
                             </div>
                             <div class="input-group">
@@ -288,7 +288,7 @@
                     {{ form.pos_pso }}
                     {{ form.committees_collaborations.label_tag }}
                     {{ form.committees_collaborations }}
-                    <input type="hidden" name="committees_collaborations_ids" id="committees-collaborations-ids">
+                    <input type="hidden" name="committees_collaborations_ids" id="committees-collaborations-ids" class="proposal-input">
                     {{ form.sdg_goals.label_tag }}
                     {{ form.sdg_goals }}
                     {{ form.student_coordinators.label_tag }}


### PR DESCRIPTION
## Summary
- add `.proposal-input` utility class with hover and focus states
- apply `.proposal-input` to proposal form fields across templates

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b383a41788832cbc649369c3b1da12