### PR TITLE
Ensure autosave reinitializes before saving activity rows

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -550,10 +550,12 @@ $(document).ready(function() {
                     const inp = row.querySelector('input');
                     return inp && inp.dataset.autosaveBound === 'true';
                 });
+                // Reinitialize first so new rows get included in the autosave field list
+                window.AutosaveManager.reinitialize();
+                // Then persist existing values if autosave was already bound
                 if (alreadyBound && window.AutosaveManager.autosaveDraft) {
                     window.AutosaveManager.autosaveDraft().catch(() => {});
                 }
-                window.AutosaveManager.reinitialize();
             }
         }
 


### PR DESCRIPTION
## Summary
- Reorder autosave logic so new activity rows are registered before drafting values

## Testing
- `python manage.py test` *(fails: connection to PostgreSQL server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*
- `npm test` *(fails: page.waitForRequest timeout for `**/custom/autosave-proposal/`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e427bce0832cadc0917653eb0575