### PR TITLE
Fix missing file errors in event report attachments

### DIFF
--- a/emt/templates/emt/partials/attachment_block.html
+++ b/emt/templates/emt/partials/attachment_block.html
@@ -1,16 +1,26 @@
 {% load static %}
-{% with file_url=form.instance.file.url|default:'' %}
-{% with file_name=form.instance.file.name|default:file_url %}
-{% with lower_name=file_name|lower %}
-{% if lower_name|slice:"-4:" == '.png' or lower_name|slice:"-4:" == '.jpg' or lower_name|slice:"-5:" == '.jpeg' or lower_name|slice:"-4:" == '.gif' or lower_name|slice:"-5:" == '.webp' %}
-    {% with preview_type='image' %}
-        {% include 'emt/partials/attachment_block_inner.html' %}
-    {% endwith %}
-{% else %}
-    {% with preview_type='file' %}
-        {% include 'emt/partials/attachment_block_inner.html' %}
-    {% endwith %}
-{% endif %}
-{% endwith %}
-{% endwith %}
+{% with file_field=form.instance.file %}
+    {% if file_field %}
+        {% with file_url=file_field.url %}
+            {% with file_name=file_field.name|default:file_url %}
+                {% with lower_name=file_name|lower %}
+                    {% if lower_name|slice:"-4:" == '.png' or lower_name|slice:"-4:" == '.jpg' or lower_name|slice:"-5:" == '.jpeg' or lower_name|slice:"-4:" == '.gif' or lower_name|slice:"-5:" == '.webp' %}
+                        {% with preview_type='image' %}
+                            {% include 'emt/partials/attachment_block_inner.html' %}
+                        {% endwith %}
+                    {% else %}
+                        {% with preview_type='file' %}
+                            {% include 'emt/partials/attachment_block_inner.html' %}
+                        {% endwith %}
+                    {% endif %}
+                {% endwith %}
+            {% endwith %}
+        {% endwith %}
+    {% else %}
+        {% with file_url='' file_name='' lower_name='' %}
+            {% with preview_type='file' %}
+                {% include 'emt/partials/attachment_block_inner.html' %}
+            {% endwith %}
+        {% endwith %}
+    {% endif %}
 {% endwith %}

--- a/emt/views.py
+++ b/emt/views.py
@@ -2981,7 +2981,13 @@ def preview_event_report(request, proposal_id):
     annexure_photos = []
     if report:
         for attachment in report.attachments.all():
-            file_url = getattr(attachment.file, "url", "")
+            file_field = getattr(attachment, "file", None)
+            if not file_field:
+                continue
+            try:
+                file_url = file_field.url
+            except ValueError:
+                continue
             if not file_url:
                 continue
             lower_url = file_url.lower()


### PR DESCRIPTION
## Summary
- guard annexure photo processing in the event report preview against attachments that lack an uploaded file
- render the attachment form partial without requesting a URL for empty FieldFile instances

## Testing
- python manage.py test emt.tests.test_event_report_view *(fails: remote PostgreSQL test database is unreachable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d301fd444c832c9de4d8aadd55e396