### PR TITLE
Ensure hidden textarea sync after editor updates

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3005,16 +3005,18 @@ function getWhyThisEventForm() {
             if (id) {
                 if (window.CKEDITOR && CKEDITOR.instances && CKEDITOR.instances[id]) {
                     CKEDITOR.instances[id].updateElement();
+                    field.trigger('input').trigger('change');
                 } else if (window.ClassicEditor && window._editors && window._editors[id]) {
                     field.val(window._editors[id].getData());
+                    field.trigger('input').trigger('change');
                 } else if (window.tinymce && tinymce.get(id)) {
                     field.val(tinymce.get(id).getContent());
+                    field.trigger('input').trigger('change');
                 } else if (window.Quill && window._quills && window._quills[id]) {
                     field.val(window._quills[id].root.innerHTML);
+                    field.trigger('input').trigger('change');
                 }
             }
-            field.trigger('input');
-            field.trigger('change');
             if (!field.val().trim()) {
                 showFieldError(field, 'This field is required');
                 field.addClass('animate-shake');


### PR DESCRIPTION
## Summary
- Trigger `input` and `change` events after syncing rich text editors in `validateWhyThisEvent`

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*
- `npm test` *(fails: page.waitForRequest timeout; 1 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7b67b80832ca06f5f5a2d6ce03d