### PR TITLE
Revamp Role Management organization type UI

### DIFF
--- a/static/core/css/admin_role_management.css
+++ b/static/core/css/admin_role_management.css
@@ -63,30 +63,29 @@
 }
 
 /* Organization type selection */
-.org-type-grid {
+.admin-dashboard-navcards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.5rem;
   margin-top: 1rem;
 }
 
-.org-type-card {
+.admin-navcard {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  text-align: center;
   background: var(--white);
   border: 1px solid var(--gray-200);
   border-radius: var(--border-radius-lg);
   padding: 2rem 1rem;
-  text-align: center;
-  transition: var(--transition);
   box-shadow: var(--shadow);
+  transition: var(--transition);
   text-decoration: none;
   color: inherit;
 }
 
-.org-type-card:hover {
+.admin-navcard:hover {
   transform: translateY(-4px);
   box-shadow: var(--shadow-lg);
   border-color: var(--christ-blue);
@@ -94,7 +93,7 @@
   color: inherit;
 }
 
-.org-type-card .icon-circle {
+.navcard-icon {
   width: 60px;
   height: 60px;
   border-radius: 50%;
@@ -104,27 +103,24 @@
   justify-content: center;
   color: var(--white);
   font-size: 1.5rem;
+  margin-bottom: 1rem;
   transition: var(--transition);
 }
 
-.org-type-card h5 {
+.admin-navcard:hover .navcard-icon {
+  background: var(--christ-blue-dark);
+}
+
+.navcard-title {
   font-size: 1.1rem;
   font-weight: 700;
   color: var(--gray-800);
-  margin: 0;
 }
 
-.org-type-card .manage-link {
-  margin-top: auto;
-  font-weight: 600;
-  color: var(--christ-blue);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.org-type-card:hover .icon-circle {
-  background: var(--christ-blue-dark);
+.navcard-desc {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--gray-600);
 }
 
 /* Add role form styling */

--- a/templates/core/admin_role_management.html
+++ b/templates/core/admin_role_management.html
@@ -4,6 +4,7 @@
 {% block title %}Role Management{% endblock %}
 
 {% block head_extra %}
+<link rel="stylesheet" href="{% static 'core/css/admin_dashboard.css' %}">
 <link rel="stylesheet" href="{% static 'core/css/admin_role_management.css' %}">
 {% endblock %}
 
@@ -211,32 +212,23 @@
 
     {% else %}
         <!-- Show organization types -->
-        <div class="card">
-            <div class="card-header text-white">
-                <h4 class="mb-0"><i class="fas fa-sitemap"></i> Select Organization Type</h4>
-            </div>
-            <div class="card-body">
-                {% if org_types %}
-                    <div class="org-type-grid">
-                        {% for org_type in org_types %}
-                        <a href="?org_type_id={{ org_type.id }}" class="org-type-card">
-                            <div class="icon-circle">
-                                <i class="fas fa-building"></i>
-                            </div>
-                            <h5>{{ org_type.name }}</h5>
-                            <div class="manage-link">
-                                <i class="fas fa-users-cog"></i> Manage Roles
-                            </div>
-                        </a>
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <div class="alert alert-warning">
-                        <i class="fas fa-exclamation-triangle"></i> No organization types found. Please create organization types first in the master data settings.
-                    </div>
-                {% endif %}
-            </div>
+        {% if org_types %}
+        <div class="admin-dashboard-navcards">
+            {% for org_type in org_types %}
+            <a href="?org_type_id={{ org_type.id }}" class="admin-navcard">
+                <div class="navcard-icon">
+                    <i class="fas fa-building"></i>
+                </div>
+                <div class="navcard-title">{{ org_type.name }}</div>
+                <div class="navcard-desc">Manage roles</div>
+            </a>
+            {% endfor %}
         </div>
+        {% else %}
+        <div class="alert alert-warning">
+            <i class="fas fa-exclamation-triangle"></i> No organization types found. Please create organization types first in the master data settings.
+        </div>
+        {% endif %}
     {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary
- Integrate admin dashboard styles into Role Management page
- Replace organization type grid with dashboard-style nav cards
- Add nav card styling for Role Management

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b90a571550832c8131bdc529d2230c