### PR TITLE
Allow custom autosave endpoint and add prefix test

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -261,7 +261,7 @@ async function autosave() {
                 payload[key] = value;
             }
         });
-        const res = await fetch('/suite/autosave-proposal/', {
+        const res = await fetch(window.AUTOSAVE_URL, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/tests/autosave-prefix.spec.ts
+++ b/tests/autosave-prefix.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+// Ensure autosave helper respects custom URL prefixes
+// by using window.AUTOSAVE_URL instead of a hardcoded path.
+test('autosave respects custom prefix', async ({ page }) => {
+  const autosavePath = path.join(__dirname, '..', 'emt', 'static', 'emt', 'js', 'autosave_draft.js');
+
+  // Intercept the expected autosave URL
+  const routePromise = page.waitForRequest('**/custom/autosave-proposal/');
+  await page.route('**/custom/autosave-proposal/', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+  });
+
+  await page.addInitScript(() => {
+    // Define globals used by autosave()
+    (window as any).AUTOSAVE_URL = '/custom/autosave-proposal/';
+    (window as any).AUTOSAVE_CSRF = 'TOKEN';
+  });
+
+  await page.setContent('<form><input name="title" value="Test" /></form>');
+  await page.addScriptTag({ path: autosavePath });
+
+  await page.evaluate(() => (window as any).autosave());
+  const request = await routePromise;
+  expect(request.url()).toContain('/custom/autosave-proposal/');
+});


### PR DESCRIPTION
## Summary
- Use configurable `window.AUTOSAVE_URL` for the simple autosave helper
- Add a Playwright test ensuring autosave works with a custom URL prefix

## Testing
- `python3 manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*
- `npx playwright test tests/autosave-prefix.spec.ts` *(fails: npx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b839ca3660832c9ab8ccd44cbec8c2