### PR TITLE
Fix generated_payload migration to create field when missing

### DIFF
--- a/emt/migrations/0031_ensure_generated_payload_column.py
+++ b/emt/migrations/0031_ensure_generated_payload_column.py
@@ -1,4 +1,4 @@
-from django.db import migrations
+from django.db import migrations, models
 
 
 def ensure_generated_payload_column(apps, schema_editor):
@@ -16,7 +16,8 @@ def ensure_generated_payload_column(apps, schema_editor):
     if column_name in existing_columns:
         return
 
-    field = EventReport._meta.get_field(column_name)
+    field = models.JSONField(blank=True, default=dict)
+    field.set_attributes_from_name(column_name)
     schema_editor.add_field(EventReport, field)
 
 


### PR DESCRIPTION
## Summary
- adjust the `0031_ensure_generated_payload_column` migration to build a fresh JSONField instance when adding the column
- ensure the migration can recreate the `generated_payload` column if it was missed on existing databases

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py migrate --check`
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68d594d0b5e8832c8ba8c2a4baa6402b