### PR TITLE
Enhance speaker details display in event report

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1922,8 +1922,125 @@ textarea {
 }
 
 .speakers-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
     max-height: 400px;
     overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.speaker-card {
+    display: flex;
+    gap: 1rem;
+    align-items: stretch;
+}
+
+.speaker-card-media {
+    flex-shrink: 0;
+}
+
+.speaker-photo {
+    width: 96px;
+    height: 96px;
+    border-radius: 0.5rem;
+    background: #e2e8f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    color: #1e293b;
+    font-weight: 600;
+    font-size: 1.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.speaker-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.speaker-photo-placeholder {
+    background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+}
+
+.speaker-card-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.speaker-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.speaker-contact-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    color: #475569;
+}
+
+.speaker-contact-label {
+    font-weight: 600;
+    color: #1e293b;
+    margin-right: 0.25rem;
+}
+
+.speaker-contact-item a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+.speaker-contact-item a:hover,
+.speaker-contact-item a:focus {
+    text-decoration: underline;
+}
+
+.speaker-bio {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: #475569;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.375rem;
+    padding: 0.75rem;
+}
+
+.speaker-bio-label {
+    display: block;
+    font-weight: 600;
+    color: #1e293b;
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+}
+
+.speaker-bio p {
+    margin: 0;
+}
+
+@media (max-width: 640px) {
+    .speaker-card {
+        flex-direction: column;
+    }
+
+    .speaker-card-media {
+        width: 100%;
+    }
+
+    .speaker-photo {
+        width: 100%;
+        max-height: 220px;
+        font-size: 1.5rem;
+    }
 }
 
 /* Placeholder Section Styling */

--- a/emt/views.py
+++ b/emt/views.py
@@ -2143,17 +2143,31 @@ def submit_event_report(request, proposal_id):
 
     # Fetch speakers data for editing
     speakers_qs = SpeakerProfile.objects.filter(proposal=proposal)
-    speakers_json = [
-        {
-            "full_name": s.full_name,
-            "name": s.full_name,  # Backward compatibility
-            "designation": s.designation,
-            "affiliation": s.affiliation,
-            "organization": s.affiliation,  # Backward compatibility
-            "contact": s.contact_email,
-        }
-        for s in speakers_qs
-    ]
+    speakers_json = []
+    for speaker in speakers_qs:
+        photo_url = ""
+        if speaker.photo:
+            try:
+                photo_url = speaker.photo.url
+            except ValueError:
+                photo_url = ""
+
+        speakers_json.append(
+            {
+                "full_name": speaker.full_name,
+                "name": speaker.full_name,  # Backward compatibility
+                "designation": speaker.designation,
+                "affiliation": speaker.affiliation,
+                "organization": speaker.affiliation,  # Backward compatibility
+                "contact": speaker.contact_email,
+                "contact_email": speaker.contact_email,
+                "contact_number": speaker.contact_number,
+                "linkedin_url": speaker.linkedin_url,
+                "detailed_profile": speaker.detailed_profile,
+                "photo": photo_url,
+                "photo_url": photo_url,
+            }
+        )
 
     # Get or create content sections for the report
     event_summary = None


### PR DESCRIPTION
## Summary
- include full speaker metadata and photo URLs in the event report context
- render detailed speaker cards in the event report form with contact, profile, and photo placeholders
- add styling for the richer speaker layout and responsive media presentation

## Testing
- python manage.py test emt.tests.test_event_report_view *(fails: database connection is unreachable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd80796dfc832cb3bd284e3f2f04e2