### PR TITLE
Fix event report views and add PDF workflow tests

### DIFF
--- a/emt/templates/emt/generated_reports.html
+++ b/emt/templates/emt/generated_reports.html
@@ -46,11 +46,12 @@
                   </td>
                   <td class="iqac-td-title">
                     <div class="iqac-event-info">
-                      <div class="iqac-event-title">{{ report.event_title|default:"(Untitled Event)" }}</div>
+                      <div class="iqac-event-title">{{ report.proposal.event_title|default:"(Untitled Event)" }}</div>
+                      <div class="iqac-event-meta">{{ report.proposal.organization|default:"N/A" }}</div>
                     </div>
                   </td>
                   <td class="iqac-td-status">
-                    <span class="iqac-status-badge">{{ report.generated_at|date:"M d, Y" }}</span>
+                    <span class="iqac-status-badge">{{ report.created_at|date:"M d, Y" }}</span>
                   </td>
                   <td class="iqac-td-actions">
                     <div class="iqac-action-buttons">
@@ -58,8 +59,8 @@
                       <div class="iqac-download-dropdown">
                         <button class="iqac-action-btn download-btn">Download</button>
                         <div class="iqac-download-options">
-                          <a href="{% url 'emt:download_pdf' report.id %}">PDF</a>
-                          <a href="{% url 'emt:download_word' report.id %}">Word</a>
+                          <a href="{% url 'emt:download_pdf' report.proposal.id %}">PDF</a>
+                          <a href="{% url 'emt:download_word' report.proposal.id %}">Word</a>
                         </div>
                       </div>
                     </div>

--- a/emt/templates/emt/report_generation.html
+++ b/emt/templates/emt/report_generation.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'emt/css/iqac_generated_reports.css' %}">
+<div class="iqac-dashboard-bg">
+  <div class="iqac-dashboard-container">
+    <div class="iqac-page-header">
+      <div class="iqac-header-content">
+        <div class="iqac-header-icon">
+          <span class="iqac-section-emoji"><i class="fa-solid fa-file-lines"></i></span>
+        </div>
+        <div class="iqac-header-text">
+          <h1 class="iqac-page-title">Generate Event Report</h1>
+          <p class="iqac-page-subtitle">Provide the event details to create a downloadable PDF.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="iqac-card">
+      <form method="post" action="{% url 'emt:generate_report_pdf' %}" class="iqac-form">
+        {% csrf_token %}
+        <div class="iqac-form-grid">
+          <div class="iqac-form-group">
+            <label for="event-title">Event Title</label>
+            <input id="event-title" name="event_title" type="text" class="iqac-input" placeholder="e.g., Research Symposium 2024" required>
+          </div>
+          <div class="iqac-form-group">
+            <label for="event-date">Event Date</label>
+            <input id="event-date" name="event_date" type="date" class="iqac-input">
+          </div>
+          <div class="iqac-form-group">
+            <label for="venue">Venue</label>
+            <input id="venue" name="venue" type="text" class="iqac-input" placeholder="e.g., Main Auditorium">
+          </div>
+        </div>
+
+        <div class="iqac-form-group">
+          <label for="event-summary">Event Summary</label>
+          <textarea id="event-summary" name="event_summary" class="iqac-textarea" rows="4" placeholder="Summarize the proceedings and highlights."></textarea>
+        </div>
+        <div class="iqac-form-group">
+          <label for="key-outcomes">Key Outcomes</label>
+          <textarea id="key-outcomes" name="key_outcomes" class="iqac-textarea" rows="4" placeholder="List the primary outcomes or achievements."></textarea>
+        </div>
+        <div class="iqac-form-group">
+          <label for="additional-notes">Additional Notes</label>
+          <textarea id="additional-notes" name="additional_notes" class="iqac-textarea" rows="3" placeholder="Include acknowledgements or follow-up actions."></textarea>
+        </div>
+
+        <div class="iqac-form-actions">
+          <button type="submit" class="iqac-action-btn primary">Download PDF</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/emt/templates/emt/view_report.html
+++ b/emt/templates/emt/view_report.html
@@ -68,9 +68,13 @@
 
                 <!-- Report Content Preview -->
                 <div class="report-preview">
-                    {% if report.html_content %}
+                    {% if report.ai_generated_report %}
                         <div class="content-preview">
