### PR TITLE
fix: retain organization choices after refresh

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -378,6 +378,11 @@ $(document).ready(function() {
         $('#form-panel-content').html(formContent);
 
         setTimeout(() => {
+            // Load any saved draft values before initializing widgets
+            if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                window.AutosaveManager.reinitialize();
+            }
+
             if (section === 'basic-info') {
                 setupDjangoFormIntegration();
                 // We call the new function to set up the listener for activities.

--- a/emt/tests/test_autosave_draft_persistence.py
+++ b/emt/tests/test_autosave_draft_persistence.py
@@ -56,3 +56,25 @@ class AutosaveDraftPersistenceTests(TestCase):
         self.assertNotIn("event_title", data2.get("errors", {}))
         proposal.refresh_from_db()
         self.assertEqual(proposal.event_title, "My Event")
+
+    def test_organization_fields_persist_after_autosave(self):
+        ot2 = OrganizationType.objects.create(name="Club")
+        org2 = Organization.objects.create(name="Robotics", org_type=ot2)
+        payload = {
+            "organization_type": str(ot2.id),
+            "organization": str(org2.id),
+            "academic_year": "2024-2025",
+        }
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        pid = resp.json()["proposal_id"]
+
+        resp2 = self.client.get(reverse("emt:submit_proposal_with_pk", args=[pid]))
+        self.assertEqual(resp2.status_code, 200)
+        html = resp2.content.decode()
+        self.assertIn(f'<option value="{ot2.id}" selected', html)
+        self.assertIn(f'<option value="{org2.id}" selected', html)


### PR DESCRIPTION
## Summary
- ensure autosave restores organization fields before UI widgets initialize
- add regression test for organization autosave persistence

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test emt.tests.test_autosave_draft_persistence -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b9c656bfa0832c847dbfa7e0867f05