### PR TITLE
Fix missing DashboardAssignment import in dashboard view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -30,6 +30,7 @@ from .models import (
     RoleAssignment,
     Organization,
     OrganizationType,
+    DashboardAssignment,
     Report,
     Class,
     OrganizationRole,


### PR DESCRIPTION
## Summary
- import `DashboardAssignment` in `core.views` so the dashboard view can access the helper

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d044ce1248832c98a2b0b4c1b3b4c8