### PR TITLE
Enable editing of proposal speakers in event report

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1925,24 +1925,46 @@ textarea {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    max-height: 400px;
-    overflow-y: auto;
-    padding-right: 0.25rem;
 }
 
-.speaker-card {
+.speaker-card { 
+    display: flex; 
+    gap: 1rem; 
+    align-items: stretch; 
+}
+
+.speakers-editable {
     display: flex;
-    gap: 1rem;
-    align-items: stretch;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
-.speaker-card-media {
-    flex-shrink: 0;
+.speaker-card-editable {
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    background: #ffffff;
+    align-items: flex-start;
 }
 
-.speaker-photo {
-    width: 96px;
-    height: 96px;
+.speaker-card-readonly {
+    border: 1px dashed #cbd5f5;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    background: #f8fafc;
+}
+
+.speaker-card-media { 
+    flex-shrink: 0; 
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.speaker-photo { 
+    width: 96px; 
+    height: 96px; 
     border-radius: 0.5rem;
     background: #e2e8f0;
     display: flex;
@@ -1956,33 +1978,201 @@ textarea {
     letter-spacing: 0.03em;
 }
 
-.speaker-photo img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+.speaker-photo img { 
+    width: 100%; 
+    height: 100%; 
+    object-fit: cover; 
 }
 
-.speaker-photo-placeholder {
+.speaker-photo-container {
+    position: relative;
+}
+
+.speaker-photo-remove {
+    position: absolute;
+    top: -0.4rem;
+    right: -0.4rem;
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    border: none;
+    background: #ef4444;
+    color: #ffffff;
+    font-size: 1rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 6px 12px rgba(15, 23, 42, 0.15);
+}
+
+.speaker-photo-remove[hidden] {
+    display: none;
+}
+
+.speaker-photo-upload {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    color: #2563eb;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.speaker-photo-upload input {
+    display: none;
+}
+
+.speaker-photo-placeholder { 
     background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
 }
 
-.speaker-card-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+.speaker-card-content { 
+    flex: 1; 
+    display: flex; 
+    flex-direction: column; 
+    gap: 0.75rem; 
 }
 
-.speaker-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-}
-
-.speaker-contact-info {
+.speaker-header {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+}
+
+.speaker-header-title {
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.speaker-readonly-hint {
+    font-size: 0.85rem;
+    color: #64748b;
+}
+
+.speaker-meta { 
+    display: flex; 
+    flex-direction: column; 
+    gap: 0.125rem; 
+}
+
+.speaker-fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem 1rem;
+}
+
+.speaker-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.speaker-field label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #334155;
+}
+
+.speaker-field input,
+.speaker-field textarea {
+    width: 100%;
+    border: 1px solid #cbd5f5;
+    border-radius: 0.5rem;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.95rem;
+    background: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.speaker-field input:focus,
+.speaker-field textarea:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    outline: none;
+}
+
+.speaker-field textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+.speaker-field-full {
+    grid-column: 1 / -1;
+}
+
+.speaker-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.speaker-save-btn,
+.speaker-reset-btn {
+    border-radius: 0.5rem;
+    padding: 0.45rem 1.1rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.speaker-save-btn {
+    background: #2563eb;
+    color: #ffffff;
+    box-shadow: 0 4px 10px rgba(37, 99, 235, 0.25);
+}
+
+.speaker-save-btn:disabled {
+    background: #93c5fd;
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.speaker-reset-btn {
+    background: #f1f5f9;
+    color: #1e293b;
+    border: 1px solid #e2e8f0;
+}
+
+.speaker-reset-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.speaker-status {
+    font-size: 0.85rem;
+    color: #475569;
+    min-width: 140px;
+}
+
+.speaker-card-dirty .speaker-status {
+    color: #b45309;
+}
+
+.speaker-card-readonly .speaker-photo-remove {
+    display: none;
+}
+
+.speaker-card-readonly .speaker-photo-upload {
+    color: #94a3b8;
+    cursor: default;
+}
+
+.speaker-card-readonly .speaker-field input,
+.speaker-card-readonly .speaker-field textarea {
+    background: #eef2ff;
+    border-color: #dbeafe;
+}
+
+.speaker-contact-info { 
+    display: flex; 
+    flex-direction: column; 
+    gap: 0.25rem; 
     font-size: 0.85rem;
     color: #475569;
 }
@@ -2028,18 +2218,23 @@ textarea {
 }
 
 @media (max-width: 640px) {
-    .speaker-card {
-        flex-direction: column;
-    }
+    .speaker-card { 
+        flex-direction: column; 
+    } 
 
-    .speaker-card-media {
-        width: 100%;
-    }
+    .speaker-card-media { 
+        width: 100%; 
+        align-items: flex-start; 
+    } 
 
-    .speaker-photo {
-        width: 100%;
-        max-height: 220px;
-        font-size: 1.5rem;
+    .speaker-photo { 
+        width: 100%; 
+        max-height: 220px; 
+        font-size: 1.5rem; 
+    } 
+
+    .speaker-fields {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -381,6 +381,7 @@
         window.SDG_GOALS = {{ sdg_goals_list|default:'[]'|safe }};
         window.PROPOSAL_ACTIVITIES = {{ proposal_activities_json|safe }};
         window.EXISTING_SPEAKERS = {{ speakers_json|default:'[]'|safe }};
+        window.SPEAKER_UPDATE_BASE = "{% url 'emt:api_update_speaker' proposal.id 0 %}".split('0/')[0];
         window.ATTENDANCE_PRESENT = {{ attendance_present|default:0 }};
         window.ATTENDANCE_ABSENT = {{ attendance_absent|default:0 }};
         window.ATTENDANCE_VOLUNTEERS = {{ attendance_volunteers|default:0 }};

--- a/emt/tests/test_speaker_api.py
+++ b/emt/tests/test_speaker_api.py
@@ -1,0 +1,111 @@
+import shutil
+import tempfile
+
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from core.models import Organization, OrganizationType
+from emt.models import EventProposal, SpeakerProfile
+
+
+class SpeakerApiTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self._media_root = tempfile.mkdtemp()
+        self.override = override_settings(MEDIA_ROOT=self._media_root)
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(lambda: shutil.rmtree(self._media_root, ignore_errors=True))
+
+        self.submitter = User.objects.create_user(username="submitter", password="pass")
+        self.other_user = User.objects.create_user(username="other", password="pass")
+
+        org_type = OrganizationType.objects.create(name="Department")
+        organization = Organization.objects.create(name="IQAC", org_type=org_type)
+
+        self.proposal = EventProposal.objects.create(
+            event_title="Test Event",
+            organization=organization,
+            submitted_by=self.submitter,
+            academic_year="2024-2025",
+        )
+
+        self.speaker = SpeakerProfile.objects.create(
+            proposal=self.proposal,
+            full_name="John Doe",
+            designation="Analyst",
+            affiliation="Research Lab",
+            contact_email="john@example.com",
+            contact_number="1234567890",
+            linkedin_url="https://linkedin.com/in/johndoe",
+            detailed_profile="Bio information",
+        )
+
+        self.url = reverse(
+            "emt:api_update_speaker", args=[self.proposal.id, self.speaker.id]
+        )
+
+    def _payload(self, **overrides):
+        data = {
+            "full_name": "Dr. Jane Doe",
+            "designation": "Senior Analyst",
+            "affiliation": "Innovation Hub",
+            "contact_email": "jane@example.com",
+            "contact_number": "5551234567",
+            "linkedin_url": "https://linkedin.com/in/janedoe",
+            "detailed_profile": "Updated biography",
+        }
+        data.update(overrides)
+        return data
+
+    def test_requires_permission(self):
+        self.client.force_login(self.other_user)
+        response = self.client.post(self.url, self._payload())
+        self.assertEqual(response.status_code, 403)
+
+    def test_updates_speaker_fields(self):
+        self.client.force_login(self.submitter)
+        payload = self._payload()
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data.get("success"))
+        self.assertEqual(data["speaker"]["full_name"], payload["full_name"])
+        self.speaker.refresh_from_db()
+        self.assertEqual(self.speaker.full_name, payload["full_name"])
+        self.assertEqual(self.speaker.designation, payload["designation"])
+        self.assertEqual(self.speaker.affiliation, payload["affiliation"])
+        self.assertEqual(self.speaker.contact_email, payload["contact_email"])
+        self.assertEqual(self.speaker.contact_number, payload["contact_number"])
+        self.assertEqual(self.speaker.linkedin_url, payload["linkedin_url"])
+        self.assertEqual(self.speaker.detailed_profile, payload["detailed_profile"])
+
+    def test_remove_photo(self):
+        photo = SimpleUploadedFile("photo.jpg", b"file", content_type="image/jpeg")
+        self.speaker.photo.save("photo.jpg", photo, save=True)
+        self.client.force_login(self.submitter)
+        payload = self._payload(remove_photo="1")
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data.get("success"))
+        self.assertEqual(data["speaker"].get("photo"), "")
+        self.speaker.refresh_from_db()
+        self.assertFalse(bool(self.speaker.photo))
+
+    def test_upload_new_photo(self):
+        self.client.force_login(self.submitter)
+        payload = self._payload()
+        new_photo = SimpleUploadedFile(
+            "new.jpg", b"newfile", content_type="image/jpeg"
+        )
+        payload["photo"] = new_photo
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data.get("success"))
+        self.assertNotEqual(data["speaker"].get("photo"), "")
+        self.speaker.refresh_from_db()
+        self.assertTrue(bool(self.speaker.photo))

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -48,6 +48,11 @@ urlpatterns = [
 
     # THE NEW, GENERIC ORG API ENDPOINT:
     path('api/organizations/', views.api_organizations, name='api_organizations'),
+    path(
+        'api/proposals/<int:proposal_id>/speakers/<int:speaker_id>/',
+        views.api_update_speaker,
+        name='api_update_speaker',
+    ),
 
     # Faculty remains as is
     path("api/faculty/", views.api_faculty, name="api_faculty"),


### PR DESCRIPTION
## Summary
- allow inline editing of proposal speaker reference cards on the event report form
- expose a speaker update API and include speaker IDs in serialized JSON payloads
- refresh styling for editable speaker cards and add regression tests for the API, including image handling

## Testing
- DATABASE_URL=sqlite:///test.sqlite3 python manage.py test emt.tests.test_speaker_api *(fails: conflicting migrations between 0027_attendancerow_category and 0028_cdltaskassignment_label_cdltaskassignment_status_and_more)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaf6cc39c832cb085b78d5d0c390e