### PR TITLE
Handle organization fields in autosave validation

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3274,7 +3274,11 @@ function getWhyThisEventForm() {
         const nonFieldMessages = [];
 
         const mark = (name, message) => {
-            let field = $(`#${name.replace(/_/g, '-')}-modern`);
+            const fieldMap = {
+                'organization_type': '#org-type-modern-input',
+                'organization': '#org-modern-select'
+            };
+            let field = $(fieldMap[name] || `#${name.replace(/_/g, '-')}-modern`);
             if (!field.length) {
                 field = $(`[name="${name}"]`);
                 if (field.length && field.attr('type') === 'hidden') {


### PR DESCRIPTION
## Summary
- ensure autosave error highlighting works for organization type and organization fields

## Testing
- `python manage.py test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bedf3ef1bc832cb6256c90d08ac902