### PR TITLE
Move proposal notifications to bottom right

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -410,7 +410,7 @@
   }
   
   /* ---- Notifications ---- */
-  .notification { position: fixed; top: 20px; right: 20px; background: var(--white);
+  .notification { position: fixed; bottom: 20px; right: 20px; background: var(--white);
     padding: 1rem 1.25rem; border-radius: 12px; box-shadow: var(--shadow-2); z-index: 1001;
     opacity: 0; transform: translateX(100%); transition: all .25s ease; max-width: 320px; }
   .notification.show { opacity: 1; transform: translateX(0); }

--- a/emt/static/emt/js/ga_editor.js
+++ b/emt/static/emt/js/ga_editor.js
@@ -140,7 +140,7 @@
 
   function toast(message, type='info'){
     const el = document.createElement('div');
-    el.style.cssText = `position:fixed;top:20px;right:20px;background:${type==='success'?'#10b981':type==='warning'?'#f59e0b':'#3b82f6'};color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:1000;max-width:300px;font-size:.9rem;`;
+    el.style.cssText = `position:fixed;bottom:20px;right:20px;background:${type==='success'?'#10b981':type==='warning'?'#f59e0b':'#3b82f6'};color:#fff;padding:12px 16px;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:1000;max-width:300px;font-size:.9rem;`;
     el.textContent = message;
     document.body.appendChild(el);
     setTimeout(() => { el.style.opacity = '0'; el.style.transform = 'translateX(100%)'; setTimeout(() => el.remove(), 300); }, 2200);


### PR DESCRIPTION
## Summary
- Show proposal form notifications at the bottom-right corner for improved UX.
- Place GA editor toast messages at bottom-right to match notification placement.

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beabfc9a78832c81c55982aa386efa