### PR TITLE
Handle partial activity rows during proposal autosave

### DIFF
--- a/emt/tests/test_autosave_draft_persistence.py
+++ b/emt/tests/test_autosave_draft_persistence.py
@@ -110,3 +110,25 @@ class AutosaveDraftPersistenceTests(TestCase):
         html = resp3.content.decode()
         self.assertIn(f'<option value="{ot2.id}" selected', html)
         self.assertIn(f'<option value="{org2.id}" selected', html)
+
+    def test_autosave_saves_complete_activities_ignoring_incomplete(self):
+        payload = self._payload()
+        payload.update(
+            {
+                "num_activities": "2",
+                "activity_name_1": "Orientation",
+                "activity_date_1": "2024-01-01",
+                "activity_name_2": "Workshop",
+            }
+        )
+        resp = self.client.post(
+            reverse("emt:autosave_proposal"),
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        pid = resp.json()["proposal_id"]
+        proposal = EventProposal.objects.get(id=pid)
+        activities = list(proposal.activities.all())
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].name, "Orientation")


### PR DESCRIPTION
## Summary
- ensure proposal autosave persists valid activity rows even when others are incomplete
- add regression test for partial activity autosave

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be975f0e68832c946f7bbd03c8af18