### PR TITLE
Refresh faculty TomSelect labels after fetching

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -658,10 +658,20 @@ $(document).ready(function() {
                 fetch(`${window.API_FACULTY}?ids=${missing.join(',')}`)
                     .then(r => r.json())
                     .then(data => {
-                        data.forEach(opt => tomselect.addOption(opt));
-                        tomselect.setValue(initialValues);
+                        data.forEach(opt => {
+                            if (tomselect.options[opt.id]) {
+                                tomselect.updateOption(opt.id, opt);
+                            } else {
+                                tomselect.addOption(opt);
+                            }
+                        });
+                        tomselect.setValue(initialValues, true);
+                        tomselect.refreshItems();
                     })
-                    .catch(() => tomselect.setValue(initialValues));
+                    .catch(() => {
+                        tomselect.setValue(initialValues, true);
+                        tomselect.refreshItems();
+                    });
             } else {
                 tomselect.setValue(initialValues);
             }


### PR DESCRIPTION
## Summary
- ensure TomSelect updates existing faculty options when rehydrating
- refresh selected faculty labels after loading missing options

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c48b30e0832cbc002d04607ce65d