### PR TITLE
Scope proposal drafts per user

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,9 @@
   <meta name="csrf-token" content="{{ csrf_token }}">
   <!-- Auth status for JS (avoids inline template in script) -->
   <meta name="authenticated" content="{{ request.user.is_authenticated|yesno:'true,false' }}">
+  <script>
+    window.USER_ID = "{{ request.user.id|default:'' }}";
+  </script>
 </head>
 <body class="command-center-layout">
 


### PR DESCRIPTION
## Summary
- expose current user's id via `window.USER_ID`
- key proposal draft autosave storage by user id
- migrate and clear legacy autosave keys without user scope

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b830cb3414832ca9da82521d703e58