### PR TITLE
Add AI report link on preview page

### DIFF
--- a/emt/templates/emt/iqac_report_preview.html
+++ b/emt/templates/emt/iqac_report_preview.html
@@ -50,7 +50,8 @@
     background: #f0f0f0;
   }
 
-  .controls button {
+  .controls button,
+  .controls a.control-button {
     font-family: "Times New Roman", Times, serif;
     font-size: 12pt;
     padding: 4px 16px;
@@ -59,7 +60,37 @@
     cursor: pointer;
   }
 
-  .controls button:focus {
+  .controls a.control-button {
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    line-height: 1.2;
+    color: #000;
+  }
+
+  .controls a.control-button.primary {
+    background: #2c5aa0;
+    border-color: #2c5aa0;
+    color: #fff;
+  }
+
+  .controls a.control-button.primary:hover {
+    background: #244a82;
+    border-color: #244a82;
+    color: #fff;
+  }
+
+  .controls a.control-button[aria-disabled="true"] {
+    background: #bfc7d3;
+    border-color: #bfc7d3;
+    color: #f5f5f5;
+    cursor: not-allowed;
+  }
+
+  .controls button:focus,
+  .controls a.control-button:focus {
     outline: 1pt dotted #000;
     outline-offset: 2px;
   }
@@ -474,6 +505,7 @@
   <div class="control-row">
     <span class="status-pill" id="status-pill">Preparing content…</span>
     <div class="controls">
+      <a href="{{ ai_report_url }}" class="control-button primary" id="generate-ai-report"{% if not form_is_valid %} aria-disabled="true" data-disabled="true" title="Resolve required fields before generating the AI report."{% endif %}>Generate Report</a>
       <button type="button" id="edit-toggle" data-mode="preview">Edit</button>
       <button type="button" id="print-btn">Print / Save PDF</button>
     </div>
@@ -1299,6 +1331,15 @@
     document.addEventListener('DOMContentLoaded', function () {
       document.body.classList.add('iqac-report-preview');
       init();
+
+      const generateBtn = document.getElementById('generate-ai-report');
+      if (generateBtn && generateBtn.dataset.disabled === 'true') {
+        generateBtn.setAttribute('tabindex', '-1');
+        generateBtn.addEventListener('click', function (event) {
+          event.preventDefault();
+          window.alert('Please complete the required sections in the event report before generating the AI report.');
+        });
+      }
     });
   })();
 </script>

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -312,6 +312,22 @@ console.log(JSON.stringify({
         self.assertContains(response, "Frontend summary")
         self.assertContains(response, "Frontend outcomes")
 
+    def test_preview_includes_generate_report_link(self):
+        url = reverse("emt:preview_event_report", args=[self.proposal.id])
+        data = {
+            "actual_event_type": "Seminar",
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        ai_url = reverse("emt:ai_generate_report", args=[self.proposal.id])
+        self.assertEqual(response.context["ai_report_url"], ai_url)
+        self.assertContains(response, 'id="generate-ai-report"', html=False)
+        self.assertContains(response, ai_url)
+
     def test_preview_preserves_checked_and_unchecked_fields(self):
         url = reverse("emt:preview_event_report", args=[self.proposal.id])
         data = {

--- a/emt/views.py
+++ b/emt/views.py
@@ -29,6 +29,7 @@ from django.utils import timezone
 from django.utils.dateparse import parse_date
 from django.utils.formats import date_format
 from django.utils.timezone import now
+from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods, require_POST
 
@@ -3039,11 +3040,14 @@ def preview_event_report(request, proposal_id):
 
     context = {
         "proposal": proposal,
+        "report": report,
         "post_data": post_data,
         "proposal_fields": proposal_fields,
         "report_fields": report_fields,
         "form": form,
+        "form_is_valid": form_is_valid,
         "initial_report_data": json.dumps(initial_data, ensure_ascii=False),
+        "ai_report_url": reverse("emt:ai_generate_report", args=[proposal.id]),
     }
     return render(request, "emt/iqac_report_preview.html", context)
 


### PR DESCRIPTION
## Summary
- expose the AI report generation URL when building the preview context so templates can link to it
- add a prominent "Generate Report" control to the preview screen with disabled handling when form data is incomplete
- cover the new link and context in the event report preview tests

## Testing
- `python manage.py test emt.tests.test_event_report_view -v 2` *(fails: unable to reach configured PostgreSQL instance in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bd1cd534832cbe1df47fb944989f