### PR TITLE
Prevent selecting host organization in committees

### DIFF
--- a/emt/forms.py
+++ b/emt/forms.py
@@ -165,6 +165,14 @@ class EventProposalForm(forms.ModelForm):
             self.add_error('organization', 'Please select an organization name.')
         elif org_type and organization and organization.org_type != org_type:
             self.add_error('organization', 'Selected organization does not match the chosen type.')
+        else:
+            committees = (data.get('committees_collaborations') or '').split(',')
+            committees = [c.strip().lower() for c in committees if c.strip()]
+            if organization.name.lower() in committees:
+                self.add_error(
+                    'committees_collaborations',
+                    'Organization cannot be both host and committee/collaboration.',
+                )
         return data
 
     def clean_academic_year(self):

--- a/emt/tests/test_committees_main_org_validation.py
+++ b/emt/tests/test_committees_main_org_validation.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from emt.forms import EventProposalForm
+from core.models import OrganizationType, Organization
+
+class CommitteesMainOrgValidationTests(TestCase):
+    def setUp(self):
+        self.org_type = OrganizationType.objects.create(name="Department")
+        self.org = Organization.objects.create(name="Data Science", org_type=self.org_type, is_active=True)
+
+    def get_base_data(self):
+        return {
+            'organization_type': self.org_type.id,
+            'organization': self.org.id,
+            'event_title': 'Test Event',
+            'event_start_date': '2025-01-01',
+            'event_end_date': '2025-01-02',
+            'venue': 'Hall',
+            'academic_year': '2024-2025',
+        }
+
+    def test_same_org_not_allowed(self):
+        data = self.get_base_data()
+        data['committees_collaborations'] = 'Data Science, Other Org'
+        form = EventProposalForm(data=data, selected_academic_year='2024-2025')
+        self.assertFalse(form.is_valid())
+        self.assertIn('committees_collaborations', form.errors)
+
+    def test_different_org_allowed(self):
+        data = self.get_base_data()
+        data['committees_collaborations'] = 'Other Org'
+        form = EventProposalForm(data=data, selected_academic_year='2024-2025')
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
## Summary
- Disallow choosing the hosting organization as a committee or collaborator
- Add form validation preventing host organization duplication
- Test to ensure host organization cannot appear in committees list

## Testing
- `python manage.py test` *(fails: connection to Postgres server is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d535f694832cb1f22ba85844570b