### PR TITLE
Close attachment block with tag

### DIFF
--- a/emt/templates/emt/partials/attachment_block.html
+++ b/emt/templates/emt/partials/attachment_block.html
@@ -13,3 +13,4 @@
 {% endif %}
 {% endwith %}
 {% endwith %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- add the missing `{% endwith %}` to close the outer context block in the attachment partial

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d30110973c832c959c441becb6b1ab