### PR TITLE
Refine speaker action bar layout

### DIFF
--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -2196,6 +2196,67 @@ textarea {
     grid-column: 1 / -1;
 }
 
+.speaker-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: auto;
+    padding-bottom: 0;
+}
+
+.speaker-form .speakers-list {
+    min-height: auto;
+    padding-bottom: 0;
+}
+
+.speaker-form .speaker-field textarea,
+.speaker-form .speaker-field-textarea,
+.speaker-form textarea {
+    min-height: 96px;
+    max-height: 240px;
+    resize: vertical;
+}
+
+.actions-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: space-between;
+    margin-top: 16px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-top: 1px solid #e5e7eb;
+    background: #fff;
+}
+
+.speaker-form .actions-bar {
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    box-shadow: 0 -6px 12px rgba(15, 23, 42, 0.04);
+}
+
+.actions-bar button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 16px;
+    font-weight: 600;
+}
+
+.actions-bar-help {
+    margin: 8px 0 0;
+    text-align: left;
+    color: #64748b;
+    font-size: 0.875rem;
+}
+
+.speaker-form .actions-bar-help {
+    margin-bottom: 0;
+    text-align: right;
+}
+
 .speaker-status {
     font-size: 0.85rem;
     color: #475569;
@@ -2213,12 +2274,6 @@ textarea {
 
 .speaker-status[data-state="error"] {
     color: #b91c1c;
-}
-
-.speakers-actions {
-    margin-top: 0.75rem;
-    display: flex;
-    justify-content: flex-start;
 }
 
 .speaker-card-add {
@@ -2334,13 +2389,19 @@ textarea {
         align-items: flex-start;
     }
 
-    .speakers-actions {
-        justify-content: center;
-    }
-
     .speaker-card-add {
         width: 100%;
         justify-content: center;
+    }
+
+    .speaker-form .actions-bar {
+        justify-content: center;
+    }
+
+    .speaker-form .actions-bar .speaker-card-add,
+    .speaker-form .actions-bar .btn-save-section {
+        width: 100%;
+        margin-left: 0;
     }
 
     .speaker-photo {

--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -1023,13 +1023,6 @@ $(document).on('click', '#ai-sdg-implementation', function(){
               </div>
           </div>
 
-          <!-- Save Section -->
-          <div class="form-row full-width">
-              <div class="save-section-container">
-                  <button type="button" class="btn-save-section">Save & Continue</button>
-                  <div class="save-help-text">Complete this section to unlock the next one</div>
-              </div>
-          </div>
       `;
   }
   
@@ -2267,14 +2260,18 @@ function populateSpeakersFromProposal() {
     const listHtml = cardsHtml || getNoSpeakersMessageHtml();
 
     container.innerHTML = `
-        <div class="speakers-list speakers-editable">
-            ${listHtml}
-        </div>
-        <div class="speakers-actions">
-            <button type="button" class="speaker-card-add">
-                <span class="speaker-card-add-icon" aria-hidden="true">+</span>
-                <span>Add Speaker</span>
-            </button>
+        <div class="speaker-form">
+            <div class="speakers-list speakers-editable">
+                ${listHtml}
+            </div>
+            <p class="save-help-text actions-bar-help">Complete this section to unlock the next one</p>
+            <div class="actions-bar" role="group" aria-label="Speaker actions">
+                <button type="button" class="speaker-card-add">
+                    <span class="speaker-card-add-icon" aria-hidden="true">+</span>
+                    <span>Add Speaker</span>
+                </button>
+                <button type="button" class="btn-save-section">Save & Continue</button>
+            </div>
         </div>
     `;
     setupSpeakerCardEditors(container);


### PR DESCRIPTION
## Summary
- move the "Add Speaker" and "Save & Continue" controls into a shared action bar rendered with the speaker list
- remove the old participants save section and add sticky action bar styling with compact textarea heights
- update responsive rules so the action bar wraps cleanly on small screens while keeping consistent button sizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce418cdfc0832c88b476ae631a7946