### PR TITLE
Handle unknown organization types in autosave

### DIFF
--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -491,6 +491,22 @@ class AutosaveProposalTests(TestCase):
         self.assertIn("organization", data.get("errors", {}))
         self.assertEqual(Organization.objects.filter(name="Science Club").count(), 0)
 
+    def test_autosave_rejects_unknown_organization_type(self):
+        payload = self._payload()
+        payload["organization_type"] = "Unknown"
+        payload["organization"] = "science"
+        count_before = OrganizationType.objects.count()
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data.get("success"))
+        self.assertIn("organization_type", data.get("errors", {}))
+        self.assertEqual(OrganizationType.objects.count(), count_before)
+
     def test_reset_proposal_draft_deletes_draft(self):
         resp = self.client.post(
             reverse("emt:autosave_proposal"),

--- a/emt/views.py
+++ b/emt/views.py
@@ -604,15 +604,17 @@ def autosave_proposal(request):
     org_name_val = data.get("organization")
     if org_type_val and org_name_val and not str(org_name_val).isdigit():
         from core.models import Organization, OrganizationType
-
-        org_type_obj, _ = OrganizationType.objects.get_or_create(name=org_type_val)
-        existing = Organization.objects.filter(
-            org_type=org_type_obj, name__iexact=str(org_name_val).strip()
-        ).first()
-        if existing:
-            data["organization"] = str(existing.id)
+        org_type_obj = OrganizationType.objects.filter(name=org_type_val).first()
+        if not org_type_obj:
+            errors["organization_type"] = ["Organization type not found"]
         else:
-            errors["organization"] = ["Organization not found"]
+            existing = Organization.objects.filter(
+                org_type=org_type_obj, name__iexact=str(org_name_val).strip()
+            ).first()
+            if existing:
+                data["organization"] = str(existing.id)
+            else:
+                errors["organization"] = ["Organization not found"]
 
     proposal = None
     if pid := data.get("proposal_id"):


### PR DESCRIPTION
## Summary
- Prevent autosave endpoint from creating new OrganizationType records
- Validate organization type name before resolving organization
- Cover unrecognized organization type in autosave tests

## Testing
- `DATABASE_URL=sqlite:///test.db python manage.py test emt.tests.test_existing -v 2` *(fails: EventApprovalsNavTests.test_faculty_sees_event_approvals_link)*
- `DATABASE_URL=sqlite:///test.db python manage.py test emt.tests.test_existing.AutosaveProposalTests.test_autosave_rejects_unknown_organization_type -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b82b5295f0832c811993365612f507