### PR TITLE
Fix event report preview multi-value preservation

### DIFF
--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -43,8 +43,10 @@
 
         <form method="post" action="{% url 'emt:submit_event_report' proposal.id %}">
             {% csrf_token %}
-            {% for key, value in post_data.items %}
-                <input type="hidden" name="{{ key }}" value="{{ value|escape }}">
+            {% for key, values in post_data.lists %}
+                {% for value in values %}
+                    <input type="hidden" name="{{ key }}" value="{{ value|default_if_none:''|escape }}">
+                {% endfor %}
             {% endfor %}
             {# Ensure attachment formset management fields exist (even if there are no attachments) #}
             <input type="hidden" name="form-TOTAL_FORMS" value="{{ post_data|get_item:'form-TOTAL_FORMS'|default:'0' }}">

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -264,11 +264,11 @@
                             <div class="activity-row">
                                 <div class="input-group">
                                     <label for="activity_name_{{ forloop.counter }}" class="activity-label">{{ forloop.counter }}. Activity Name</label>
-                                    <input type="text" id="activity_name_{{ forloop.counter }}" name="activity_name_{{ forloop.counter }}" class="proposal-input" value="{{ act.activity_name }}">
+                                    <input type="text" id="activity_name_{{ forloop.counter }}" name="activity_name_{{ forloop.counter }}" value="{{ act.activity_name }}" class="proposal-input">
                                 </div>
                                 <div class="input-group">
                                     <label for="activity_date_{{ forloop.counter }}" class="date-label">{{ forloop.counter }}. Activity Date</label>
-                                    <input type="date" id="activity_date_{{ forloop.counter }}" name="activity_date_{{ forloop.counter }}" class="proposal-input" value="{{ act.activity_date }}">
+                                    <input type="date" id="activity_date_{{ forloop.counter }}" name="activity_date_{{ forloop.counter }}" value="{{ act.activity_date }}" class="proposal-input">
                                 </div>
                                 <button type="button" class="remove-activity btn btn-sm btn-outline-danger">×</button>
                             </div>


### PR DESCRIPTION
## Summary
- ensure the report preview form emits one hidden input per POST value so multi-select fields survive the preview
- add a regression test that round-trips a multi-value selection through preview and final submit, encoding the post body like the browser would
- update the Node-based stubs so the autosave and speakers tests emulate the combined selectors and DOM APIs used by submit_event_report.js

## Testing
- DATABASE_URL=sqlite:///test.sqlite3 python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests

------
https://chatgpt.com/codex/tasks/task_e_68d054645f3c832c9a8264c9c271dae6