-                            {{ report.html_content|safe|truncatewords:30 }}
+                            {{ report.ai_generated_report|linebreaks }}
+                        </div>
+                    {% elif report.summary %}
+                        <div class="content-preview">
+                            {{ report.summary|linebreaks }}
                         </div>
                     {% else %}
                         <div class="no-content">
@@ -81,7 +85,7 @@
 
                 <!-- Action Buttons -->
                 <div class="report-actions">
-                    <a href="{% url 'emt:download_pdf' report.id %}" class="action-btn primary">
+                    <a href="{% url 'emt:download_pdf' report.proposal.id %}" class="action-btn primary">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <polyline points="7,10 12,15 17,10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -89,7 +93,7 @@
                         </svg>
                         Download PDF
                     </a>
-                    <a href="#" class="action-btn secondary">
+                    <a href="{% url 'emt:download_word' report.proposal.id %}" class="action-btn secondary">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                             <polyline points="7,10 12,15 17,10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/emt/tests/test_report_generation.py
+++ b/emt/tests/test_report_generation.py
@@ -1,0 +1,156 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_logged_in
+from django.db.models.signals import post_save
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import Report
+from core.signals import assign_role_on_login, create_or_update_user_profile
+
+from emt.models import EventProposal, EventReport
+
+
+class ReportGenerationViewsTests(TestCase):
+    def test_report_form_route_returns_200(self):
+        response = self.client.get(reverse("emt:report_form"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "emt/report_generation.html")
+
+    def test_generate_report_pdf_rejects_non_post(self):
+        response = self.client.get(reverse("emt:generate_report_pdf"))
+        self.assertEqual(response.status_code, 405)
+
+    @patch("emt.views.pdfkit.from_string", return_value=b"%PDF-1.4 test")
+    def test_generate_report_pdf_returns_pdf(self, mock_from_string):
+        payload = {
+            "event_title": "AI Workshop",
+            "event_date": "2024-09-01",
+        }
+        response = self.client.post(reverse("emt:generate_report_pdf"), data=payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn("Event_Report.pdf", response["Content-Disposition"])
+        mock_from_string.assert_called_once()
+
+
+class EventReportWorkflowTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="reporter", password="testpass")
+        self.client.force_login(self.user)
+        self.proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Campus Meetup",
+            event_datetime=timezone.now(),
+        )
+
+    def test_generate_report_populates_ai_fields(self):
+        response = self.client.get(reverse("emt:generate_report", args=[self.proposal.id]))
+        self.assertEqual(response.status_code, 302)
+        report = EventReport.objects.get(proposal=self.proposal)
+        self.assertTrue(report.ai_generated_report)
+        self.assertTrue(report.summary)
+
+    def test_download_pdf_uses_event_report_fields(self):
+        report = EventReport.objects.create(
+            proposal=self.proposal,
+            ai_generated_report="Comprehensive AI content",
+            summary="Fallback summary",
+        )
+        with patch("reportlab.pdfgen.canvas.Canvas") as mock_canvas:
+            canvas_instance = mock_canvas.return_value
+            canvas_instance.drawString.return_value = None
+            canvas_instance.showPage.return_value = None
+            canvas_instance.save.return_value = None
+            response = self.client.get(reverse("emt:download_pdf", args=[self.proposal.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn(self.proposal.event_title, response["Content-Disposition"])
+
+    def test_admin_reports_view_handles_event_reports(self):
+        EventReport.objects.create(
+            proposal=self.proposal,
+            ai_generated_report="Admin table content",
+            summary="",
+        )
+        Report.objects.create(title="Submitted Report", report_type="event")
+        response = self.client.get(reverse("emt:admin_reports_view"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Campus Meetup")
+
+    def test_generated_reports_links_resolve(self):
+        report = EventReport.objects.create(
+            proposal=self.proposal,
+            ai_generated_report="Detailed AI write-up",
+        )
+        response = self.client.get(reverse("emt:generated_reports"))
+        self.assertEqual(response.status_code, 200)
+        view_url = reverse("emt:view_report", args=[report.id])
+        download_url = reverse("emt:download_pdf", args=[self.proposal.id])
+        self.assertContains(response, view_url)
+        self.assertContains(response, download_url)
+
+        view_response = self.client.get(view_url)
+        self.assertEqual(view_response.status_code, 200)
+        self.assertContains(view_response, "Detailed AI write-up")
+
+        with patch("reportlab.pdfgen.canvas.Canvas") as mock_canvas:
+            canvas_instance = mock_canvas.return_value
+            canvas_instance.drawString.return_value = None
+            canvas_instance.showPage.return_value = None
+            canvas_instance.save.return_value = None
+            download_response = self.client.get(download_url)
+        self.assertEqual(download_response.status_code, 200)
+
+    def test_submit_event_report_prefills_existing_text(self):
+        EventReport.objects.create(
+            proposal=self.proposal,
+            summary="Stored summary text",
+            outcomes="Documented outcomes",
+        )
+        response = self.client.get(reverse("emt:submit_event_report", args=[self.proposal.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Stored summary text")
+        self.assertContains(response, "Documented outcomes")
+
+    def test_view_report_prefers_ai_text_and_download_link(self):
+        report = EventReport.objects.create(
+            proposal=self.proposal,
+            ai_generated_report="AI generated narrative",
+            summary="Concise fallback summary",
+        )
+        response = self.client.get(reverse("emt:view_report", args=[report.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "AI generated narrative")
+        download_url = reverse("emt:download_pdf", args=[self.proposal.id])
+        self.assertContains(response, download_url)
+        with patch("reportlab.pdfgen.canvas.Canvas") as mock_canvas:
+            canvas_instance = mock_canvas.return_value
+            canvas_instance.drawString.return_value = None
+            canvas_instance.showPage.return_value = None
+            canvas_instance.save.return_value = None
+            download_response = self.client.get(download_url)
+        self.assertEqual(download_response.status_code, 200)
+
+    def test_view_report_falls_back_to_summary(self):
+        report = EventReport.objects.create(
+            proposal=self.proposal,
+            summary="Only summary available",
+        )
+        response = self.client.get(reverse("emt:view_report", args=[report.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Only summary available")

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -27,6 +27,8 @@ urlpatterns = [
     path('autosave-need-analysis/', views.autosave_need_analysis, name='autosave_need_analysis'),
     path('autosave-event-report/', views.autosave_event_report, name='autosave_event_report'),
     path('pending-reports/', views.pending_reports, name='pending_reports'),
+    path('report-generation/', views.report_form, name='report_form'),
+    path('report-generation/pdf/', views.generate_report_pdf, name='generate_report_pdf'),
     path('generate-report/<int:proposal_id>/', views.generate_report, name='generate_report'),
     path('report-success/<int:proposal_id>/', views.report_success, name='report_success'),
     path('download/pdf/<int:proposal_id>/', views.download_pdf, name='download_pdf'),
@@ -34,6 +36,7 @@ urlpatterns = [
     path('download/audience-csv/<int:proposal_id>/', views.download_audience_csv, name='download_audience_csv'),
     path('generated-reports/', views.generated_reports, name='generated_reports'),
     path('view-report/<int:report_id>/', views.view_report, name='view_report'),
+    path('admin/reports/', views.admin_reports_view, name='admin_reports_view'),
 
     path('reports/<int:report_id>/attendance/upload/', views.upload_attendance_csv, name='attendance_upload'),
     path('reports/<int:report_id>/attendance/save/', views.save_attendance_rows, name='attendance_save'),

--- a/templates/core/admin_reports.html
+++ b/templates/core/admin_reports.html
@@ -99,7 +99,7 @@
                 <td>
                     {% if report.proposal %}
                         <a href="{% url 'emt:view_report' report.id %}" class="report-action-btn">View</a>
-                        <a href="{% url 'emt:download_pdf' report.id %}" class="report-action-btn">PDF</a>
+                        <a href="{% url 'emt:download_pdf' report.proposal.id %}" class="report-action-btn">PDF</a>
                     {% else %}
                         {% if report.file %}
                             <a href="{{ report.file.url }}" class="report-action-btn" download>Download</a>


### PR DESCRIPTION
## Summary
- add a dedicated event report generation template and expose URLs for the form and PDF endpoint
- update event report views/templates to use real EventReport fields and fix generated/admin listings
- add regression tests covering the PDF workflow, generated report listings, and report view fallbacks

## Testing
- python manage.py test emt *(fails: database connection to the configured PostgreSQL instance is unreachable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0fba92b4832cad2f249674bab88b