### PR TITLE
Fix attendance upload to include faculty rows

### DIFF
--- a/emt/tests/test_attendance_upload_view.py
+++ b/emt/tests/test_attendance_upload_view.py
@@ -1,0 +1,97 @@
+import csv
+import json
+from io import StringIO
+
+from django.contrib.auth.models import User
+from django.contrib.auth.signals import user_logged_in
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db.models.signals import post_save
+from django.test import TestCase
+from django.urls import reverse
+
+from core.models import Organization, OrganizationType
+from core.signals import create_or_update_user_profile, assign_role_on_login
+from emt.models import EventProposal, EventReport
+
+
+class UploadAttendanceCsvViewTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        post_save.disconnect(create_or_update_user_profile, sender=User)
+        user_logged_in.disconnect(assign_role_on_login)
+
+    @classmethod
+    def tearDownClass(cls):
+        user_logged_in.connect(assign_role_on_login)
+        post_save.connect(create_or_update_user_profile, sender=User)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="upload", password="pass")
+        self.client.force_login(self.user)
+
+        org_type = OrganizationType.objects.create(name="Dept")
+        organization = Organization.objects.create(name="Org", org_type=org_type)
+        proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Upload Test Event",
+            organization=organization,
+        )
+        self.report = EventReport.objects.create(proposal=proposal)
+
+    def _build_combined_csv(self, total_rows=101, faculty_index=-1):
+        """Create a CSV payload with a faculty row at the desired index."""
+        data = StringIO()
+        writer = csv.writer(data)
+        writer.writerow(
+            [
+                "Category",
+                "Identifier",
+                "Full Name",
+                "Affiliation",
+                "Absent",
+                "Student Volunteer",
+            ]
+        )
+
+        for idx in range(total_rows):
+            if idx == faculty_index or (faculty_index < 0 and idx == total_rows - 1):
+                writer.writerow(
+                    [
+                        "faculty",
+                        f"FAC{idx}",
+                        f"Faculty {idx}",
+                        "Dept",
+                        "FALSE",
+                        "FALSE",
+                    ]
+                )
+            else:
+                writer.writerow(
+                    [
+                        "student",
+                        f"STU{idx}",
+                        f"Student {idx}",
+                        "Class",
+                        "FALSE",
+                        "FALSE",
+                    ]
+                )
+
+        data.seek(0)
+        return SimpleUploadedFile(
+            "attendance.csv", data.getvalue().encode("utf-8"), content_type="text/csv"
+        )
+
+    def test_uploaded_rows_include_faculty_beyond_first_page(self):
+        url = reverse("emt:attendance_upload", args=[self.report.id])
+        upload = self._build_combined_csv(total_rows=101)
+
+        response = self.client.post(url, {"csv_file": upload})
+        self.assertEqual(response.status_code, 200)
+
+        rows = json.loads(response.context["rows_json"])
+        self.assertEqual(len(rows), 101)
+        self.assertEqual(rows[-1]["category"], "faculty")
+        self.assertEqual(response.context["counts"]["total"], 101)

--- a/emt/views.py
+++ b/emt/views.py
@@ -2632,7 +2632,11 @@ def upload_attendance_csv(request, report_id):
 
     context = {
         "report": report,
-        "rows_json": json.dumps(rows_page),
+        # When a CSV is uploaded we want to preview the entire dataset so that
+        # faculty rows are not hidden behind the initial 100 row slice.
+        # The frontend already paginates the full list on the client side, so
+        # pass the complete set of rows instead of just the first page.
+        "rows_json": json.dumps(rows if rows else rows_page),
         "students_group_json": json.dumps(student_groups),
         "faculty_group_json": json.dumps(faculty_groups),
         "error": error,


### PR DESCRIPTION
## Summary
- ensure the attendance upload preview passes the full dataset to the client so faculty entries are visible
- add a regression test covering faculty rows beyond the initial 100 record slice

## Testing
- python manage.py test emt.tests.test_attendance_upload_view *(fails: django.db.utils.OperationalError: connection to server at "yamanote.proxy.rlwy.net" (66.33.22.242), port 25156 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ca42291e80832c99e40b84e4463a4a