### PR TITLE
Update attendance UI with faculty table

### DIFF
--- a/emt/static/emt/css/attendance.css
+++ b/emt/static/emt/css/attendance.css
@@ -1,6 +1,17 @@
 .attendance-container {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
+}
+
+.attendance-container .table-section {
+  background: var(--surface-color, #fff);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.attendance-container .table-section + .table-section {
+  margin-top: 1.5rem;
 }
 
 .stats-grid {
@@ -34,10 +45,21 @@
 }
 
 .actions {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
   display: flex;
   gap: 1rem;
   justify-content: flex-end;
+}
+
+.attendance-pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.attendance-pagination button {
+  min-width: 5rem;
 }
 
 .loading {

--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -52,26 +52,40 @@
                 </div>
             </div>
 
-            <div class="table-responsive mt-4">
-                <table id="attendance-table" class="table table-sm table-striped table-hover align-middle d-none">
-                    <thead class="table-light">
-                        <tr>
-                            <th>Registration No</th>
-                            <th>Full Name</th>
-                            <th>Class</th>
-                            <th>Absent</th>
-                            <th>Student Volunteer</th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+            <div id="student-table-section" class="table-section mt-4 d-none">
+                <h2 id="students-section-title" class="h5 mb-3">Student Attendance</h2>
+                <div class="table-responsive">
+                    <table id="student-attendance-table" class="table table-striped table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Registration No</th>
+                                <th>Full Name</th>
+                                <th>Affiliation</th>
+                                <th>Absent</th>
+                                <th>Student Volunteer</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
 
-            <div id="grouped-sections" class="mt-4 d-none">
-                <h2 id="students-section-title" class="h5 mb-3">Students (Class-wise)</h2>
-                <div id="students-group" class="mb-4"></div>
-                <h2 id="faculty-section-title" class="h5 mb-3">Faculty (Organization-wise)</h2>
-                <div id="faculty-group"></div>
+            <div id="faculty-table-section" class="table-section mt-4 d-none">
+                <h2 id="faculty-section-title" class="h5 mb-3">Faculty &amp; Guests</h2>
+                <div class="table-responsive">
+                    <table id="faculty-attendance-table" class="table table-striped table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Registration No</th>
+                                <th>Full Name</th>
+                                <th>Affiliation</th>
+                                <th>Absent</th>
+                                <th>Student Volunteer</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
 
             <div id="actions" class="actions d-none">
@@ -90,8 +104,6 @@
     const reportUrl = "{% url 'emt:submit_event_report' report.proposal.id %}";
     const downloadFilename = "student_audience_{{ report.id }}.csv";
     const csrftoken = '{{ csrf_token }}';
-    const initialStudents = {{ students_group_json|default:'{}'|safe }};
-    const initialFaculty = {{ faculty_group_json|default:'{}'|safe }};
 </script>
 <script src="{% static 'emt/js/attendance.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- widen the attendance upload view and split the grid into dedicated student and faculty/guest tables with matching controls
- tag attendance rows in the backend with category and affiliation data so the UI can render faculty alongside students
- expand the attendance data view tests to cover the new metadata and faculty grouping logic

## Testing
- `python manage.py test emt.tests.test_attendance_data_view emt.tests.test_attendance_save` *(fails: cannot reach configured PostgreSQL service from the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca031b4670832cb09b47813683fdd7