### PR TITLE
Fix autosave for faculty multi-select with no options

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -200,9 +200,17 @@ window.AutosaveManager = (function() {
                     f.checked = val === f.value;
                 } else if (f.multiple) {
                     const values = Array.isArray(val) ? val : [val];
-                    Array.from(f.options).forEach(o => {
-                        o.selected = values.includes(o.value);
-                    });
+                    if (f.options.length === 0) {
+                        values.forEach(v => {
+                            // create option placeholders so value persists even without preset options
+                            const opt = new Option(v, v, true, true);
+                            f.add(opt);
+                        });
+                    } else {
+                        Array.from(f.options).forEach(o => {
+                            o.selected = values.includes(o.value);
+                        });
+                    }
                 } else if (!f.value) {
                     f.value = val;
                 }


### PR DESCRIPTION
## Summary
- ensure autosaved multi-select values are restored even when no options exist

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b9834be084832c97f8818a09e1c016