### PR TITLE
Use solid bell icon in header

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,7 @@
       <div class="utility-right" style="display: flex; align-items: center; gap: 1.5rem;">
         <div class="notification-section">
           <button class="utility-btn notification-btn" id="notificationBtn" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">
-            <i class="fa-regular fa-bell notification-icon"></i>
+            <i class="fa-solid fa-bell notification-icon"></i>
             {% if notifications and notifications|length > 0 %}
             <span class="notification-badge" id="notificationBadge">{{ notifications|length }}</span>
             {% endif %}


### PR DESCRIPTION
## Summary
- switch header notification bell to solid Font Awesome icon so it consistently displays

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b75d7f88a4832ca5a25134fa6f6ef9