### PR TITLE
fix: preserve activity autosave data

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -543,9 +543,14 @@ $(document).ready(function() {
             });
             numActivitiesInput.value = rows.length;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
-                // Persist current values *before* reinitializing to avoid
-                // overwriting renamed activity fields with stale data.
-                if (window.AutosaveManager.autosaveDraft) {
+                // Only autosave existing values if fields were previously bound
+                // to the autosave manager. Freshly rendered rows don't have the
+                // `data-autosave-bound` flag and would otherwise wipe saved data.
+                const alreadyBound = Array.from(rows).some(row => {
+                    const inp = row.querySelector('input');
+                    return inp && inp.dataset.autosaveBound === 'true';
+                });
+                if (alreadyBound && window.AutosaveManager.autosaveDraft) {
                     window.AutosaveManager.autosaveDraft().catch(() => {});
                 }
                 window.AutosaveManager.reinitialize();


### PR DESCRIPTION
## Summary
- avoid wiping saved data for activity name/date when rendering activities

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at "yamanote.proxy.rlwy.net" (66.33.22.242) port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1e207f0832c97ac9453f730742a