### PR TITLE
Remove stray return from impersonate_user view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5549,8 +5549,6 @@ def impersonate_user(request):
     except Exception as e:
         return JsonResponse({'success': False, 'error': str(e)})
 
-    return JsonResponse({'suggestions': suggestions})
-
 # ─────────────────────────────────────────────────────────────
 #  Student Event Details View
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- remove the unreachable JsonResponse in `impersonate_user` that referenced an undefined variable
- leave the view returning JSON for both success and error conditions only through the try/except branches

## Testing
- python manage.py test core.tests.test_impersonation *(fails: database connection to Railway Postgres is unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceae0a1248832cb2be9415c082973d