### PR TITLE
Add legacy EMT URL prefix

### DIFF
--- a/iqac_project/urls.py
+++ b/iqac_project/urls.py
@@ -9,6 +9,8 @@ urlpatterns = [
     path('', include('core.urls')),  # core: dashboard, login, etc.
     path('accounts/', include('allauth.urls')),  # login/logout
     path('suite/', include(('emt.urls', 'emt'), namespace='emt')),  # emt app
+    # Legacy prefix to support older links that still reference '/emt/'
+    path('emt/', include(('emt.urls', 'emt'), namespace='emt_legacy')),  # backward compatibility
     path('transcript/', include('transcript.urls')),  # transcript module
 ]
 


### PR DESCRIPTION
## Summary
- Support legacy `/emt/` paths by routing them to the same views as the `/suite/` prefix.

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf1fd51f0832cb6ec40e3d4237aa9