### PR TITLE
Fix sidebar detection expression in base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 {% load static group_filters admin_tags %}
-{% with has_sidebar=unrestricted_nav or allowed_nav_items %}
+{% with has_sidebar=unrestricted_nav|default:allowed_nav_items %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- replace the invalid `{% with %}` expression that used `or` with a default filter so the template renders under Django 5.2

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cf6f848478832cba21dcd855289062