### PR TITLE
Ensure generated_payload column exists for EventReport

### DIFF
--- a/emt/migrations/0031_ensure_generated_payload_column.py
+++ b/emt/migrations/0031_ensure_generated_payload_column.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def ensure_generated_payload_column(apps, schema_editor):
+    EventReport = apps.get_model("emt", "EventReport")
+    table_name = EventReport._meta.db_table
+    column_name = "generated_payload"
+
+    connection = schema_editor.connection
+    with connection.cursor() as cursor:
+        existing_columns = {
+            column.name
+            for column in connection.introspection.get_table_description(cursor, table_name)
+        }
+
+    if column_name in existing_columns:
+        return
+
+    field = EventReport._meta.get_field(column_name)
+    schema_editor.add_field(EventReport, field)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("emt", "0030_alter_eventreportattachment_options_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(ensure_generated_payload_column, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add a defensive migration that ensures the EventReport.generated_payload column exists before continuing

## Testing
- python manage.py test emt.tests.test_event_report_session emt.tests.test_report_generation *(fails: connection to remote PostgreSQL instance is unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37af7fae4832ca92b012360b8c1b3