### PR TITLE
Fix attendance field population for HTML inputs

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1639,7 +1639,7 @@ function fillAttendanceCounts() {
         if (value === undefined || value === null) return;
         const el = document.getElementById(id);
         if (!el) return;
-        if (Object.prototype.hasOwnProperty.call(el, 'value')) {
+        if ('value' in el && typeof el.value !== 'undefined') {
             el.value = value;
         } else {
             el.textContent = value;


### PR DESCRIPTION
## Summary
- update the fillAttendanceCounts helper to detect HTML input elements via the `value` property
- keep textContent updates for non-input targets so saved counts populate correctly

## Testing
- not run (frontend behaviour requires manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68cd7cbb9fdc832ca712a016f3288aab