### PR TITLE
Remove legacy session_feedback column from event reports

### DIFF
--- a/emt/migrations/0032_remove_session_feedback.py
+++ b/emt/migrations/0032_remove_session_feedback.py
@@ -1,0 +1,39 @@
+
+from django.db import migrations
+
+
+def drop_session_feedback(apps, schema_editor):
+    connection = schema_editor.connection
+    with connection.cursor() as cursor:
+        vendor = connection.vendor
+        if vendor == "sqlite":
+            cursor.execute("PRAGMA table_info('emt_eventreport')")
+            columns = {row[1] for row in cursor.fetchall()}
+            if "session_feedback" not in columns:
+                return
+            cursor.execute("ALTER TABLE emt_eventreport DROP COLUMN session_feedback")
+        elif vendor == "postgresql":
+            cursor.execute(
+                """
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'emt_eventreport'
+                  AND column_name = 'session_feedback'
+                """
+            )
+            if cursor.fetchone() is None:
+                return
+            cursor.execute("ALTER TABLE emt_eventreport DROP COLUMN session_feedback")
+        else:
+            raise NotImplementedError(f"Unsupported database vendor: {vendor}")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("emt", "0031_eventreport_review_stage"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_session_feedback, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add a conditional migration that drops the legacy `session_feedback` column from `emt_eventreport` so the table matches the `EventReport` model

## Testing
- python manage.py migrate emt 0032
- python manage.py shell <<'PY'
from django.conf import settings
from django.test import Client
settings.ALLOWED_HOSTS.append('testserver')
client = Client()
client.login(username='tester', password='pass1234')
response = client.post('/suite/autosave-event-report/', data={'proposal_id': 1, 'location': 'Auditorium'}, content_type='application/json')
print(response.status_code, response.json())
PY


------
https://chatgpt.com/codex/tasks/task_e_68d900a3eed0832ca46bc9d99693eb8c