### PR TITLE
Trim spacing around Save & Continue controls

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -399,10 +399,10 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 0.75rem;
+    gap: 0.5rem;
     text-align: center;
-    margin: 1.5rem 0 0;
-    padding: 1.25rem 0 0;
+    margin: -1.25rem 0 0;
+    padding: 0.5rem 0 0;
     border: none;
     border-top: 1px solid var(--border-color);
     border-radius: 0;

--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1774,9 +1774,9 @@ $(document).ready(function() {
                 
                 <!-- Save Section -->
                 <div class="form-row full-width">
-                    <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
-                        <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                        <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
+                    <div class="save-section-container">
+                        <button type="button" class="btn-save-section">Save & Continue</button>
+                        <div class="save-help-text">Complete this section to unlock the next one</div>
                     </div>
                 </div>
             </div>

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1025,9 +1025,9 @@ $(document).on('click', '#ai-sdg-implementation', function(){
 
           <!-- Save Section -->
           <div class="form-row full-width">
-              <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
-                  <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                  <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
+              <div class="save-section-container">
+                  <button type="button" class="btn-save-section">Save & Continue</button>
+                  <div class="save-help-text">Complete this section to unlock the next one</div>
               </div>
           </div>
       `;

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -277,9 +277,9 @@
 
                         <!-- Save Section -->
                         <div class="form-row full-width">
-                            <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
-                                <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                                <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
+                            <div class="save-section-container">
+                                <button type="button" class="btn-save-section">Save & Continue</button>
+                                <div class="save-help-text">Complete this section to unlock the next one</div>
                             </div>
                         </div>
                     </div>

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -260,9 +260,9 @@
                         
                         <!-- Save Section -->
                         <div class="form-row full-width">
-                            <div class="save-section-container" style="display: flex; flex-direction: column; align-items: center;">
-                                <button type="button" class="btn-save-section" style="margin-bottom: 0.5rem;">Save & Continue</button>
-                                <div class="save-help-text" style="margin-top: 0.75rem;">Complete this section to unlock the next one</div>
+                            <div class="save-section-container">
+                                <button type="button" class="btn-save-section">Save & Continue</button>
+                                <div class="save-help-text">Complete this section to unlock the next one</div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- reduce the vertical padding on the Save & Continue section so the button sits closer to preceding fields
- remove inline margin styles from templates and JS snippets so the shared CSS can manage spacing consistently

## Testing
- not run (front-end styling change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce3d2ec0ac832c9f11040e789a47bb