### PR TITLE
Improve autosave validation handling

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2493,7 +2493,7 @@ function getWhyThisEventForm() {
             window.AutosaveManager.manualSave()
                 .then((data) => {
                     hideLoadingOverlay();
-                    if (data && data.errors) {
+                    if (data && data.errors && Object.keys(data.errors).length) {
                         handleAutosaveErrors(data);
                         showNotification('Please fix the errors before continuing.', 'error');
                         return;
@@ -3266,6 +3266,9 @@ function getWhyThisEventForm() {
         const errors = (errorData && typeof errorData === 'object') ? (errorData.errors || errorData) : null;
         if (!errors || typeof errors !== 'object') {
             showNotification('Autosave failed. Please try again.', 'error');
+            return;
+        }
+        if (!Object.keys(errors).length) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure autosave error handling only triggers when error details exist
- guard against empty error payloads in `handleAutosaveErrors`

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee1f30df8832cb52e37c1b44e11d6