### PR TITLE
Improve attendance faculty view and remove guest tab

### DIFF
--- a/emt/templates/emt/attendance_upload.html
+++ b/emt/templates/emt/attendance_upload.html
@@ -57,11 +57,6 @@
                         Faculty
                     </button>
                 </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" type="button" role="tab" data-category="external" data-label="Guests" data-volunteer-label="Volunteer">
-                        Guests
-                    </button>
-                </li>
             </ul>
 
             <div id="loading" class="loading text-center my-3">


### PR DESCRIPTION
## Summary
- remove the guest tab from the attendance upload view so only student and faculty filters are shown
- update the attendance table renderer to paginate within the selected category, keeping faculty rows visible alongside their affiliations
- treat external attendees as part of the student view and refresh pagination controls/state when new data is loaded

## Testing
- python manage.py test emt.tests.test_attendance_data_view *(fails: connection to remote PostgreSQL test database is unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caffa95aa4832c82f84124dd5f8ca9