### PR TITLE
Fix activities autosave sync for proposals

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1397,6 +1397,13 @@ $(document).ready(function() {
                 }
                 clearFieldError($(this));
             });
+            // Sync changes from the hidden Django field back to the visible modern field
+            djangoField.on('input change', function() {
+                const value = $(this).val();
+                if (modernField.val() !== value) {
+                    modernField.val(value);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- keep proposal fields in sync when autosave restores Django hidden values

## Testing
- `npm test` *(fails: Test timeout waiting for custom autosave prefix request)*
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be9acb39a8832cb18edb4e92c872e4