### PR TITLE
Allow configuring new Railway database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
+# Application configuration
+DATABASE_URL=postgres://username:password@host:5432/dbname
 AI_BACKEND=OPENROUTER
 OPENROUTER_API_KEY=__set_me__
 OPENROUTER_MODEL=qwen/qwen3-coder:free
 LOCAL_AI_BASE_URL=http://127.0.0.1:8000
 LOCAL_AI_MODEL=Qwen2.5-7B-Instruct-1M
+
+# Railway migration helper script
 SOURCE_DATABASE_URL=postgres://username:password@old-host:5432/olddb
 TARGET_DATABASE_URL=postgres://username:password@new-host:5432/newdb

--- a/README.md
+++ b/README.md
@@ -383,7 +383,18 @@ Replace `2025-2026` with the year you want to delete.
 
 ## Railway PostgreSQL Migration
 
-Use the provided `migrate_railway_pg.sh` script to migrate data between two Railway-managed PostgreSQL databases.
+When you rotate to a fresh Railway PostgreSQL instance, update the Django app first:
+
+1. Copy `.env.example` if you have not already and set `DATABASE_URL` to the new Railway **External Connection** string.
+2. Apply migrations against the empty database:
+
+   ```bash
+   python manage.py migrate
+   ```
+
+3. Restart your deployment so the new connection string is picked up.
+
+If you also need to transfer the previous data set, use the provided `migrate_railway_pg.sh` script to copy records between two Railway-managed PostgreSQL databases.
 
 1. Copy the example environment file and fill in values from Railway's `DATABASE_URL` for both old and new databases:
 

--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -9,6 +9,9 @@ except Exception:
 import logging
 import dj_database_url
 
+
+logger = logging.getLogger(__name__)
+
 # ---- .env loader (django-environ if available, else os.getenv) ----
 
 try:
@@ -153,8 +156,14 @@ DATABASES = {
         ssl_require=False,
     )
 }
-if "railway.internal" in DATABASES["default"].get("HOST", ""):
-    raise RuntimeError("Invalid DB host — still pointing to Railway.")
+db_host = DATABASES["default"].get("HOST", "")
+if db_host and "railway.internal" in db_host:
+    logger.warning(
+        "Detected Railway internal database host (%s). Replace DATABASE_URL in your "
+        ".env with the External Connection string from Railway to avoid private network"
+        " URLs.",
+        db_host,
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- log a helpful warning instead of aborting when a Railway internal host is detected so the new connection string can be swapped in via .env
- document the steps for pointing Django at the new Railway database and expose DATABASE_URL in .env.example

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cc060a7710832c9137b105ef3fd618