### PR TITLE
refine notification bell styling

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -184,6 +184,7 @@ body.command-center-layout{
   font-weight:900 !important;
   font-size:1.35rem !important;
   line-height:1 !important;
+  width:auto; height:auto; background:none;
   color:var(--gold-accent) !important;
 }
 .notification-badge{
@@ -206,7 +207,7 @@ body.command-center-layout{
 .notification-list{ max-height:400px; overflow-y:auto; }
 .notification-item{ display:flex; gap:.75rem; padding:.75rem 1rem; border-bottom:1px solid var(--gray-100); }
 .notification-item.unread{ background:var(--gray-050); }
-.notification-icon{ width:32px; height:32px; border-radius:50%; display:grid; place-items:center; background:var(--gray-200); color:var(--christ-blue); }
+.notification-item .notification-icon{ width:32px; height:32px; border-radius:50%; display:grid; place-items:center; background:var(--gray-200); color:var(--christ-blue); }
 
 /* Profile (gold avatar) */
 .profile-section{ position:relative; }


### PR DESCRIPTION
## Summary
- avoid unwanted gray background on header notification bell
- ensure bell icon inherits gold accent and reset default sizing

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63b5498e0832c9cbd3043cf2b54a1