### PR TITLE
Make IQAC preview template standalone

### DIFF
--- a/emt/templates/emt/iqac_report_preview.html
+++ b/emt/templates/emt/iqac_report_preview.html
@@ -1,9 +1,10 @@
-{% extends "base.html" %}
 {% load static %}
-
-{% block title %}IQAC Report Preview{% endblock %}
-
-{% block head_extra %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>IQAC Report Preview</title>
 <style>
   @page {
     size: A4;
@@ -379,9 +380,8 @@
     }
   }
 </style>
-{% endblock %}
-
-{% block content %}
+</head>
+<body>
 <div class="iqac-preview">
   <div class="preview-controls">
     <button type="button" id="mode-toggle" data-mode="preview">Edit</button>
@@ -1267,4 +1267,5 @@
 
   document.addEventListener('DOMContentLoaded', init);
 </script>
-{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert the IQAC report preview template into a standalone HTML page so it no longer extends the dashboard shell

## Testing
- Manual verification in the browser to confirm the preview renders alone, edit mode toggles, and print layout remains A4

------
https://chatgpt.com/codex/tasks/task_e_68d0e08de550832cad7ff00d7d186b73