### PR TITLE
Remove actual speakers input and tighten speaker card spacing

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -1902,8 +1902,8 @@ textarea {
     background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
     border: 1px solid #e2e8f0;
     border-radius: 0.5rem;
-    padding: 1.25rem;
-    margin: 0.35rem 0;
+    padding: 1rem 1.25rem;
+    margin: 0.25rem 0 0.75rem;
 }
 
 .speaker-reference-item {

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -608,7 +608,6 @@ $(document).on('click', '#ai-sdg-implementation', function(){
               }
               populateSpeakersFromProposal();
               fillOrganizingCommittee();
-              fillActualSpeakers();
               fillAttendanceCounts();
               if (typeof setupAttendanceLink === 'function') setupAttendanceLink();
           };
@@ -1098,15 +1097,6 @@ $(document).on('click', '#ai-sdg-implementation', function(){
               </div>
           </div>
 
-          <div class="form-row full-width">
-              <div class="input-group">
-                  <label for="actual-speakers-modern">Actual Speakers</label>
-                  <textarea id="actual-speakers-modern" name="actual_speakers" rows="8" 
-                      placeholder="List the actual speakers who participated:&#10;&#10;• Speaker 1: Dr. [Name] - [Designation] - [Institution/Company]&#10;  Topic: [Session topic]&#10;  Duration: [Time duration]&#10;&#10;• Speaker 2: Prof. [Name] - [Designation] - [Institution/Company]&#10;  Topic: [Session topic]&#10;  Duration: [Time duration]&#10;&#10;Include any changes from the original proposal and reasons for changes."></textarea>
-                  <div class="help-text">List actual speakers and any changes from the original proposal</div>
-              </div>
-          </div>
-
           <!-- Save Section -->
           <div class="form-row full-width">
               <div class="save-section-container">
@@ -1584,42 +1574,6 @@ function fillOrganizingCommittee() {
     }
 }
 
-function fillActualSpeakers() {
-    const field = $('#actual-speakers-modern');
-    if (field.length && field.val().trim() === '') {
-        let arr = [];
-        try {
-            const raw = window.PROPOSAL_DATA && window.PROPOSAL_DATA.speakers;
-            if (typeof raw === 'string') {
-                const parsed = JSON.parse(raw);
-                if (Array.isArray(parsed)) arr = parsed;
-            } else if (Array.isArray(raw)) {
-                arr = raw;
-            } else if (Array.isArray(window.EXISTING_SPEAKERS)) {
-                arr = window.EXISTING_SPEAKERS;
-            } else {
-                const tag = document.getElementById('proposal-speakers-json');
-                if (tag) {
-                    const txt = (tag.textContent || tag.innerText || '').trim();
-                    try {
-                        const parsed2 = JSON.parse(txt);
-                        if (Array.isArray(parsed2)) arr = parsed2;
-                    } catch (e) {}
-                }
-            }
-        } catch (e) {}
-        if (arr.length) {
-            const lines = arr.map((sp, idx) => {
-            const name = sp.full_name || sp.name || '';
-            const designation = sp.designation ? ` - ${sp.designation}` : '';
-            const org = sp.organization || sp.affiliation ? ` - ${(sp.organization || sp.affiliation)}` : '';
-            return `• ${name}${designation}${org}`;
-        });
-            field.val(lines.join('\n'));
-        }
-    }
-}
-
 function fillAttendanceCounts() {
     const counts = window.ATTENDANCE_COUNTS || {};
     const present = (counts.present !== undefined && counts.present !== null)
@@ -1671,7 +1625,6 @@ function populateProposalData() {
     setTimeout(function() {
         fillEventRelevance();
         fillOrganizingCommittee();
-        fillActualSpeakers();
         fillAttendanceCounts();
     }, 100);
 
@@ -1685,7 +1638,6 @@ function populateProposalData() {
             if (!container && attempt < 10) return setTimeout(() => init(attempt+1), 100);
             populateSpeakersFromProposal();
             fillOrganizingCommittee();
-            fillActualSpeakers();
             fillAttendanceCounts();
         };
         setTimeout(() => init(0), 50);

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -376,13 +376,11 @@ function extract(name){
 const loadSectionContent = extract('loadSectionContent');
 const populateSpeakersFromProposal = extract('populateSpeakersFromProposal');
 const fillOrganizingCommittee = extract('fillOrganizingCommittee');
-const fillActualSpeakers = extract('fillActualSpeakers');
 const fillAttendanceCounts = extract('fillAttendanceCounts');
 
 let domReady = false;
 const speakersDisplay = {innerHTML: ''};
 const orgEl = {value:'', length:1, val:function(v){ if(v===undefined) return this.value; this.value=v; return this; }, text:function(v){ if(v===undefined) return this.value; this.value=v; return this; }};
-const actualEl = {value:'', length:1, val:function(v){ if(v===undefined) return this.value; this.value=v; return this; }, text:function(v){ if(v===undefined) return this.value; this.value=v; return this; }};
 const makeField = () => ({value:'', length:1, val:function(v){ if(v===undefined) return this.value; this.value=v; return this; }, text:function(v){ if(v===undefined) return this.value; this.value=v; return this; }});
 
 const elements = {
@@ -401,7 +399,6 @@ function $(sel){
   if(sel === '.form-grid') return {html:function(content){ setTimeout(()=>{domReady=true;},0); return this; }};
   if(!domReady) return {length:0, val:function(){}};
   if(sel === '#organizing-committee-modern') return orgEl;
-  if(sel === '#actual-speakers-modern') return actualEl;
   return {length:0, val:function(){}};
 }
 
@@ -424,7 +421,6 @@ global.window = {
 
 eval(populateSpeakersFromProposal);
 eval(fillOrganizingCommittee);
-eval(fillActualSpeakers);
 eval(fillAttendanceCounts);
 eval(loadSectionContent);
 
@@ -434,7 +430,6 @@ setTimeout(()=>{
   console.log(JSON.stringify({
     display: speakersDisplay.innerHTML,
     organizing: orgEl.value,
-    actual: actualEl.value,
     total: elements['num-participants-modern'].value,
     volunteers: elements['num-volunteers-modern'].value,
     hiddenVolunteers: elements['num-volunteers-hidden'].value,
@@ -457,7 +452,6 @@ setTimeout(()=>{
         data = json.loads(result.stdout.strip())
         self.assertIn("Dr. Xavier", data["display"])
         self.assertIn("Proposer: Alice", data["organizing"])
-        self.assertIn("Dr. Xavier", data["actual"])
         self.assertEqual("10", str(data["total"]))
         self.assertEqual("3", str(data["volunteers"]))
         self.assertEqual("3", str(data["hiddenVolunteers"]))


### PR DESCRIPTION
## Summary
- remove the "Actual Speakers" textarea from the participant information step so only the proposal speakers reference card remains
- trim the speaker reference card padding/margins to cut the excess white space under the card
- update the node-backed unit test harness to reflect the streamlined participant section

## Testing
- `python manage.py test emt.tests.test_event_report_view` *(fails: database connection to Railway postgres instance is unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce34363284832cafee96cf8cf05d7d