### PR TITLE
Add default review stage for event reports

### DIFF
--- a/emt/migrations/0031_eventreport_review_stage.py
+++ b/emt/migrations/0031_eventreport_review_stage.py
@@ -1,0 +1,72 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("emt", "0030_eventreport_status"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE emt_eventreport
+                        ADD COLUMN IF NOT EXISTS review_stage VARCHAR(20);
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE emt_eventreport
+                        DROP COLUMN IF EXISTS review_stage;
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE emt_eventreport
+                        ALTER COLUMN review_stage SET DEFAULT 'draft';
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE emt_eventreport
+                        ALTER COLUMN review_stage DROP DEFAULT;
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        UPDATE emt_eventreport
+                        SET review_stage = COALESCE(NULLIF(review_stage, ''), 'draft');
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE emt_eventreport
+                        ALTER COLUMN review_stage SET NOT NULL;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE emt_eventreport
+                        ALTER COLUMN review_stage DROP NOT NULL;
+                    """,
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="eventreport",
+                    name="review_stage",
+                    field=models.CharField(
+                        choices=[
+                            ("draft", "Draft"),
+                            ("submitted", "Submitted"),
+                            ("under_review", "Under Review"),
+                            ("approved", "Approved"),
+                            ("rejected", "Rejected"),
+                            ("finalized", "Finalized"),
+                        ],
+                        default="draft",
+                        editable=False,
+                        help_text="Internal field to track the latest review stage for the report.",
+                        max_length=20,
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/emt/models.py
+++ b/emt/models.py
@@ -601,6 +601,13 @@ class EventReport(models.Model):
         choices=Status.choices,
         default=Status.DRAFT,
     )
+    review_stage = models.CharField(
+        max_length=20,
+        choices=Status.choices,
+        default=Status.DRAFT,
+        editable=False,
+        help_text="Internal field to track the latest review stage for the report.",
+    )
     location = models.CharField(max_length=200, blank=True)
     blog_link = models.URLField(blank=True)
     actual_event_type = models.CharField(max_length=200, blank=True)


### PR DESCRIPTION
## Summary
- add an internal `review_stage` field to event reports with a default value to avoid null inserts
- backfill and enforce the new review stage column via a defensive migration that tolerates existing databases

## Testing
- not run (local environment is missing the optional `xhtml2pdf` dependency used by the transcript app)


------
https://chatgpt.com/codex/tasks/task_e_68d8fcdb012c832cb0904338f51320f3