### PR TITLE
Fix autosaved activity fields not showing after reload

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -596,6 +596,11 @@ $(document).ready(function() {
         if (window.EXISTING_ACTIVITIES && window.EXISTING_ACTIVITIES.length) {
             numActivitiesInput.value = window.EXISTING_ACTIVITIES.length;
             render(window.EXISTING_ACTIVITIES.length);
+        } else {
+            const savedCount = parseInt(numActivitiesInput.value, 10);
+            if (savedCount > 0) {
+                render(savedCount);
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- ensure dynamic activity rows re-render based on autosaved count when no server data exists

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9868d6e50832ca964ad162cdedb8d