### PR TITLE
Fix template rendering for CDL support form

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -420,6 +420,12 @@ class CDLSupportForm(forms.ModelForm):
             "poster_summary": forms.Textarea(attrs={"rows": 4}),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            existing = field.widget.attrs.get("class", "")
+            field.widget.attrs["class"] = f"{existing} proposal-input".strip()
+
     def clean_poster_summary(self):
         text = self.cleaned_data.get("poster_summary", "").strip()
         if text and len(text.split()) > 150:

--- a/emt/templates/emt/cdl_support.html
+++ b/emt/templates/emt/cdl_support.html
@@ -59,52 +59,52 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.poster_choice.id_for_label }}">Poster Choice</label>
-                  {{ form.poster_choice.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_choice }}
                 <div class="help-text">Select your preferred poster style</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.organization_name.id_for_label }}">Organization Name</label>
-                  {{ form.organization_name.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.organization_name }}
                 <div class="help-text">Name of organizing body</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_time.id_for_label }}">Event Time</label>
-                  {{ form.poster_time.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_time }}
                 <div class="help-text">Time for the event</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_date.id_for_label }}">Event Date</label>
-                  {{ form.poster_date.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_date }}
                 <div class="help-text">Date of the event</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_venue.id_for_label }}">Event Venue</label>
-                  {{ form.poster_venue.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_venue }}
                 <div class="help-text">Location where event will be held</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.resource_person_name.id_for_label }}">Resource Person Name</label>
-                  {{ form.resource_person_name.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.resource_person_name }}
                 <div class="help-text">Name of the main speaker/presenter</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.resource_person_designation.id_for_label }}">Resource Person Designation</label>
-                  {{ form.resource_person_designation.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.resource_person_designation }}
                 <div class="help-text">Title/position of the resource person</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_event_title.id_for_label }}">Event Title for Poster</label>
-                  {{ form.poster_event_title.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_event_title }}
                 <div class="help-text">Title as it should appear on poster</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_summary.id_for_label }}">Event Summary</label>
-                  {{ form.poster_summary.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_summary }}
                 <div class="help-text">Brief description for the poster</div>
               </div>
               <div class="input-group">
                 <label for="{{ form.poster_design_link.id_for_label }}">Design Link/Reference</label>
-                  {{ form.poster_design_link.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.poster_design_link }}
                 <div class="help-text">Link to design references or requirements</div>
               </div>
             </div>
@@ -140,12 +140,12 @@
               <div class="cdl-form-grid">
                 <div class="input-group">
                   <label for="{{ form.certificate_choice.id_for_label }}">Certificate Choice</label>
-                    {{ form.certificate_choice.as_widget(attrs={'class': 'proposal-input'}) }}
+                    {{ form.certificate_choice }}
                   <div class="help-text">Select your preferred certificate style</div>
                 </div>
                 <div class="input-group">
                   <label for="{{ form.certificate_design_link.id_for_label }}">Design Link/Reference</label>
-                    {{ form.certificate_design_link.as_widget(attrs={'class': 'proposal-input'}) }}
+                    {{ form.certificate_design_link }}
                   <div class="help-text">Link to design references or requirements</div>
                 </div>
               </div>
@@ -167,7 +167,7 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.other_services.id_for_label }}">Additional Services</label>
-                  {{ form.other_services.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.other_services }}
                 <div class="help-text">Describe any other CDL services you need</div>
               </div>
             </div>
@@ -184,7 +184,7 @@
             <div class="cdl-form-grid">
               <div class="input-group">
                 <label for="{{ form.blog_content.id_for_label }}">Blog Content</label>
-                  {{ form.blog_content.as_widget(attrs={'class': 'proposal-input'}) }}
+                  {{ form.blog_content }}
                 <div class="help-text">Provide up to 150 words for blog content</div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- avoid template syntax errors by rendering CDL support fields directly
- assign common `proposal-input` class to form widgets in `CDLSupportForm`

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3988b8fe8832c9348e958efefdb87