### PR TITLE
Adjust top bar text scope and restore bell icon styling

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -168,7 +168,7 @@ body.command-center-layout{
 #sidebarToggle span,
 #sidebarToggle span span{ background:#ffffff !important; }
 
-.utility-right{ display:flex; align-items:center; gap:1.5rem; color:#ffffff !important; }
+.utility-right{ display:flex; align-items:center; gap:1.5rem; }
 /* Limit white text to topbar controls only */
 .utility-right > *{ color:#ffffff; }
 
@@ -179,10 +179,7 @@ body.command-center-layout{
   display:inline-flex; align-items:center; justify-content:center;
   background:transparent; border:0; cursor:pointer;
 }
-.notification-section .notification-btn > i.fa-bell,
-.notification-section .notification-btn > i.fa-solid.fa-bell,
-.notification-section .notification-btn > i.fa-bell::before,
-.notification-section .notification-btn > i.fa-solid.fa-bell::before{
+.notification-section .notification-btn > i.fa-bell{
   font-family:"Font Awesome 6 Free", var(--fa-font-solid,"Font Awesome 6 Free") !important;
   font-weight:900 !important;
   font-size:1.35rem !important;


### PR DESCRIPTION
## Summary
- scope utility bar color so only top-level items render white
- restore notification bell icon styling with gold Font Awesome glyph
- ensure dropdown menus use dark ink text

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at yamanote.proxy.rlwy.net refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b636a31400832c99a3e2b88f59714b