### PR TITLE
Fix schedule validation ignoring empty rows

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2885,6 +2885,10 @@ function getWhyThisEventForm() {
             const time = timeInput.val().trim();
             const activity = activityInput.val().trim();
 
+            if (!time && !activity) {
+                return; // Skip completely empty rows
+            }
+
             if (!time) {
                 showScheduleError(timeInput, 'Date & time required');
                 isValid = false;


### PR DESCRIPTION
## Summary
- ignore completely empty rows in proposal schedule validation to prevent false errors

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed)*
- `npm test` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9844f1cc832cb9f26b29ee5f9cf5