### PR TITLE
Simplify save section spacing on event report

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -395,11 +395,21 @@
   
   /* ---- Save/Submit blocks ---- */
   .proposal-content .save-section-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
     text-align: center;
-    padding-top: 1rem;
+    margin: 1.5rem 0 0;
+    padding: 1.25rem 0 0;
+    border: none;
     border-top: 1px solid var(--border-color);
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
   }
-  .proposal-content .save-help-text { font-size: .75rem; color: var(--text-muted); margin-top: .5rem; }
+  .proposal-content .save-help-text { font-size: .75rem; color: var(--text-muted); margin-top: 0; }
   
   .proposal-content .submit-section {
     background: var(--white);


### PR DESCRIPTION
## Summary
- tighten the `save-section-container` layout within proposal/event report pages so the save actions sit closer to preceding content
- remove the gradient card treatment for save sections on the event report to avoid large blank areas after the speaker list

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce373debf8832cb820b7a15a9ddbe4