### PR TITLE
refactor: improve proposal input styling

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -220,7 +220,14 @@
   
   .proposal-content .input-group { display: flex; flex-direction: column; }
   .proposal-content .input-group label {
-    font-weight: 600; color: var(--text-dark); margin-bottom: .5rem; font-size: .875rem;
+    font-weight: 600;
+    color: var(--text-dark);
+    margin-bottom: .5rem;
+    font-size: .875rem;
+    transition: color .2s ease;
+  }
+  .proposal-content .input-group.focused label {
+    color: var(--primary-blue);
   }
   
   /* Inputs */
@@ -249,19 +256,25 @@
 
   /* Reusable proposal input */
   .proposal-input {
-    background-color: #f8f9fa !important;
-    border: 1px solid #ced4da !important;
-    border-radius: 0.25rem !important;
-    padding: 0.5rem 0.75rem !important;
-    transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+    background-color: #fff !important;
+    border: 1px solid #d0d5dd !important;
+    border-radius: 0.5rem !important;
+    padding: 0.625rem 0.75rem !important;
+    transition: border-color .2s ease, box-shadow .2s ease, background-color .2s ease;
   }
   .proposal-input:hover {
-    border-color: #adb5bd !important;
+    border-color: #b6bbc2 !important;
+    background-color: #f9fafb !important;
   }
   .proposal-input:focus {
     outline: none !important;
-    border-color: #0d6efd !important;
-    box-shadow: 0 0 0 0.25rem rgba(13,110,253,.25) !important;
+    background-color: #fff !important;
+    border-color: var(--primary-blue) !important;
+    box-shadow: 0 0 0 3px rgba(38,68,135,.15) !important;
+  }
+  .proposal-content .input-group.focused .proposal-input {
+    border-color: var(--primary-blue) !important;
+    box-shadow: 0 0 0 3px rgba(38,68,135,.15) !important;
   }
   
   /* Help text */

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3344,6 +3344,9 @@ function getWhyThisEventForm() {
     // Initialize autosave indicators
     initializeAutosaveIndicators();
 
+    // Enhance text inputs with improved interactions
+    enhanceProposalInputs();
+
     console.log('Dashboard initialized successfully.');
     console.log('All original functionality preserved with new UI');
 });
@@ -3579,5 +3582,25 @@ function removeSubmitSection() {
   if (submitSection) {
     submitSection.remove();
   }
+}
+
+// Apply focus styling and auto-resize behavior to text inputs
+function enhanceProposalInputs() {
+  document.querySelectorAll('.proposal-content .input-group .proposal-input').forEach((el) => {
+    const group = el.closest('.input-group');
+    if (!group) return;
+
+    el.addEventListener('focus', () => group.classList.add('focused'));
+    el.addEventListener('blur', () => group.classList.remove('focused'));
+
+    if (el.tagName === 'TEXTAREA') {
+      const resize = () => {
+        el.style.height = 'auto';
+        el.style.height = el.scrollHeight + 'px';
+      };
+      el.addEventListener('input', resize);
+      resize();
+    }
+  });
 }
 


### PR DESCRIPTION
## Summary
- restyle proposal text boxes with modern hover and focus feedback
- add JS helper to auto-resize textareas and highlight focused inputs

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b91722ed14832cb0c5a2eb7e6b90e8