### PR TITLE
Resolve dashboard 404s and cleanup startup warnings

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -163,6 +163,7 @@ urlpatterns = [
     path('api/student/performance-data/', views.api_student_performance_data, name='api_student_performance_data'),
     path('api/user/events-data/', views.api_user_events_data, name='api_user_events_data'),
     path('api/student/contributions/', views.api_student_contributions, name='api_student_contributions'),
+    path('api/user/proposals/', views.api_user_proposals, name='api_user_proposals'),
     path('api/cdl/head-dashboard/', views.api_cdl_head_dashboard, name='api_cdl_head_dashboard'),
     path('api/cdl/member/work/', views.api_cdl_member_work, name='api_cdl_member_work'),
     path('api/cdl/members/', views.api_cdl_members, name='api_cdl_members'),

--- a/core/views.py
+++ b/core/views.py
@@ -665,17 +665,8 @@ def dashboard(request):
     "org_count": org_count,
     }
 
-        # --- robust template selection + debug ---
-    from django.conf import settings
+        # --- robust template selection ---
     from django.template.loader import select_template
-    import os
-
-    # quick runtime checks (remove after verifying)
-    print("TEMPLATE_DIRS:", settings.TEMPLATES[0]['DIRS'])
-    exp1 = os.path.join(settings.BASE_DIR, "templates", "core", "student_dashboard.html")
-    exp2 = os.path.join(settings.BASE_DIR, "templates", "student_dashboard.html")
-    print("EXPECTS:", exp1, "EXISTS:", os.path.exists(exp1))
-    print("EXPECTS:", exp2, "EXISTS:", os.path.exists(exp2))
 
     candidates = ["core/student_dashboard.html", "student_dashboard.html"] if is_student else ["core/dashboard.html", "dashboard.html"]
     tpl = select_template(candidates)  # picks the first that actually exists

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -176,9 +176,8 @@ LOGOUT_REDIRECT_URL = '/accounts/login/'
 # ──────────────────────────────────────────────────────────────────────────────
 # ALLAUTH SETTINGS
 # ──────────────────────────────────────────────────────────────────────────────
-ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_USERNAME_REQUIRED = False
-ACCOUNT_AUTHENTICATION_METHOD = 'email'
+ACCOUNT_LOGIN_METHODS = {'email'}
+ACCOUNT_SIGNUP_FIELDS = ['email*', 'password1*', 'password2*']
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/login/'

--- a/iqac_project/urls.py
+++ b/iqac_project/urls.py
@@ -10,7 +10,6 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),  # login/logout
     path('suite/', include(('emt.urls', 'emt'), namespace='emt')),  # emt app
     path('transcript/', include('transcript.urls')),  # transcript module
-    path('emt/', include('emt.urls')),
 ]
 
 # This line enables media file serving (for student photos) in development.


### PR DESCRIPTION
## Summary
- Remove stray debug prints from student dashboard view
- Expose `/api/user/proposals/` endpoint and update URLs
- Update Allauth config and remove duplicate EMT URL include

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b906c85574832cbf31e65c68141c51