### PR TITLE
Allow attendance navigation when autosave fails

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -3138,11 +3138,21 @@ function setupAttendanceLink() {
                     else if (path.startsWith('/emt/')) prefix = '/emt';
                     window.AUTOSAVE_URL = `${prefix}/autosave-event-report/`;
                 }
-                const result = (window.ReportAutosaveManager && window.ReportAutosaveManager.manualSave)
-                    ? await window.ReportAutosaveManager.manualSave()
-                    : null;
 
-                const reportId = result?.report_id || window.REPORT_ID;
+                let reportId = window.REPORT_ID;
+                let result = null;
+                if (window.ReportAutosaveManager && window.ReportAutosaveManager.manualSave) {
+                    try {
+                        result = await window.ReportAutosaveManager.manualSave();
+                    } catch (autosaveError) {
+                        console.error('Autosave failed before opening attendance; continuing when possible.', autosaveError);
+                    }
+                }
+
+                if (result?.report_id) {
+                    reportId = result.report_id;
+                }
+
                 if (reportId) {
                     // Respect site prefix (/suite or /emt) when building the URL
                     const path = window.location.pathname || '';
@@ -3162,8 +3172,8 @@ function setupAttendanceLink() {
                     alert('Unable to prepare attendance. Please try saving once.');
                 }
             } catch (e) {
-                console.error('Failed to autosave before opening attendance:', e);
-                alert('Save failed. Please fix any errors and try again.');
+                console.error('Unexpected error while preparing attendance:', e);
+                alert('Unable to open attendance page. Please try again.');
             } finally {
                 hideLoadingOverlay();
             }


### PR DESCRIPTION
## Summary
- allow the attendance link to fall back to the existing report when manual autosave fails
- avoid showing the autosave failure alert so users can still open the attendance upload page

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8f6964558832c9d3a0c3a92b6df76