### PR TITLE
Remove icons from graduate attributes editor

### DIFF
--- a/emt/templates/emt/graduate_attributes_edit.html
+++ b/emt/templates/emt/graduate_attributes_edit.html
@@ -21,7 +21,7 @@
                 <div class="section-title">
                     Graduate Attributes
                     <span class="selected-count" id="selectedCount">0 selected</span>
-                    <span class="ai-assist"><i class="fas fa-magic" aria-hidden="true"></i> AI Suggest</span>
+                    <span class="ai-assist">AI Suggest</span>
                 </div>
                 <div class="section-subtitle">Choose attributes that best represent the learning outcomes of your event</div>
             </div>
@@ -40,7 +40,6 @@
                 <div class="attributes-grid" id="ga-grid">
                     <div class="attribute-category academic" data-id="academic">
                         <div class="category-header">
-                            <div class="category-icon"><i class="fa-solid fa-building-columns" aria-hidden="true"></i></div>
                             <div class="category-title">Academic Excellence</div>
                         </div>
                         <div class="category-description">Extensive knowledge and ability to apply it effectively in chosen discipline</div>
@@ -67,7 +66,6 @@
 
                     <div class="attribute-category professional" data-id="professional">
                         <div class="category-header">
-                            <div class="category-icon"><i class="fa-solid fa-user-tie" aria-hidden="true"></i></div>
                             <div class="category-title">Professional Excellence</div>
                         </div>
                         <div class="category-description">Comprehensive specialist knowledge ensuring work readiness and professional competence</div>
@@ -99,7 +97,6 @@
 
                     <div class="attribute-category personality" data-id="personality">
                         <div class="category-header">
-                            <div class="category-icon"><i class="fa-solid fa-seedling" aria-hidden="true"></i></div>
                             <div class="category-title">Personality Development</div>
                         </div>
                         <div class="category-description">Personal growth, self-awareness, and character development for holistic education</div>
@@ -134,7 +131,6 @@
 
                     <div class="attribute-category leadership" data-id="leadership">
                         <div class="category-header">
-                            <div class="category-icon"><i class="fa-solid fa-chess-king" aria-hidden="true"></i></div>
                             <div class="category-title">Leadership</div>
                         </div>
                         <div class="category-description">Ability to guide, inspire, and coordinate teams toward common goals</div>
@@ -166,7 +162,6 @@
 
                     <div class="attribute-category communication" data-id="communication">
                         <div class="category-header">
-                            <div class="category-icon"><i class="fa-solid fa-comments" aria-hidden="true"></i></div>
                             <div class="category-title">Communication</div>
                         </div>
                         <div class="category-description">Effective verbal, written, and digital communication across diverse contexts</div>
@@ -195,7 +190,6 @@
 
                     <div class="attribute-category social" data-id="social">
                         <div class="category-header">
-                            <div class="category-icon"><i class="fa-solid fa-globe" aria-hidden="true"></i></div>
                             <div class="category-title">Social Sensitivity</div>
                         </div>
                         <div class="category-description">Cultural awareness, empathy, and ability to work in diverse environments</div>


### PR DESCRIPTION
## Summary
- remove the font-based icons from each Graduate Attributes category card so only text remains
- drop the unused magic-wand icon markup from the hidden AI Suggest label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfb1c8d310832cbb2056b0878680b1