### PR TITLE
feat(static): fix prod static on Render via WhiteNoise, correct static paths, add hosts & csrf

### DIFF
--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 import os
+from decouple import config
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
 try:
     from dotenv import load_dotenv
-    BASE_DIR = Path(__file__).resolve().parent.parent
     load_dotenv(dotenv_path=BASE_DIR / ".env")
 except Exception:
     pass
@@ -53,18 +56,20 @@ OPENROUTER_MODEL   = _env("OPENROUTER_MODEL", default="qwen/qwen3.5:free")
 
 # SECRET_KEY loaded from environment with a development fallback
 SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-…')
-DEBUG = True
-
+DEBUG = config("DEBUG", default="False").lower() == "true"
 ALLOWED_HOSTS = [
-    '127.0.0.1',
-    'localhost',
-    '192.168.0.104',
-    '7c40-103-229-129-85.ngrok-free.app',
+    "iqac-suite.onrender.com",
+    ".onrender.com",
+    "localhost",
+    "127.0.0.1",
 ]
 
 CSRF_TRUSTED_ORIGINS = [
-    "https://7c40-103-229-129-85.ngrok-free.app",
+    "https://iqac-suite.onrender.com",
+    "https://*.onrender.com",
 ]
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # ──────────────────────────────────────────────────────────────────────────────
 # INSTALLED APPS
@@ -77,6 +82,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    # 3rd-party
+    # whitenoise has no app entry; it’s middleware only
     'django.contrib.sites',  # ← required by allauth
     'django_extensions',
 
@@ -86,18 +93,18 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
 
-    # Your apps
+    # local apps
     'core.apps.CoreConfig',
     'emt',
     'transcript',
 ]
-
-ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 # ──────────────────────────────────────────────────────────────────────────────
 # MIDDLEWARE
 # ──────────────────────────────────────────────────────────────────────────────
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    # WhiteNoise must come right after SecurityMiddleware
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -211,16 +218,21 @@ USE_TZ = True
 # ──────────────────────────────────────────────────────────────────────────────
 # STATIC FILES
 # ──────────────────────────────────────────────────────────────────────────────
-STATIC_URL = '/static/'
-STATICFILES_DIRS = [
-    BASE_DIR / 'static',
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_DIRS = [BASE_DIR / "static"] if (BASE_DIR / "static").exists() else []
+
+# WhiteNoise: hashed filenames + gzip/brotli
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+# Ensure default finders are present
+STATICFILES_FINDERS = [
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
-STATIC_ROOT = BASE_DIR / 'staticfiles'
 
-# settings.py
-
-MEDIA_URL = '/media/'
-MEDIA_ROOT = BASE_DIR / 'media'
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
 
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
@@ -289,14 +301,3 @@ LOGGING = {
         },
     },
 }
-ALLOWED_HOSTS = ["iqac-suite.onrender.com", "localhost", "127.0.0.1"]
-
-RENDER_EXTERNAL_HOSTNAME = os.getenv("RENDER_EXTERNAL_HOSTNAME")
-if RENDER_EXTERNAL_HOSTNAME:
-    # e.g. "iqac-suite.onrender.com"
-    ALLOWED_HOSTS.append(RENDER_EXTERNAL_HOSTNAME)
-    CSRF_TRUSTED_ORIGINS = ["https://iqac-suite.onrender.com"]
-else:
-    # fallback for local/dev or if you want to be permissive temporarily
-    # ALLOWED_HOSTS.append("iqac-suite.onrender.com")   # <-- you can hardcode your URL too
-    pass

--- a/scripts/check_static.sh
+++ b/scripts/check_static.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+python manage.py findstatic emt/css/styles.css || true
+python manage.py collectstatic --noinput
+python - <<'PY'
+import os, django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "iqac_project.settings")
+django.setup()
+from django.conf import settings
+print("STATIC_URL:", settings.STATIC_URL)
+print("STATIC_ROOT exists:", (settings.BASE_DIR / "staticfiles").exists())
+PY


### PR DESCRIPTION
## Summary
- serve static files via WhiteNoise with compressed manifest storage
- configure Render hosts, CSRF origins, and proxy SSL header
- add helper script to verify collectstatic output

## Testing
- `./scripts/check_static.sh`
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test` *(fails: TemplateDoesNotExist: core/user_dashboard.html)*

------
https://chatgpt.com/codex/tasks/task_e_68b62c0b89e0832cb737b2f00bd471d6