### PR TITLE
Handle stale autosave data and validate speaker contacts

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -93,6 +93,10 @@ window.AutosaveManager = (function() {
         // Merge any previously saved values for fields not currently present
         Object.entries(saved).forEach(([key, val]) => {
             if (!['_proposal_id', 'speakers'].includes(key) && data[key] === undefined) {
+                const prefixes = ['speaker_', 'activity_', 'expense_', 'income_'];
+                if (prefixes.some(p => key.startsWith(p)) && !document.querySelector(`[name="${key}"]`)) {
+                    return; // ignore stale dynamic field data
+                }
                 data[key] = val;
             }
         });


### PR DESCRIPTION
## Summary
- Drop autosaved field data for removed speakers, activities, expenses, and income entries
- Delete speaker data from local storage on removal and focus on first invalid speaker field
- Validate speaker email and LinkedIn URL with Django validators

## Testing
- ⚠️ `python manage.py test` (failed: connection to server at "yamanote.proxy.rlwy.net" failed)


------
https://chatgpt.com/codex/tasks/task_e_68c19856307c832c8b5614a6fba24374