### PR TITLE
Improve notification and profile overlays

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -152,7 +152,8 @@ body.command-center-layout{
   box-shadow:var(--shadow-md);
   display:flex; align-items:center; justify-content:space-between;
   padding:0 var(--sp-4);
-  z-index:40;
+  position:relative;
+  z-index:2000;
 }
 
 /* Hide the campus logo image (keep text) */
@@ -200,7 +201,7 @@ body.command-center-layout{
   width:320px; max-width:90vw; max-height:500px;
   background:#fff; border:1px solid var(--gray-200); border-radius:12px;
   box-shadow:var(--shadow-lg); opacity:0; visibility:hidden; transform:translateY(-10px);
-  transition:var(--tr); z-index:1000; overflow:hidden; color:var(--ink-900);
+  transition:var(--tr); z-index:20000; overflow:hidden; color:var(--ink-900);
 }
 .notification-dropdown.active{ opacity:1; visibility:visible; transform:translateY(0); }
 .notification-header{ display:flex; align-items:center; justify-content:space-between; padding:.75rem 1rem; border-bottom:1px solid var(--gray-200); }
@@ -222,7 +223,7 @@ body.command-center-layout{
 .profile-dropdown{
   position:absolute; top:calc(100% + .5rem); right:0; min-width:200px; background:#fff;
   border:1px solid var(--gray-200); border-radius:12px; box-shadow:var(--shadow-lg);
-  opacity:0; visibility:hidden; transform:translateY(-10px); transition:var(--tr); z-index:1000; color:var(--ink-900);
+  opacity:0; visibility:hidden; transform:translateY(-10px); transition:var(--tr); z-index:20000; color:var(--ink-900);
 }
 .profile-dropdown.active{ opacity:1; visibility:visible; transform:translateY(0); }
 .profile-dropdown .dropdown-header{

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,7 @@
       <div class="utility-right" style="display: flex; align-items: center; gap: 1.5rem;">
         <div class="notification-section">
           <button class="utility-btn notification-btn" id="notificationBtn" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">
-            <i class="fa-solid fa-bell notification-icon"></i>
+            <i class="fa-regular fa-bell notification-icon"></i>
             {% if notifications and notifications|length > 0 %}
             <span class="notification-badge" id="notificationBadge">{{ notifications|length }}</span>
             {% endif %}


### PR DESCRIPTION
## Summary
- Use cleaner Font Awesome bell icon in header
- Raise z-index for notification and profile dropdowns so they display above other content

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b63f0c8e20832cb40c049c3a8ed7c9