### PR TITLE
Secure admin impersonation via POST and CSRF

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -4,6 +4,9 @@ from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.urls import path
 from django.shortcuts import redirect
 from django.contrib import messages
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.http import require_POST
 
 from .models import (
     SDGGoal,
@@ -30,6 +33,8 @@ class ImpersonationUserAdmin(BaseUserAdmin):
         ]
         return custom_urls + urls
     
+    @method_decorator(csrf_protect)
+    @method_decorator(require_POST)
     def impersonate_user(self, request, user_id):
         """Impersonate user from admin"""
         if not request.user.is_superuser:
@@ -38,6 +43,10 @@ class ImpersonationUserAdmin(BaseUserAdmin):
 
         try:
             target_user = User.objects.get(id=user_id, is_active=True)
+            if target_user.is_superuser:
+                messages.error(request, "Cannot impersonate superusers")
+                return redirect('admin:auth_user_changelist')
+
             request.session['impersonate_user_id'] = target_user.id
             request.session['original_user_id'] = request.user.id
             log_impersonation_start(request, target_user)

--- a/templates/admin/auth/user/change_form.html
+++ b/templates/admin/auth/user/change_form.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+{{ block.super }}
+{% if not original.is_superuser %}
+<li>
+    <form method="post" action="{% url 'admin:auth_user_impersonate' original.id %}" style="display:inline;">
+        {% csrf_token %}
+        <button type="submit" class="button">Impersonate</button>
+    </form>
+</li>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- require POST + CSRF protection for admin impersonation
- block impersonating superusers
- change user change form to submit POST with CSRF token

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b83132f464832c9c1bc21eaccad79b