### PR TITLE
Sync editors before validating proposal fields

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3000,6 +3000,20 @@ function getWhyThisEventForm() {
         requiredTextareas.forEach(selector => {
             const field = $(selector).filter(':visible').first();
             if (!field.length) return;
+            const id = field.attr('id');
+
+            if (id) {
+                if (window.CKEDITOR && CKEDITOR.instances && CKEDITOR.instances[id]) {
+                    CKEDITOR.instances[id].updateElement();
+                } else if (window.ClassicEditor && window._editors && window._editors[id]) {
+                    field.val(window._editors[id].getData());
+                } else if (window.tinymce && tinymce.get(id)) {
+                    field.val(tinymce.get(id).getContent());
+                } else if (window.Quill && window._quills && window._quills[id]) {
+                    field.val(window._quills[id].root.innerHTML);
+                }
+            }
+
             field.trigger('change');
             if (!field.val().trim()) {
                 showFieldError(field, 'This field is required');


### PR DESCRIPTION
## Summary
- ensure rich-text editors sync their content before `validateWhyThisEvent` checks values

## Testing
- `npm test` *(fails: page.waitForRequest timeout)*
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" failed: Network is unreachable)*
- `node -e <manual validateWhyThisEvent>`

------
https://chatgpt.com/codex/tasks/task_e_68bfb2abef8c832cb9c2ea5757a227e0