### PR TITLE
Fix notification badge positioning

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -189,7 +189,10 @@ body.command-center-layout{
   color:var(--gold-accent) !important;
 }
 .notification-badge{
-  position:absolute; top:-.35rem; right:-.35rem;
+  position:absolute;
+  top:0;
+  right:0;
+  transform:translate(50%,-50%);
   min-width:18px; padding:.125rem .375rem; border-radius:10px;
   background:#ef4444; color:#fff; font-size:.75rem; font-weight:700;
   text-align:center; pointer-events:none; z-index:2;


### PR DESCRIPTION
## Summary
- ensure notification badge positions relative to bell icon

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b762ef4434832c9bb0a52ef8d1378a