### PR TITLE
Ensure attendance upload sends full dataset

### DIFF
--- a/emt/static/emt/js/attendance.js
+++ b/emt/static/emt/js/attendance.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
-    let rows = initialRows || [];
+    let rows = Array.isArray(initialRows) ? initialRows : [];
     const perPage = 100;
     let currentPage = 1;
     let activeCategory = 'student';
@@ -382,7 +382,7 @@ document.addEventListener('DOMContentLoaded', function () {
         fetch(dataUrl)
             .then(r => r.json())
             .then(data => {
-                rows = data.rows || [];
+                rows = Array.isArray(data.rows) ? data.rows : [];
                 currentPage = 1;
                 renderTables();
             })


### PR DESCRIPTION
## Summary
- ensure the attendance upload view serializes the complete saved dataset and keeps pagination flags aligned with it
- harden the attendance preview script so it always works with array data when the full dataset is supplied
- add a regression test covering saved attendance sets with more than 100 rows to confirm faculty tabs remain visible

## Testing
- python manage.py test emt.tests.test_attendance_upload_view *(fails: cannot reach configured PostgreSQL instance)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5030b1ec832c9f29136b3525d8b0