### PR TITLE
Add dedicated faculty and guest sections to attendance upload

### DIFF
--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -71,7 +71,7 @@
             </div>
 
             <div id="faculty-table-section" class="table-section mt-4 d-none">
-                <h2 id="faculty-section-title" class="h5 mb-3">Faculty &amp; Guests</h2>
+                <h2 id="faculty-section-title" class="h5 mb-3">Faculty Attendance</h2>
                 <div class="table-responsive">
                     <table id="faculty-attendance-table" class="table table-striped table-hover align-middle">
                         <thead class="table-light">
@@ -80,7 +80,25 @@
                                 <th>Full Name</th>
                                 <th>Affiliation</th>
                                 <th>Absent</th>
-                                <th>Student Volunteer</th>
+                                <th>Volunteer</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div id="guest-table-section" class="table-section mt-4 d-none">
+                <h2 id="guest-section-title" class="h5 mb-3">Guest Attendance</h2>
+                <div class="table-responsive">
+                    <table id="guest-attendance-table" class="table table-striped table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Registration No</th>
+                                <th>Full Name</th>
+                                <th>Affiliation</th>
+                                <th>Absent</th>
+                                <th>Volunteer</th>
                             </tr>
                         </thead>
                         <tbody></tbody>


### PR DESCRIPTION
## Summary
- split the attendance upload preview into student, faculty, and guest sections
- render new faculty and guest tables on the frontend while reusing a helper for row rendering

## Testing
- `python manage.py test emt.tests.test_attendance_data_view` *(fails: cannot reach remote PostgreSQL database in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca30dd7934832c8325b29e06f731df