### PR TITLE
feat: enhance sidebar permissions

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -798,34 +798,46 @@ class SidebarPermission(models.Model):
         if role and role.lower() == "admin":
             return "ALL"
 
-        allowed = set()
-
-        # --- Role-based permissions ---
-        if role:
-            role_perm = cls.objects.filter(role__iexact=role).first()
-            if role_perm:
-                allowed.update(role_perm.items)
+        allowed: set[str] = set()
 
         # --- User-specific overrides ---
-        user_perm = cls.objects.filter(user=user).first()
+        user_perm = cls.objects.filter(user=user, role__in=["", None]).first()
         if user_perm:
             allowed.update(user_perm.items)
 
-        # --- Expand to include parents ---
+        # --- Organization role assignments ---
+        role_ids = RoleAssignment.objects.filter(user=user).values_list("role_id", flat=True)
+        if role_ids:
+            role_keys = [f"orgrole:{rid}" for rid in role_ids]
+            for perm in cls.objects.filter(user__isnull=True, role__in=role_keys):
+                allowed.update(perm.items)
+
+        # --- Legacy role fallback ---
+        if not allowed and role:
+            role_perm = cls.objects.filter(user__isnull=True, role__iexact=role).first()
+            if role_perm:
+                allowed.update(role_perm.items)
+
+        # --- Expand to include parents and legacy aliases ---
         def expand_with_parents(selected_ids, navs):
             expanded = set(selected_ids)
 
-            def recurse(items, parent_id=None):
+            def recurse(items):
                 for item in items:
-                    if "children" in item:
-                        for child in item["children"]:
+                    children = item.get("children")
+                    if children:
+                        for child in children:
                             if child["id"] in expanded:
-                                expanded.add(item["id"])  # ensure parent is included
-                        recurse(item["children"], item["id"])
+                                expanded.add(item["id"])
+                        recurse(children)
             recurse(navs)
+            # Add leaf aliases for backwards compatibility (e.g. events:submit_proposal → submit_proposal)
+            for item in list(expanded):
+                if ":" in item:
+                    expanded.add(item.split(":", 1)[1])
             return expanded
 
-        return list(expand_with_parents(allowed, NAV_ITEMS))
+        return sorted(expand_with_parents(allowed, NAV_ITEMS))
 
 class DashboardAssignment(models.Model):
     """Stores dashboard assignments for users and roles."""

--- a/templates/core_admin/sidebar_permissions.html
+++ b/templates/core_admin/sidebar_permissions.html
@@ -113,6 +113,7 @@
             <option value="{{ u.id }}" {% if selected_user == u.id|stringformat:'s' %}selected{% endif %}>{{ u.name }}</option>
           {% endfor %}
         </select>
+        <button type="button" id="selectAllUsersBtn" class="btn btn-secondary" style="margin-top:4px;">Select All Users</button>
         <small class="hint">Use Ctrl/Command to select multiple users. Navbar updates may require logout/login.</small>
       </label>
 
@@ -240,7 +241,8 @@ let selectedAssigned  = new Set();
     const assignedEmpty =$('#assignedEmpty');
     const globalSearch  =$('#globalSearch');
   const userSelect=$('#userSelect');
-    const orgTypeSelect=$('#orgTypeSelect'); 
+  const selectAllUsersBtn=$('#selectAllUsersBtn');
+    const orgTypeSelect=$('#orgTypeSelect');
     const orgRoleSelect=$('#orgRoleSelect');
     const changeIndicator=$('#changeIndicator');
 
@@ -424,7 +426,10 @@ document.getElementById('permissionsForm').addEventListener('submit', e => {
 
   userSelect.addEventListener('change',()=>{
     const ids=Array.from(userSelect.selectedOptions).map(o=>o.value).filter(Boolean);
-    if(ids.length<=1) reloadWithFilters();
+    if(ids.length===1) reloadWithFilters();
+  });
+  selectAllUsersBtn?.addEventListener('click',()=>{
+    Array.from(userSelect.options).forEach(o=>o.selected=true);
   });
     if(orgTypeSelect) orgTypeSelect.addEventListener('change',()=>{ if(!orgTypeSelect.value){ orgRoleSelect && (orgRoleSelect.value=''); } reloadWithFilters(); });
     if(orgRoleSelect) orgRoleSelect.addEventListener('change',()=> reloadWithFilters());


### PR DESCRIPTION
## Summary
- merge user-specific and role-based sidebar permissions
- allow admins to select all users when assigning sidebar items
- refine user filter reload behavior on permissions page

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b63e56f570832cbb81d29b4b897d8a