### PR TITLE
Add AgentScope sidecar and Django integration

### DIFF
--- a/core/ai_client.py
+++ b/core/ai_client.py
@@ -1,0 +1,31 @@
+import os
+import logging
+import requests
+
+AI_URL = os.getenv("IQAC_AI_URL", "http://127.0.0.1:8699")
+
+logger = logging.getLogger(__name__)
+
+class AIClient:
+    def __init__(self, base: str = AI_URL, timeout: int = 25):
+        self.base = base.rstrip("/")
+        self.timeout = timeout
+
+    def _post(self, path: str, payload: dict):
+        url = f"{self.base}{path}"
+        logger.debug("POST %s payload=%s", url, payload)
+        resp = requests.post(url, json=payload, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+    def need_analysis(self, ctx: dict):
+        return self._post("/generate/need_analysis", ctx)
+
+    def objectives(self, ctx: dict):
+        return self._post("/generate/objectives", ctx)
+
+    def outcomes(self, ctx: dict):
+        return self._post("/generate/outcomes", ctx)
+
+    def report(self, ctx: dict):
+        return self._post("/generate/report", ctx)

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -112,6 +112,49 @@
             <textarea id="id_objectives" name="objectives" class="proposal-input" hidden>{{ objectives.content|default_if_none:'' }}</textarea>
             <textarea id="id_learning_outcomes" name="outcomes" class="proposal-input" hidden>{{ outcomes.content|default_if_none:'' }}</textarea>
             <textarea name="flow" class="proposal-input" hidden>{{ flow.content|default_if_none:'' }}</textarea>
+            <div class="ai-actions space-y-2">
+              <button type="button" id="btnNeed" class="btn btn-outline-primary">AI: Need Analysis</button>
+              <button type="button" id="btnObj" class="btn btn-outline-primary">AI: Objectives</button>
+              <button type="button" id="btnOut" class="btn btn-outline-primary">AI: Outcomes + Mapping</button>
+              <button type="button" id="btnRpt" class="btn btn-outline-primary">AI: Full Report Draft</button>
+            </div>
+
+            <script>
+async function postForm(url){
+  const form = document.querySelector('form');
+  const fd = new FormData(form);
+  const resp = await fetch(url, {method:'POST', body: fd});
+  if(!resp.ok) throw new Error('AI error');
+  return await resp.json();
+}
+
+document.getElementById('btnNeed').addEventListener('click', async () => {
+  const data = await postForm('{% url "emt:ai_need_analysis" %}');
+  document.getElementById('id_need_analysis').value = data.need_analysis || '';
+});
+
+document.getElementById('btnObj').addEventListener('click', async () => {
+  const data = await postForm('{% url "emt:ai_objectives" %}');
+  const area = document.getElementById('id_objectives');
+  if(Array.isArray(data.objectives)){
+    area.value = data.objectives.map(o => `• ${o.title}: ${o.detail} (Metric: ${o.measurable_metric})`).join('\n');
+  }
+});
+
+document.getElementById('btnOut').addEventListener('click', async () => {
+  const data = await postForm('{% url "emt:ai_outcomes" %}');
+  const area = document.getElementById('id_learning_outcomes');
+  if(Array.isArray(data.outcomes)){
+    area.value = data.outcomes.map(x => `• ${x.statement} | Measure: ${x.measurement} | PSO:${(x.mapped?.PSO||[]).join(',')} PO:${(x.mapped?.PO||[]).join(',')} SDG:${(x.mapped?.SDG||[]).join(',')}`).join('\n');
+  }
+});
+
+document.getElementById('btnRpt').addEventListener('click', async () => {
+  const data = await postForm('{% url "emt:ai_report" %}');
+  const preview = document.getElementById('report_preview');
+  if(preview){ preview.textContent = data.report_markdown || ''; }
+});
+            </script>
 
             <div class="form-panel" id="form-panel">
                 <div class="form-panel-content" id="form-panel-content">

--- a/emt/tests/test_ai_endpoints.py
+++ b/emt/tests/test_ai_endpoints.py
@@ -1,0 +1,35 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from unittest.mock import patch
+
+class AIGenerationViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    @patch('emt.views_ai.AIClient.need_analysis', return_value={'need_analysis': 'ok'})
+    def test_ai_need_analysis(self, mock_ai):
+        resp = self.client.post(reverse('emt:ai_need_analysis'), {'title': 'T', 'department': 'D'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get('need_analysis'), 'ok')
+        mock_ai.assert_called()
+
+    @patch('emt.views_ai.AIClient.objectives', return_value={'objectives': []})
+    def test_ai_objectives(self, mock_ai):
+        resp = self.client.post(reverse('emt:ai_objectives'), {'title': 'T', 'department': 'D'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('objectives', resp.json())
+        mock_ai.assert_called()
+
+    @patch('emt.views_ai.AIClient.outcomes', return_value={'outcomes': []})
+    def test_ai_outcomes(self, mock_ai):
+        resp = self.client.post(reverse('emt:ai_outcomes'), {'title': 'T', 'department': 'D'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('outcomes', resp.json())
+        mock_ai.assert_called()
+
+    @patch('emt.views_ai.AIClient.report', return_value={'report_markdown': 'md', 'tables': {}})
+    def test_ai_report(self, mock_ai):
+        resp = self.client.post(reverse('emt:ai_report'), {'title': 'T', 'department': 'D'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn('report_markdown', resp.json())
+        mock_ai.assert_called()

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from . import views
+from . import views, views_ai
 from suite import views as suite_views
 from ai import enhance_summary as ai_views
 
@@ -81,4 +81,8 @@ urlpatterns = [
     path('api/organization-types/', views.api_organization_types, name='api_organization_types'),
     path('api/outcomes/<int:org_id>/', views.api_outcomes, name='api_outcomes'),
 
+    path('ai/need-analysis', views_ai.ai_need_analysis, name='ai_need_analysis'),
+    path('ai/objectives', views_ai.ai_objectives, name='ai_objectives'),
+    path('ai/outcomes', views_ai.ai_outcomes, name='ai_outcomes'),
+    path('ai/report', views_ai.ai_report, name='ai_report'),
 ]

--- a/emt/views_ai.py
+++ b/emt/views_ai.py
@@ -1,0 +1,62 @@
+import logging
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+from django.views.decorators.csrf import csrf_exempt
+from core.ai_client import AIClient
+
+logger = logging.getLogger(__name__)
+
+
+def _build_ctx_from_request(request):
+    title = request.POST.get("title")
+    department = request.POST.get("department") or getattr(request.user, "profile", None) and getattr(request.user.profile, "department_name", None)
+    description = request.POST.get("description")
+    objectives_hint = request.POST.get("objectives")
+    outcomes_hint = request.POST.get("outcomes")
+    pso_list = [p.code for p in getattr(request.user, "pso_available", [])] if hasattr(request.user, "pso_available") else []
+    po_list = ["PO1", "PO2", "PO3"]
+    sdg_list = ["SDG3", "SDG4", "SDG9"]
+    ctx = {
+        "title": title or "TBD",
+        "department": department or "TBD",
+        "description": description or "TBD",
+        "objectives_hint": objectives_hint,
+        "outcomes_hint": outcomes_hint,
+        "pso_list": pso_list,
+        "po_list": po_list,
+        "sdg_list": sdg_list,
+    }
+    logger.debug("Built context %s", ctx)
+    return ctx
+
+
+@require_POST
+@csrf_exempt
+def ai_need_analysis(request):
+    ctx = _build_ctx_from_request(request)
+    data = AIClient().need_analysis(ctx)
+    return JsonResponse(data)
+
+
+@require_POST
+@csrf_exempt
+def ai_objectives(request):
+    ctx = _build_ctx_from_request(request)
+    data = AIClient().objectives(ctx)
+    return JsonResponse(data)
+
+
+@require_POST
+@csrf_exempt
+def ai_outcomes(request):
+    ctx = _build_ctx_from_request(request)
+    data = AIClient().outcomes(ctx)
+    return JsonResponse(data)
+
+
+@require_POST
+@csrf_exempt
+def ai_report(request):
+    ctx = _build_ctx_from_request(request)
+    data = AIClient().report(ctx)
+    return JsonResponse(data)

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -42,6 +42,7 @@ try:
     AI_HTTP_TIMEOUT = int(AI_HTTP_TIMEOUT)
 except Exception:
     AI_HTTP_TIMEOUT = 120
+IQAC_AI_URL = _env("IQAC_AI_URL", default="http://127.0.0.1:8699")
 
 # Optional: generator/critic models if used elsewhere in code
 OLLAMA_GEN_MODEL    = _env("OLLAMA_GEN_MODEL", default=OLLAMA_MODEL)

--- a/sidecar/main.py
+++ b/sidecar/main.py
@@ -1,0 +1,143 @@
+import os
+import json
+import logging
+from typing import List, Optional
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from agentscope import Agent, Hub, Model
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = os.getenv("AS_PROVIDER", "ollama").lower()
+MODEL_NAME = os.getenv("AS_MODEL", "llama3.1:8b")
+TEMP = float(os.getenv("AS_TEMP", "0.3"))
+
+llm = Model(MODEL_NAME, provider=PROVIDER, temperature=TEMP)
+
+class ProposalContext(BaseModel):
+    title: str
+    department: str
+    audience: Optional[str] = None
+    date: Optional[str] = None
+    venue: Optional[str] = None
+    description: Optional[str] = None
+    objectives_hint: Optional[str] = None
+    outcomes_hint: Optional[str] = None
+    pso_list: List[str] = Field(default_factory=list)
+    po_list: List[str] = Field(default_factory=list)
+    sdg_list: List[str] = Field(default_factory=list)
+    budget_items: Optional[List[dict]] = None
+    participants: Optional[List[dict]] = None
+
+class ObjectiveItem(BaseModel):
+    title: str
+    detail: str
+    measurable_metric: str
+
+class OutcomeItem(BaseModel):
+    statement: str
+    measurement: str
+    mapped: dict
+
+class NeedAnalysisResp(BaseModel):
+    need_analysis: str
+
+class ObjectivesResp(BaseModel):
+    objectives: List[ObjectiveItem]
+
+class OutcomesResp(BaseModel):
+    outcomes: List[OutcomeItem]
+
+class ReportResp(BaseModel):
+    report_markdown: str
+    tables: dict = Field(default_factory=dict)
+
+summarizer = Agent("Summarizer", llm)
+mapper = Agent("Mapper", llm)
+formatter = Agent("Formatter", llm)
+guard = Agent("Guard", llm)
+
+hub = Hub([summarizer, mapper, formatter, guard])
+
+app = FastAPI(title="IQAC AgentScope Sidecar", version="0.1")
+
+COMMON_SYS = (
+    "You are an academic writing assistant for a university IQAC system. "
+    "Be factual, formal, and concise. If data is missing, write 'TBD'. "
+    "Never invent statistics or approvals."
+)
+
+@app.post("/generate/need_analysis", response_model=NeedAnalysisResp)
+async def gen_need_analysis(ctx: ProposalContext):
+    prompt = f"""
+{COMMON_SYS}
+Task: Draft a Need Analysis for the event.
+Context: {ctx.model_dump_json()}
+Output: 1–2 paragraphs under heading 'Need Analysis'.
+"""
+    logger.debug("Generating need analysis with context: %s", ctx)
+    text = hub.run({"role": "user", "content": prompt})
+    return NeedAnalysisResp(need_analysis=str(text))
+
+@app.post("/generate/objectives", response_model=ObjectivesResp)
+async def gen_objectives(ctx: ProposalContext):
+    prompt = f"""
+{COMMON_SYS}
+Task: Produce 3–6 SMART objectives for the event.
+Context: {ctx.model_dump_json()}
+Return JSON list with: title, detail, measurable_metric.
+"""
+    logger.debug("Generating objectives with context: %s", ctx)
+    raw = hub.run({"role": "user", "content": prompt})
+    try:
+        data = json.loads(str(raw))
+        items = [ObjectiveItem(**o) for o in data]
+    except Exception:
+        logger.exception("Failed to parse objectives JSON; returning fallback")
+        items = [ObjectiveItem(title="TBD Objective", detail=str(raw)[:500], measurable_metric="TBD")]
+    return ObjectivesResp(objectives=items)
+
+@app.post("/generate/outcomes", response_model=OutcomesResp)
+async def gen_outcomes(ctx: ProposalContext):
+    prompt = f"""
+{COMMON_SYS}
+Task: Propose measurable outcomes and map each to PSO/PO/SDG from the provided lists.
+Context: {ctx.model_dump_json()}
+Return JSON list of objects: {{statement, measurement, mapped: {{PSO:[], PO:[], SDG:[]}}}}
+Rules: Only use IDs given in lists; if unsure → empty array.
+"""
+    logger.debug("Generating outcomes with context: %s", ctx)
+    raw = hub.run({"role": "user", "content": prompt})
+    try:
+        data = json.loads(str(raw))
+        items = [OutcomeItem(**o) for o in data]
+    except Exception:
+        logger.exception("Failed to parse outcomes JSON; returning fallback")
+        items = [OutcomeItem(statement="TBD", measurement="TBD", mapped={"PSO": [], "PO": [], "SDG": []})]
+    return OutcomesResp(outcomes=items)
+
+@app.post("/generate/report", response_model=ReportResp)
+async def gen_report(ctx: ProposalContext):
+    prompt = f"""
+{COMMON_SYS}
+Task: Write a full event report in Markdown with these sections:
+## Title
+## Need Analysis
+## Objectives
+## Outcomes and Measurement
+## PSO/PO/SDG Mapping
+## Conduct and Timeline
+## Participation Summary
+## Budget Summary
+## Conclusion
+
+Constraints:
+- If ctx.participants or ctx.budget_items exist, create simple Markdown tables.
+- Keep formal tone, avoid claims not present in context.
+Context JSON: {ctx.model_dump_json()}
+"""
+    logger.debug("Generating report with context: %s", ctx)
+    text = hub.run({"role": "user", "content": prompt})
+    tables = {"participants": ctx.participants or [], "budget": ctx.budget_items or []}
+    return ReportResp(report_markdown=str(text), tables=tables)

--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+agentscope
+pydantic


### PR DESCRIPTION
## Summary
- build FastAPI AgentScope sidecar for generating need analysis, objectives, outcomes, and reports
- wire Django to sidecar via AIClient, new proxy views, URLs, and template buttons
- add basic tests for new AI endpoints

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bac0ee1dd4832c91a8e312c3782914