### PR TITLE
Fix event report preview flow and gate AI redirect

### DIFF
--- a/emt/templates/emt/iqac_report_preview.html
+++ b/emt/templates/emt/iqac_report_preview.html
@@ -51,7 +51,7 @@
   }
 
   .controls button,
-  .controls a.control-button {
+  .controls .control-button {
     font-family: "Times New Roman", Times, serif;
     font-size: 12pt;
     padding: 4px 16px;
@@ -60,7 +60,7 @@
     cursor: pointer;
   }
 
-  .controls a.control-button {
+  .controls .control-button {
     text-decoration: none;
     display: inline-flex;
     align-items: center;
@@ -70,19 +70,19 @@
     color: #000;
   }
 
-  .controls a.control-button.primary {
+  .controls .control-button.primary {
     background: #2c5aa0;
     border-color: #2c5aa0;
     color: #fff;
   }
 
-  .controls a.control-button.primary:hover {
+  .controls .control-button.primary:hover {
     background: #244a82;
     border-color: #244a82;
     color: #fff;
   }
 
-  .controls a.control-button[aria-disabled="true"] {
+  .controls .control-button[aria-disabled="true"] {
     background: #bfc7d3;
     border-color: #bfc7d3;
     color: #f5f5f5;
@@ -90,9 +90,14 @@
   }
 
   .controls button:focus,
-  .controls a.control-button:focus {
+  .controls .control-button:focus {
     outline: 1pt dotted #000;
     outline-offset: 2px;
+  }
+
+  .generate-ai-form {
+    display: inline;
+    margin: 0;
   }
 
   main#report,
@@ -505,7 +510,18 @@
   <div class="control-row">
     <span class="status-pill" id="status-pill">Preparing content…</span>
     <div class="controls">
-      <a href="{{ ai_report_url }}" class="control-button primary" id="generate-ai-report"{% if not form_is_valid %} aria-disabled="true" data-disabled="true" title="Resolve required fields before generating the AI report."{% endif %}>Generate Report</a>
+      <form id="generate-ai-form" class="generate-ai-form" method="post" action="{% url 'emt:submit_event_report' proposal.id %}">
+        {% csrf_token %}
+        {% for key, values in post_data_items %}
+          {% if key != 'csrfmiddlewaretoken' and key != 'generate_ai' %}
+            {% for value in values %}
+              <input type="hidden" name="{{ key }}" value="{{ value }}">
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+        <input type="hidden" name="generate_ai" value="1">
+        <button type="submit" class="control-button primary" id="generate-ai-report"{% if not form_is_valid %} aria-disabled="true" data-disabled="true" title="Resolve required fields before generating the AI report."{% endif %}>Generate Report</button>
+      </form>
       <button type="button" id="edit-toggle" data-mode="preview">Edit</button>
       <button type="button" id="print-btn">Print / Save PDF</button>
     </div>
@@ -1339,6 +1355,11 @@
           event.preventDefault();
           window.alert('Please complete the required sections in the event report before generating the AI report.');
         });
+        if (generateBtn.form) {
+          generateBtn.form.addEventListener('submit', function (event) {
+            event.preventDefault();
+          });
+        }
       }
     });
   })();

--- a/emt/tests/test_event_report_view.py
+++ b/emt/tests/test_event_report_view.py
@@ -44,6 +44,22 @@ class SubmitEventReportViewTests(TestCase):
             date=date(2024, 1, 1),
         )
 
+    def _build_valid_report_post_data(self, extra=None):
+        data = {
+            "actual_event_type": "Seminar",
+            "report_signed_date": "2024-01-10",
+            "num_activities": "1",
+            "activity_name_1": "Session 1",
+            "activity_date_1": "2024-01-02",
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        if extra:
+            data.update(extra)
+        return data
+
     def test_activities_prefilled_in_report_form(self):
         response = self.client.get(
             reverse("emt:submit_event_report", args=[self.proposal.id])
@@ -68,27 +84,38 @@ class SubmitEventReportViewTests(TestCase):
 
     def test_can_update_activities_via_report_submission(self):
         url = reverse("emt:submit_event_report", args=[self.proposal.id])
-        data = {
-            "actual_event_type": "Seminar",
-            "report_signed_date": "2024-01-10",
-            "num_activities": "2",
-            "activity_name_1": "Session 1",
-            "activity_date_1": "2024-01-02",
-            "activity_name_2": "Session 2",
-            "activity_date_2": "2024-01-03",
-            "form-TOTAL_FORMS": "0",
-            "form-INITIAL_FORMS": "0",
-            "form-MIN_NUM_FORMS": "0",
-            "form-MAX_NUM_FORMS": "1000",
-        }
+        data = self._build_valid_report_post_data(
+            {
+                "num_activities": "2",
+                "activity_name_2": "Session 2",
+                "activity_date_2": "2024-01-03",
+            }
+        )
         response = self.client.post(url, data)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "emt/iqac_report_preview.html")
+        self.assertContains(response, 'id="generate-ai-report"', html=False)
         activities = list(
             EventActivity.objects.filter(proposal=self.proposal).order_by("date")
         )
         self.assertEqual(len(activities), 2)
         self.assertEqual(activities[0].name, "Session 1")
         self.assertEqual(activities[1].name, "Session 2")
+
+    def test_submit_event_report_without_generate_ai_renders_preview(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        response = self.client.post(url, self._build_valid_report_post_data())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "emt/iqac_report_preview.html")
+        self.assertContains(response, 'id="generate-ai-report"', html=False)
+
+    def test_submit_event_report_with_generate_ai_redirects_to_progress(self):
+        url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        data = self._build_valid_report_post_data({"generate_ai": "1"})
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        progress_url = reverse("emt:ai_report_progress", args=[self.proposal.id])
+        self.assertEqual(response["Location"], progress_url)
 
     def test_attendance_counts_displayed(self):
         report = EventReport.objects.create(proposal=self.proposal)
@@ -326,7 +353,10 @@ console.log(JSON.stringify({
         ai_url = reverse("emt:ai_generate_report", args=[self.proposal.id])
         self.assertEqual(response.context["ai_report_url"], ai_url)
         self.assertContains(response, 'id="generate-ai-report"', html=False)
-        self.assertContains(response, ai_url)
+        submit_url = reverse("emt:submit_event_report", args=[self.proposal.id])
+        self.assertContains(response, 'id="generate-ai-form"', html=False)
+        self.assertContains(response, f'action="{submit_url}"', html=False)
+        self.assertContains(response, 'name="generate_ai"', html=False)
 
     def test_preview_preserves_checked_and_unchecked_fields(self):
         url = reverse("emt:preview_event_report", args=[self.proposal.id])


### PR DESCRIPTION
## Summary
- gate the AI progress redirect in `submit_event_report` behind an explicit `generate_ai` flag and return the preview when it is absent
- expose saved form data to the preview template so the "Generate Report" control can submit the correct payload via POST
- convert the preview "Generate Report" control into a POST form that sets the AI flag and extend regression coverage for both preview and AI flows

## Testing
- `python manage.py test emt.tests.test_event_report_view` *(fails: cannot reach configured PostgreSQL host in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c63abc60832c8ad45a8bfe304477