### PR TITLE
Redirect participant count to attendance page

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1621,12 +1621,14 @@ function fillActualSpeakers() {
 
 function fillAttendanceCounts() {
     const totalField = $('#total-participants-modern');
-    if (
-        totalField.length &&
-        totalField.val().trim() === '' &&
-        typeof window.ATTENDANCE_PRESENT !== 'undefined'
-    ) {
+    const numField = $('#num-participants-modern');
+    if (typeof window.ATTENDANCE_PRESENT === 'undefined') return;
+
+    if (totalField.length && totalField.val().trim() === '') {
         totalField.val(window.ATTENDANCE_PRESENT);
+    }
+    if (numField.length && numField.val().trim() === '') {
+        numField.val(window.ATTENDANCE_PRESENT);
     }
 }
 
@@ -2344,18 +2346,25 @@ function setupDynamicActivities() {
 
 function setupAttendanceLink() {
     const attendanceField = $('#attendance-modern');
-    if (!attendanceField.length) return;
+    const participantFields = $('#num-participants-modern, #total-participants-modern');
+    const fields = [];
+    if (attendanceField && attendanceField.length) fields.push(attendanceField);
+    if (participantFields && participantFields.length) fields.push(participantFields);
+    if (!fields.length) return;
 
-    const url = attendanceField.data('attendance-url');
-    attendanceField
-        .prop('readonly', true)
-        .css('cursor', 'pointer')
-        .attr('href', url || '#');
+    fields.forEach((field) => {
+        const url = field.data('attendance-url');
+        field
+            .prop('readonly', true)
+            .css('cursor', 'pointer')
+            .attr('href', url || '#');
+    });
 
     $(document)
-        .off('click', '#attendance-modern')
-        .on('click', '#attendance-modern', async () => {
-            const href = attendanceField.data('attendance-url');
+        .off('click', '#attendance-modern, #num-participants-modern, #total-participants-modern')
+        .on('click', '#attendance-modern, #num-participants-modern, #total-participants-modern', async function () {
+            const field = $(this);
+            const href = field.data('attendance-url');
             if (href) {
                 window.location.href = href;
                 return;
@@ -2384,10 +2393,12 @@ function setupAttendanceLink() {
                     if (path.startsWith('/suite/')) prefix = '/suite';
                     else if (path.startsWith('/emt/')) prefix = '/emt';
                     const attendanceUrl = `${prefix}/reports/${reportId}/attendance/upload/`;
-                    attendanceField
-                        .attr('data-attendance-url', attendanceUrl)
-                        .data('attendance-url', attendanceUrl)
-                        .attr('href', attendanceUrl);
+                    fields.forEach((f) => {
+                        f
+                            .attr('data-attendance-url', attendanceUrl)
+                            .data('attendance-url', attendanceUrl)
+                            .attr('href', attendanceUrl);
+                    });
                     window.location.href = attendanceUrl;
                 } else {
                     alert('Unable to prepare attendance. Please try saving once.');
@@ -2455,9 +2466,8 @@ function initializeAutosaveIndicators() {
             if (path.startsWith('/suite/')) prefix = '/suite';
             else if (path.startsWith('/emt/')) prefix = '/emt';
             const attendanceUrl = `${prefix}/reports/${reportId}/attendance/upload/`;
-            $('#attendance-modern')
+            $('#attendance-modern, #num-participants-modern, #total-participants-modern')
                 .attr('data-attendance-url', attendanceUrl)
-                .data('data-attendance-url', attendanceUrl)
                 .data('attendance-url', attendanceUrl);
             setupAttendanceLink();
         }

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -184,9 +184,16 @@ const docObj={
 function $(sel){
  if(sel===document) return docObj;
  if(sel==='#attendance-modern') return attendanceEl;
+ if(sel==='#num-participants-modern' || sel==='#total-participants-modern') return participantsEl;
  if(sel==='#autosave-indicator') return indicatorEl;
 }
 const attendanceEl={attrs:{},dataStore:{},length:1,
+  attr:function(n,v){if(v===undefined)return this.attrs[n];this.attrs[n]=v;return this;},
+  data:function(n,v){if(v===undefined)return this.dataStore[n];this.dataStore[n]=v;return this;},
+  prop:function(){return this;},
+  css:function(){return this;}
+};
+const participantsEl={attrs:{},dataStore:{},length:1,
   attr:function(n,v){if(v===undefined)return this.attrs[n];this.attrs[n]=v;return this;},
   data:function(n,v){if(v===undefined)return this.dataStore[n];this.dataStore[n]=v;return this;},
   prop:function(){return this;},
@@ -198,14 +205,16 @@ eval(setupCode);
 eval(initCode);
 initializeAutosaveIndicators();
 $(document).trigger('autosave:success', {reportId:__REPORT_ID__});
-console.log(attendanceEl.attrs['href']);
+console.log(JSON.stringify({att: attendanceEl.attrs['href'], part: participantsEl.attrs['href']}));
 '''
         node_script = node_script.replace('__SUBMIT_JS__', str(submit_js)).replace('__REPORT_ID__', str(report_id))
         with tempfile.TemporaryDirectory() as tmp:
             script_path = Path(tmp) / "run.js"
             script_path.write_text(node_script)
             result = subprocess.run(["node", str(script_path)], capture_output=True, text=True)
-        self.assertEqual(result.stdout.strip(), attendance_url)
+        out = json.loads(result.stdout.strip())
+        self.assertEqual(out["att"], attendance_url)
+        self.assertEqual(out["part"], attendance_url)
 
     def test_autosave_indicator_present(self):
         response = self.client.get(


### PR DESCRIPTION
## Summary
- Make participant count fields read-only links to the attendance upload page.
- Auto-fill participant counts from existing attendance data and update links after autosave.
- Extend tests to ensure participant inputs receive attendance links.

## Testing
- `python manage.py test` *(fails: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242) failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d03cce48832c91b18826f38cb349