### PR TITLE
Flag autosave validation errors as unsuccessful

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -132,12 +132,12 @@ window.AutosaveManager = (function() {
             return data;
         })
         .then(data => {
-            if (data && data.success && data.proposal_id) {
+            if (data && data.proposal_id) {
                 proposalId = data.proposal_id;
                 window.PROPOSAL_ID = data.proposal_id;
                 saveLocal();
                 document.dispatchEvent(new CustomEvent('autosave:success', {
-                    detail: { proposalId: data.proposal_id, errors: data.errors }
+                    detail: { proposalId: data.proposal_id, errors: data.errors, success: data.success }
                 }));
                 return data;
             }

--- a/emt/tests/test_autosave_draft_persistence.py
+++ b/emt/tests/test_autosave_draft_persistence.py
@@ -37,7 +37,7 @@ class AutosaveDraftPersistenceTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data["success"])
+        self.assertFalse(data["success"])
         self.assertIn("event_title", data["errors"])
         pid = data["proposal_id"]
         proposal = EventProposal.objects.get(id=pid)

--- a/emt/tests/test_existing.py
+++ b/emt/tests/test_existing.py
@@ -385,9 +385,8 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        # Autosave should succeed but return validation warnings for
-        # incomplete activity rows.
-        self.assertTrue(data.get("success"))
+        # Autosave should surface validation warnings for incomplete activity rows.
+        self.assertFalse(data.get("success"))
         self.assertIn("activities", data.get("errors", {}))
         self.assertIn("date", data["errors"]["activities"]["1"])
 
@@ -401,7 +400,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data.get("success"))
+        self.assertFalse(data.get("success"))
         self.assertIn("speakers", data.get("errors", {}))
         self.assertIn("designation", data["errors"]["speakers"]["0"])
 
@@ -421,9 +420,22 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data.get("success"))
+        self.assertFalse(data.get("success"))
         self.assertIn("speakers", data.get("errors", {}))
         self.assertIn("full_name", data["errors"]["speakers"]["0"])
+
+    def test_autosave_returns_success_false_on_invalid_fields(self):
+        payload = self._payload()
+        payload["event_title"] = ""  # Required field left blank
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data.get("success"))
+        self.assertIn("event_title", data.get("errors", {}))
 
     def test_autosave_requires_csrf_token(self):
         client = Client(enforce_csrf_checks=True)
@@ -487,7 +499,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data.get("success"))
+        self.assertFalse(data.get("success"))
         self.assertIn("organization", data.get("errors", {}))
         self.assertEqual(Organization.objects.filter(name="Science Club").count(), 0)
 
@@ -503,7 +515,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertTrue(data.get("success"))
+        self.assertFalse(data.get("success"))
         self.assertIn("organization_type", data.get("errors", {}))
         self.assertEqual(OrganizationType.objects.count(), count_before)
 
@@ -579,7 +591,7 @@ class AutosaveProposalTests(TestCase):
         )
         self.assertEqual(resp2.status_code, 200)
         data = resp2.json()
-        self.assertTrue(data.get("success"))
+        self.assertFalse(data.get("success"))
         self.assertIn("flow", data.get("errors", {}))
 
 

--- a/emt/views.py
+++ b/emt/views.py
@@ -636,7 +636,7 @@ def autosave_proposal(request):
             logger.debug("autosave_proposal text errors: %s", text_errors)
             return JsonResponse(
                 {
-                    "success": True,
+                    "success": False,
                     "proposal_id": proposal.id,
                     "errors": text_errors,
                 }
@@ -786,11 +786,11 @@ def autosave_proposal(request):
         list(proposal.faculty_incharges.values_list("id", flat=True)),
     )
 
-    # Always report success so that drafts are stored even when validation
-    # errors are present. The frontend will surface any issues using the
-    # returned ``errors`` map but the save itself should not be treated as a
-    # failure.
-    response = {"success": True, "proposal_id": proposal.id}
+    # Indicate overall success based on whether any validation errors were
+    # encountered. Drafts are still persisted even when ``success`` is False so
+    # the frontend can surface issues without clearing the user's progress.
+    success = not errors
+    response = {"success": success, "proposal_id": proposal.id}
     if errors:
         response["errors"] = errors
     return JsonResponse(response)


### PR DESCRIPTION
## Summary
- Mark `autosave_proposal` responses unsuccessful when validation errors exist
- Preserve drafts in JS while surfacing errors even if `success` is `false`
- Extend autosave tests to expect `success: False` for invalid inputs

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL "yamanote.proxy.rlwy.net" network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b82c9d0d88832c9775dac94ea78830