### PR TITLE
Simplify report preview actions

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function(){
                 if (previewAction) {
                     previewForm.setAttribute('action', previewAction);
                 }
-                showLoadingOverlay('Preparing IQAC preview...');
+                showLoadingOverlay('Generating report...');
                 previewForm.submit();
             });
         }

--- a/emt/templates/emt/report_preview.html
+++ b/emt/templates/emt/report_preview.html
@@ -123,16 +123,15 @@
 
             <div class="sticky-actions">
                 <div class="actions-bar">
-                    <button type="button" class="btn-secondary" id="btn-back">Back to Edit</button>
+                    <button type="button" class="btn-secondary" id="btn-back">Edit</button>
                     <button
                         type="button"
                         class="btn-primary"
                         data-preview-continue="iqac"
                         data-preview-action="{% url 'emt:preview_event_report' proposal.id %}"
                     >
-                        Continue to IQAC Preview
+                        Generate Report
                     </button>
-                    <button type="submit" name="final_submit" class="btn-primary">Submit Report</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- remove the redundant submit button from the report preview footer
- relabel the remaining actions to "Edit" and "Generate Report"
- update the loading overlay text to match the new generate report action

## Testing
- python manage.py test *(fails: cannot reach configured PostgreSQL test database in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2339a92c8832c9a478584f3e635c9