### PR TITLE
Move dashboard notifications to bottom-right

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3349,7 +3349,7 @@ function getWhyThisEventForm() {
                 .animate-bounce { animation: bounce 0.6s ease-in-out; }
                 .animate-shake { animation: shake 0.5s ease-in-out; }
                 
-                .notification { position: fixed; top: 20px; right: 20px; background: white; padding: 1rem 1.5rem; border-radius: 12px; box-shadow: 0 8px 30px rgba(0,0,0,0.15); z-index: 1001; opacity: 0; transform: translateX(100%); transition: all 0.3s ease; max-width: 320px; }
+                .notification { position: fixed; bottom: 20px; right: 20px; background: white; padding: 1rem 1.5rem; border-radius: 12px; box-shadow: 0 8px 30px rgba(0,0,0,0.15); z-index: 1001; opacity: 0; transform: translateX(100%); transition: all 0.3s ease; max-width: 320px; }
                 .notification.notification-success { border-left: 4px solid #22c55e; }
                 .notification.notification-error { border-left: 4px solid #ef4444; }
                 .notification.notification-info { border-left: 4px solid #264487; }


### PR DESCRIPTION
## Summary
- Position dashboard notifications using bottom and right offsets so they appear at the bottom-right corner

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bede32b534832c805c09bfc8ef5d8a