### PR TITLE
Remove duplicate Academic Year label in proposal template

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -196,8 +196,6 @@
                         <div class="form-row">
                             <div class="input-group">
                                 <label for="academic-year-modern">Academic Year *</label>
-
-                                <label for="academic-year-modern">Academic Year *</label>
                                 <input type="text" id="academic-year-modern" class="proposal-input"
                                        value="{{ form.academic_year.value|default:'' }}" disabled>
                                 <input type="hidden" name="academic_year" id="academic-year-hidden"


### PR DESCRIPTION
## Summary
- remove duplicate `Academic Year` label in proposal template to prevent redundant output

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b39049ea78832cb662ff627223277e