### PR TITLE
Fix autosave validation errors on empty proposal fields

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -43,15 +43,21 @@ window.AutosaveManager = (function() {
                 return; // handled separately when sending FormData
             } else if (field.type === 'checkbox') {
                 if (inputs.length > 1) {
-                    data[name] = inputs.filter(i => i.checked).map(i => i.value);
-                } else {
-                    data[name] = field.checked;
+                    const values = inputs.filter(i => i.checked).map(i => i.value);
+                    if (values.length) {
+                        data[name] = values;
+                    }
+                } else if (field.checked) {
+                    data[name] = true;
                 }
             } else if (field.type === 'radio') {
                 const checked = inputs.find(i => i.checked);
                 if (checked) data[name] = checked.value;
             } else if (field.multiple) {
-                data[name] = Array.from(field.selectedOptions).map(o => o.value);
+                const selected = Array.from(field.selectedOptions).map(o => o.value).filter(v => v !== '');
+                if (selected.length) {
+                    data[name] = selected;
+                }
             } else {
                 // When multiple inputs share the same name (e.g. hidden Django field
                 // and visible modern field), prefer a visible, non-empty value.
@@ -59,8 +65,10 @@ window.AutosaveManager = (function() {
                     || inputs.find(i => i.type !== 'hidden')
                     || inputs.find(i => i.value.trim() !== '')
                     || field;
-                let value = preferred.value;
-                data[name] = value;
+                const value = preferred.value;
+                if (String(value).trim() !== '') {
+                    data[name] = value;
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- Skip empty inputs when collecting proposal data for autosave
- Prevent unfilled sections from triggering validation errors during manual save

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c18815927c832c880de5bbf9097fab