### PR TITLE
Fix CDL communication CSRF handling

### DIFF
--- a/core/tests/test_cdl_communication.py
+++ b/core/tests/test_cdl_communication.py
@@ -1,49 +1,57 @@
-import pytest
 from django.contrib.auth.models import Group, User
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
 from django.urls import reverse
 
 
-@pytest.mark.django_db
-def test_cdl_communication_create_and_list(client):
-    # Ensure group exists
-    grp, _ = Group.objects.get_or_create(name="CDL_MEMBER")
-    user = User.objects.create_user(username="alice", password="pass123")
-    user.groups.add(grp)
-    assert client.login(username="alice", password="pass123")
+class CDLCommunicationTests(TestCase):
+    def setUp(self):
+        self.group, _ = Group.objects.get_or_create(name="CDL_MEMBER")
 
-    url = reverse("api_cdl_communication")
+    def _login_member(self, username: str) -> None:
+        user = User.objects.create_user(username=username, password="pass123")
+        user.groups.add(self.group)
+        logged_in = self.client.login(username=username, password="pass123")
+        self.assertTrue(logged_in)
 
-    # Initially empty
-    resp = client.get(url)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["success"] is True
-    assert data["messages"] == []
+    def test_create_and_list_messages(self):
+        self._login_member("alice")
+        url = reverse("api_cdl_communication")
 
-    # Create text only
-    resp = client.post(url, {"comment": "Hello world"})
-    assert resp.status_code == 201
-    msg1 = resp.json()
-    assert msg1["comment"] == "Hello world"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["messages"], [])
 
-    # Create with attachment (small text file)
-    uploaded = SimpleUploadedFile(
-        "note.txt", b"Attachment content", content_type="text/plain"
-    )
-    resp = client.post(url, {"comment": "With file"}, FILES={"attachment": uploaded})
-    assert resp.status_code == 201
-    msg2 = resp.json()
-    assert msg2["attachment_url"] is not None
+        response = self.client.post(url, {"comment": "Hello world"})
+        self.assertEqual(response.status_code, 201)
+        msg1 = response.json()
+        self.assertEqual(msg1["comment"], "Hello world")
 
-    # List again should have 2 messages (most recent first)
-    resp = client.get(url)
-    assert resp.status_code == 200
-    data = resp.json()
-    assert len(data["messages"]) == 2
-    comments = [m["comment"] for m in data["messages"]]
-    assert comments[0] in (
-        "With file",
-        "Hello world",
-    )  # Ordering by created_at desc, but creation may be fast
-    assert set(comments) == {"Hello world", "With file"}
+        uploaded = SimpleUploadedFile(
+            "note.txt",
+            b"Attachment content",
+            content_type="text/plain",
+        )
+        response = self.client.post(
+            url,
+            {"comment": "With file", "attachment": uploaded},
+        )
+        self.assertEqual(response.status_code, 201)
+        msg2 = response.json()
+        self.assertIsNotNone(msg2["attachment_url"])
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["messages"]), 2)
+        comments = {m["comment"] for m in data["messages"]}
+        self.assertSetEqual(comments, {"Hello world", "With file"})
+
+    def test_page_sets_csrf_cookie(self):
+        self._login_member("bob")
+        response = self.client.get(reverse("cdl_communication_page"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("csrftoken", response.cookies)
+        self.assertTrue(response.cookies["csrftoken"].value)

--- a/core/views.py
+++ b/core/views.py
@@ -15,7 +15,7 @@ from django.db.models import Q, Sum, Count
 from django.forms import inlineformset_factory
 from django import forms
 from django.urls import reverse
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 from django.db import models, transaction
 from django.db.models.functions import TruncDate
@@ -6835,6 +6835,7 @@ def cdl_assign_tasks_page(request, proposal_id:int):
 #  CDL Communication Page & APIs
 # ────────────────────────────────────────────────────────────────
 @login_required
+@ensure_csrf_cookie
 def cdl_communication_page(request):
     """Render the communication log page. Accessible to CDL head and employees/members."""
     # Basic role check similar to work dashboard

--- a/static/core/js/cdl_communication.js
+++ b/static/core/js/cdl_communication.js
@@ -37,7 +37,12 @@
     fd.append('comment', textRaw); // preserve users' newlines exactly
     if(fileInput.files[0]) fd.append('attachment', fileInput.files[0]);
     try{
-      const res = await fetch('/api/cdl/communication/', { method:'POST', body: fd, headers: { 'X-Requested-With':'fetch','X-CSRFToken':getCSRF() } });
+      const res = await fetch('/api/cdl/communication/', {
+        method: 'POST',
+        body: fd,
+        headers: { 'X-Requested-With': 'fetch', 'X-CSRFToken': getCSRF() },
+        credentials: 'same-origin',
+      });
       if(!res.ok){ const err = await safeJSON(res); toast(err.error||'Send failed'); return; }
       const msg = await res.json();
       appendRow(msg, true);
@@ -51,7 +56,7 @@
 
   async function loadMessages(){
     try{
-      const res = await fetch('/api/cdl/communication/');
+      const res = await fetch('/api/cdl/communication/', { credentials: 'same-origin' });
       if(!res.ok) return;
       const data = await res.json();
       messageCache = (data.messages||[]).reverse();

--- a/templates/core/cdl_communication.html
+++ b/templates/core/cdl_communication.html
@@ -60,7 +60,8 @@
         <div id="commEmpty" class="empty-log" style="margin:0">No messages yet.</div>
       </div>
     </div>
-    <form id="commForm" enctype="multipart/form-data">
+    <form id="commForm" method="post" enctype="multipart/form-data">
+      {% csrf_token %}
       <div class="input-row">
         <textarea id="commText" placeholder="Write a comment..." maxlength="4000" aria-label="Message input"></textarea>
         <button type="submit" class="send-btn" aria-label="Send message" title="Send (Shift+Enter)"><i class="fa-solid fa-paper-plane"></i></button>


### PR DESCRIPTION
## Summary
- ensure the CDL communication page always issues a CSRF cookie and renders a token in the chat form
- update the front-end fetch helper to send cookies with the API requests
- add regression tests covering message creation and CSRF cookie issuance

## Testing
- DATABASE_URL=sqlite:///db.sqlite3 python manage.py test core.tests.test_cdl_communication

------
https://chatgpt.com/codex/tasks/task_e_68d0e55dde0c832cac8f7254a5861c0f