### PR TITLE
fix: improve sidebar permission filters

### DIFF
--- a/templates/core_admin/sidebar_permissions.html
+++ b/templates/core_admin/sidebar_permissions.html
@@ -98,7 +98,7 @@
 
       <label class="filter">
         <span>Organization Role</span>
-        <select id="orgRoleSelect" {% if not selected_org_type %}disabled{% endif %} aria-label="Organization Role">
+        <select id="orgRoleSelect" aria-label="Organization Role">
           <option value="">All Roles</option>
           {% for r in org_roles %}
             <option value="{{ r.id }}" {% if selected_org_role == r.id|stringformat:'s' %}selected{% endif %}>{{ r.name }}</option>


### PR DESCRIPTION
## Summary
- allow selecting organization roles regardless of organization type
- deduplicate role options and trim blank user names

## Testing
- `python manage.py test core.tests.test_sidebar_permissions -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b6333c654c832cb8b4f1bc62d2eadd