### PR TITLE
Show attendance faculty tab even without records

### DIFF
--- a/emt/static/emt/css/attendance.css
+++ b/emt/static/emt/css/attendance.css
@@ -49,6 +49,15 @@
   cursor: pointer;
 }
 
+.attendance-category-nav .nav-link.no-data {
+  opacity: 0.65;
+}
+
+.attendance-category-nav .nav-link.no-data:hover,
+.attendance-category-nav .nav-link.no-data:focus {
+  opacity: 0.85;
+}
+
 #attendance-table {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- keep the attendance category pills visible for all attendee groups and surface placeholders when a group has no rows
- add first-render logic so a tab with data is selected while still allowing faculty/guest tabs to be opened without data
- style empty-category tabs with a lighter appearance to indicate that no records are available yet

## Testing
- python manage.py test emt.tests.test_attendance_upload_view *(fails: database connection to Railway Postgres is unreachable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cafcb54228832caec96a37c64a78f3