### PR TITLE
Sync Why This Event editors with hidden textareas

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3016,6 +3016,8 @@ function getWhyThisEventForm() {
                     field.val(window._quills[id].root.innerHTML);
                     field.trigger('input').trigger('change');
                 }
+                const baseName = selector.replace('#', '').replace('-modern', '').replace(/-/g, '_');
+                $(`textarea[name="${baseName}"]`).val(field.val());
             }
             if (!field.val().trim()) {
                 showFieldError(field, 'This field is required');


### PR DESCRIPTION
## Summary
- Update proposal dashboard validation to sync rich text editor content into hidden textareas so "Why This Event" fields persist

## Testing
- `python manage.py test` (failed: connection to server at "yamanote.proxy.rlwy.net" failed)
- `npm test` (failed: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bfea65af78832c9b997a46847589d2