### PR TITLE
fix: validate visible event fields

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2999,7 +2999,8 @@ function getWhyThisEventForm() {
 
         requiredTextareas.forEach(selector => {
             const field = $(selector);
-            if (!field.length) return; // Skip validation if field is not present
+            if (!field.length || !field.is(':visible')) return; // Skip validation if field is not present or not visible
+            field.trigger('change'); // Ensure rich-text/autosave editors sync their content
             if (!field.val() || field.val().trim() === '') {
                 showFieldError(field, 'This field is required');
                 field.addClass('animate-shake');


### PR DESCRIPTION
## Summary
- ensure "Why this Event" fields are validated only when visible
- sync rich-text/autosave editors before checking values

## Testing
- `python manage.py test` *(fails: connection to server at yamanote.proxy.rlwy.net port 25156 failed: Network is unreachable)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9c284a90832c8c6147714720114f