### PR TITLE
Fix event report Save & Continue preview redirect

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -98,7 +98,11 @@ document.addEventListener('DOMContentLoaded', function(){
       } catch (e) { /* noop */ }
   }
 
-  const previewUrl = $('#report-form').data('preview-url');
+  const $reportForm = $('#report-form');
+  const previewUrl =
+      $reportForm.attr('data-preview-url') ||
+      $reportForm.data('previewUrl') ||
+      $reportForm.data('preview-url');
 
   function ensureAutosaveUrl() {
       if (window.AUTOSAVE_URL) {


### PR DESCRIPTION
## Summary
- ensure the event report flow always reads the preview URL from the form attributes
- allow the final Save & Continue action to submit to the new preview page

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2167b93e8832c92ab402377cbb237