### PR TITLE
Allow proposal autosave to succeed with validation errors

### DIFF
--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -364,7 +364,9 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertFalse(data.get("success"))
+        # Autosave should succeed but return validation warnings for
+        # incomplete activity rows.
+        self.assertTrue(data.get("success"))
         self.assertIn("activities", data.get("errors", {}))
         self.assertIn("date", data["errors"]["activities"]["1"])
 
@@ -378,7 +380,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertFalse(data.get("success"))
+        self.assertTrue(data.get("success"))
         self.assertIn("speakers", data.get("errors", {}))
         self.assertIn("designation", data["errors"]["speakers"]["0"])
 
@@ -398,7 +400,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertFalse(data.get("success"))
+        self.assertTrue(data.get("success"))
         self.assertIn("speakers", data.get("errors", {}))
         self.assertIn("full_name", data["errors"]["speakers"]["0"])
 
@@ -464,7 +466,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertFalse(data.get("success"))
+        self.assertTrue(data.get("success"))
         self.assertIn("organization", data.get("errors", {}))
         self.assertEqual(Organization.objects.filter(name="Science Club").count(), 0)
 
@@ -540,7 +542,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp2.status_code, 200)
         data = resp2.json()
-        self.assertFalse(data.get("success"))
+        self.assertTrue(data.get("success"))
         self.assertIn("flow", data.get("errors", {}))
 
 

--- a/emt/views.py
+++ b/emt/views.py
@@ -780,7 +780,11 @@ def autosave_proposal(request):
         list(proposal.faculty_incharges.values_list("id", flat=True)),
     )
 
-    response = {"success": not errors, "proposal_id": proposal.id}
+    # Always report success so that drafts are stored even when validation
+    # errors are present. The frontend will surface any issues using the
+    # returned ``errors`` map but the save itself should not be treated as a
+    # failure.
+    response = {"success": True, "proposal_id": proposal.id}
     if errors:
         response["errors"] = errors
     return JsonResponse(response)


### PR DESCRIPTION
## Summary
- Always return `success: true` from proposal autosave and include validation errors separately
- Update autosave tests to expect success even when warnings are returned

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b394675ed0832c9c537829943f2da3