### PR TITLE
Remove TomSelect input box styling

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2303,7 +2303,15 @@ textarea {
     line-height: 22px !important;
     box-shadow: none !important;
   }
-  
+
+  .ts-wrapper .ts-control input {
+    border: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+
   /* Kill any inner box styling */
   .ts-control .ts-input{
     border: 0 !important;


### PR DESCRIPTION
## Summary
- strip default box styling from TomSelect's inner input so it inherits wrapper styles

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9223d0460832ca84493599b7597ac