### PR TITLE
fix: preserve dynamic activity values

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -543,11 +543,12 @@ $(document).ready(function() {
             });
             numActivitiesInput.value = rows.length;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
+                // Persist current values *before* reinitializing to avoid
+                // overwriting renamed activity fields with stale data.
+                if (window.AutosaveManager.autosaveDraft) {
+                    window.AutosaveManager.autosaveDraft().catch(() => {});
+                }
                 window.AutosaveManager.reinitialize();
-                // Immediately persist the updated activity structure so that
-                // newly added/removed rows and their values are saved without
-                // requiring further user interaction.
-                window.AutosaveManager.autosaveDraft().catch(() => {});
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure activity rows autosave before reinitializing autosave manager to keep names/dates

## Testing
- `python manage.py test` *(fails: OperationalError connection to server yamanote.proxy.rlwy.net: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b9cf5fc22c832c921ac6f244ab54c7