### PR TITLE
Fix autosave reinitialize to overwrite field values

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -211,9 +211,10 @@ window.AutosaveManager = (function() {
                             o.selected = values.includes(o.value);
                         });
                     }
-                } else if (!f.value) {
+                } else {
                     f.value = val;
                 }
+                f.dispatchEvent(new Event('change', { bubbles: true }));
             }
             bindField(f);
         });

--- a/emt/tests/test_autosave_draft_persistence.py
+++ b/emt/tests/test_autosave_draft_persistence.py
@@ -78,3 +78,35 @@ class AutosaveDraftPersistenceTests(TestCase):
         html = resp2.content.decode()
         self.assertIn(f'<option value="{ot2.id}" selected', html)
         self.assertIn(f'<option value="{org2.id}" selected', html)
+
+    def test_organization_fields_update_on_subsequent_autosave(self):
+        # initial save uses default organization values
+        resp1 = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(self._payload()),
+            content_type="application/json",
+        )
+        self.assertEqual(resp1.status_code, 200)
+        pid = resp1.json()["proposal_id"]
+
+        # change to a different organization type and organization
+        ot2 = OrganizationType.objects.create(name="Club")
+        org2 = Organization.objects.create(name="Robotics", org_type=ot2)
+        payload = {
+            "proposal_id": pid,
+            "organization_type": str(ot2.id),
+            "organization": str(org2.id),
+            "academic_year": "2024-2025",
+        }
+        resp2 = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp2.status_code, 200)
+
+        resp3 = self.client.get(reverse("emt:submit_proposal_with_pk", args=[pid]))
+        self.assertEqual(resp3.status_code, 200)
+        html = resp3.content.decode()
+        self.assertIn(f'<option value="{ot2.id}" selected', html)
+        self.assertIn(f'<option value="{org2.id}" selected', html)

--- a/tests/autosave-reinitialize.spec.ts
+++ b/tests/autosave-reinitialize.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('reinitialize sets saved values and dispatches change events', async ({ page }) => {
+  const autosavePath = path.join(__dirname, '..', 'emt', 'static', 'emt', 'js', 'autosave_draft.js');
+
+  await page.route('http://example.com/proposal', route => {
+    route.fulfill({
+      contentType: 'text/html',
+      body: `
+        <html><body>
+          <select name="organization_type">
+            <option value="1">Dept</option>
+            <option value="2">Club</option>
+          </select>
+          <select name="organization">
+            <option value="10">Science</option>
+            <option value="20">Robotics</option>
+          </select>
+        </body></html>
+      `,
+    });
+  });
+  await page.addInitScript(() => {
+    (window as any).USER_ID = 1;
+    (window as any).PROPOSAL_ID = '';
+  });
+  await page.goto('http://example.com/proposal');
+
+  await page.evaluate(() => {
+    // default selections rendered by server
+    (document.querySelector('[name="organization_type"]') as HTMLSelectElement).value = '1';
+    (document.querySelector('[name="organization"]') as HTMLSelectElement).value = '10';
+    // saved draft values to apply
+    localStorage.setItem('proposal_draft_1_/proposal_new', JSON.stringify({
+      organization_type: '2',
+      organization: '20'
+    }));
+    // listen for change events
+    (window as any).changes = [];
+    document.querySelectorAll('select').forEach(sel => {
+      sel.addEventListener('change', () => (window as any).changes.push(sel.name));
+    });
+  });
+
+  await page.addScriptTag({ path: autosavePath });
+
+  const values = await page.evaluate(() => {
+    return {
+      organization_type: (document.querySelector('[name="organization_type"]') as HTMLSelectElement).value,
+      organization: (document.querySelector('[name="organization"]') as HTMLSelectElement).value,
+      changes: (window as any).changes,
+    };
+  });
+
+  expect(values.organization_type).toBe('2');
+  expect(values.organization).toBe('20');
+  expect(values.changes.sort()).toEqual(['organization', 'organization_type']);
+});


### PR DESCRIPTION
## Summary
- Always apply saved values during autosave draft reinitialization and dispatch `change` events
- Test proposal autosave flow with updated organization details
- Add Playwright test ensuring reinitialize triggers change events and restores selections

## Testing
- `DATABASE_URL=sqlite://:memory: python manage.py test emt.tests.test_autosave_draft_persistence`
- `npx playwright test tests/autosave-reinitialize.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9cafa0f84832ca1bc145ffda99c98