### PR TITLE
Add notification bell and dropdown styling

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -179,7 +179,7 @@ body.command-center-layout{
   display:inline-flex; align-items:center; justify-content:center;
   background:transparent; border:0; cursor:pointer;
 }
-.notification-section .notification-btn > i.fa-bell{
+.notification-btn .notification-icon{
   font-family:"Font Awesome 6 Free", var(--fa-font-solid,"Font Awesome 6 Free") !important;
   font-weight:900 !important;
   font-size:1.35rem !important;
@@ -224,6 +224,20 @@ body.command-center-layout{
   opacity:0; visibility:hidden; transform:translateY(-10px); transition:var(--tr); z-index:1000; color:var(--ink-900);
 }
 .profile-dropdown.active{ opacity:1; visibility:visible; transform:translateY(0); }
+.profile-dropdown .dropdown-header{
+  padding:.75rem 1rem;
+  border-bottom:1px solid var(--gray-200);
+}
+.profile-dropdown .user-info strong{ display:block; }
+.profile-dropdown .user-info small{ color:var(--muted-500); }
+.profile-dropdown .dropdown-item{
+  display:flex; align-items:center; gap:.5rem;
+  padding:.5rem 1rem; color:var(--ink-900); text-decoration:none;
+}
+.profile-dropdown .dropdown-item:hover{ background:var(--gray-050); }
+.profile-dropdown .dropdown-divider{
+  height:1px; background:var(--gray-200); margin:.25rem 0;
+}
 
 /* =============================================================================
    LEFT CONTROL PANEL

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,8 +53,8 @@
 
       <div class="utility-right" style="display: flex; align-items: center; gap: 1.5rem;">
         <div class="notification-section">
-          <button class="utility-btn notification-btn" id="notificationBtn" aria-label="Notifications">
-            <i class="fa-solid fa-bell"></i>
+          <button class="utility-btn notification-btn" id="notificationBtn" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">
+            <i class="fa-solid fa-bell notification-icon"></i>
             {% if notifications and notifications|length > 0 %}
             <span class="notification-badge" id="notificationBadge">{{ notifications|length }}</span>
             {% endif %}
@@ -356,8 +356,9 @@
       if (notificationBtn && notificationDropdown) {
         notificationBtn.addEventListener('click', function(e) {
           e.stopPropagation();
-          notificationDropdown.classList.toggle('active');
-          
+          const expanded = notificationDropdown.classList.toggle('active');
+          notificationBtn.setAttribute('aria-expanded', expanded);
+
           // Close profile dropdown if open
           const profileDropdown = document.querySelector('.profile-dropdown');
           if (profileDropdown) profileDropdown.classList.remove('active');
@@ -405,7 +406,10 @@
         if (profileDropdown && !e.target.closest('.profile-section')) profileDropdown.classList.remove('active');
 
         const notificationDropdown = document.getElementById('notificationDropdown');
-        if (notificationDropdown && !e.target.closest('.notification-section')) notificationDropdown.classList.remove('active');
+        if (notificationDropdown && !e.target.closest('.notification-section')) {
+          notificationDropdown.classList.remove('active');
+          if (notificationBtn) notificationBtn.setAttribute('aria-expanded', false);
+        }
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- Add notification bell button with accessibility attributes to header
- Style profile dropdown and notification icon
- Update dropdown script to toggle accessibility state

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6399f6050832c842b19038b89c9cd