### PR TITLE
Handle speaker autosave and ignore future section errors

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -2557,7 +2557,8 @@ function getWhyThisEventForm() {
                     const relevantErrors = {};
                     if (data && data.errors) {
                         Object.entries(data.errors).forEach(([key, val]) => {
-                            if (!ignoreKeys.includes(key)) {
+                            const isIgnored = ignoreKeys.some(k => key === k || key.startsWith(k + '.'));
+                            if (!isIgnored) {
                                 relevantErrors[key] = val;
                             }
                         });


### PR DESCRIPTION
## Summary
- serialize `.speaker-item` blocks into a `speakers` array so autosave preserves names, roles, bios and LinkedIn links
- filter Save & Continue validation to ignore errors from later sections
- add regression test for speaker autosave persistence and navigation

## Testing
- `DATABASE_URL=sqlite://:memory: python manage.py test` *(fails: FAIL=17, ERR=6)*

------
https://chatgpt.com/codex/tasks/task_e_68c191d0ec48832c98c64943ac5ad5b6