### PR TITLE
Fix base template sidebar toggle without with tag

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,8 +24,7 @@
     window.USER_ID = "{{ request.user.id|default:'' }}";
   </script>
 </head>
-{% with has_sidebar=unrestricted_nav or allowed_nav_items|length %}
-<body class="command-center-layout{% if not has_sidebar %} no-sidebar{% endif %}">
+<body class="command-center-layout{% if not unrestricted_nav and not allowed_nav_items|length %} no-sidebar{% endif %}">
 
   {% if messages %}
   <div class="toast-container" aria-live="polite" aria-atomic="true">
@@ -41,7 +40,7 @@
   <div class="top-utility-bar">
     <div class="utility-bar-flex" style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
       <div class="utility-left" style="display: flex; align-items: center; gap: 1rem;">
-        {% if has_sidebar %}
+        {% if unrestricted_nav or allowed_nav_items|length %}
         <button id="sidebarToggle" aria-label="Toggle sidebar" style="background:transparent;border:none;color:#fff;font-size:20px;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:8px;">
           <span style="display:inline-block;width:18px;height:2px;background:#fff;position:relative;">
             <span style="content:'';position:absolute;left:0;top:-6px;width:18px;height:2px;background:#fff"></span>
@@ -140,7 +139,7 @@
     </div>
   </div>
 
-  {% if has_sidebar %}
+  {% if unrestricted_nav or allowed_nav_items|length %}
   <!-- ZONE 2: LEFT CONTROL PANEL -->
   <div class="left-control-panel">
     <nav class="control-navigation">
@@ -443,5 +442,4 @@
   {% block scripts %}{% endblock %}
   {% block scripts_extra %}{% endblock %}
 </body>
-{% endwith %}
 </html>


### PR DESCRIPTION
## Summary
- remove the `{% with %}` block from `base.html` that triggered a `TemplateSyntaxError` on some Django versions
- inline the sidebar visibility checks so the layout still hides navigation when no sidebar is available

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cf6a282128832cb4aa93f55fc326fe