### PR TITLE
Ensure hidden fields sync on proposal validation

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3013,7 +3013,7 @@ function getWhyThisEventForm() {
                     field.val(window._quills[id].root.innerHTML);
                 }
             }
-
+            field.trigger('input');
             field.trigger('change');
             if (!field.val().trim()) {
                 showFieldError(field, 'This field is required');


### PR DESCRIPTION
## Summary
- ensure validateWhyThisEvent triggers both `input` and `change` events after syncing rich-text editor content so hidden proposal fields update correctly

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*
- `npm test` *(fails: tests/autosave-prefix.spec.ts timeout waiting for request)*


------
https://chatgpt.com/codex/tasks/task_e_68bfc4900d10832c8042a90264604dd5