### PR TITLE
Fix attendance audience matching on attendance upload

### DIFF
--- a/emt/tests/test_attendance_data_view.py
+++ b/emt/tests/test_attendance_data_view.py
@@ -88,6 +88,24 @@ class AttendanceDataViewTests(TestCase):
         self.assertIn("CSE", data["students"])
         self.assertListEqual(sorted(data["students"]["CSE"]), ["Bob", "Carol"])
 
+    def test_skips_unmatched_department_names_in_target_audience(self):
+        proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            event_title="Dept Audience",
+            target_audience="Data Science Department, Computer Science",
+        )
+        report = EventReport.objects.create(proposal=proposal)
+
+        url = reverse("emt:attendance_data", args=[report.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertEqual(data["rows"], [])
+        self.assertEqual(data["counts"], {"total": 0, "present": 0, "absent": 0, "volunteers": 0})
+        self.assertEqual(data["students"], {})
+        self.assertEqual(data["faculty"], {})
+
     def test_includes_faculty_incharges_when_no_rows(self):
         org_type = OrganizationType.objects.create(name="Dept of Arts")
         org = Organization.objects.create(name="Fine Arts", org_type=org_type)

--- a/emt/views.py
+++ b/emt/views.py
@@ -3533,9 +3533,65 @@ def attendance_data(request, report_id):
         if name_norm:
             existing_names.add(name_norm)
 
+    def _normalise_lookup(value: str) -> str:
+        """Return a lookup friendly token ignoring whitespace and punctuation."""
+
+        return re.sub(r"[^a-z0-9]", "", (value or "").lower())
+
     names = [
         n.strip() for n in (proposal.target_audience or "").split(",") if n.strip()
     ]
+
+    def _build_faculty_entry(user, organization_name: str = "") -> dict[str, str]:
+        profile = getattr(user, "profile", None)
+        reg_no = (getattr(profile, "register_no", "") or user.username or "").strip()
+        full_name = (user.get_full_name() or user.username or "").strip()
+        return {
+            "registration_no": reg_no,
+            "full_name": full_name,
+            "organization": (organization_name or "").strip(),
+        }
+
+    faculty_lookup: dict[str, dict[str, str]] = {}
+
+    def _register_faculty_lookup(user, organization_name: str = "") -> None:
+        if not user:
+            return
+        entry = _build_faculty_entry(user, organization_name)
+        lookup_values = {
+            entry["registration_no"],
+            entry["full_name"],
+            user.username,
+            f"{user.first_name} {user.last_name}".strip(),
+        }
+        for value in list(lookup_values):
+            if value:
+                lookup_values.add(value.replace(" ", ""))
+        for value in lookup_values:
+            token = _normalise_lookup(value)
+            if token:
+                existing = faculty_lookup.get(token)
+                if existing and existing.get("organization") and not entry["organization"]:
+                    continue
+                faculty_lookup[token] = entry
+
+    membership_qs = (
+        OrganizationMembership.objects.filter(role="faculty")
+        .select_related("user__profile", "organization")
+        .order_by("id")
+    )
+    membership_org_by_user: dict[int, str] = {}
+    for membership in membership_qs:
+        organization_name = (
+            membership.organization.name if membership.organization else ""
+        )
+        _register_faculty_lookup(membership.user, organization_name)
+        if membership.user_id and organization_name:
+            membership_org_by_user.setdefault(membership.user_id, organization_name)
+
+    for faculty_user in proposal.faculty_incharges.all().select_related("profile"):
+        organization_name = membership_org_by_user.get(faculty_user.id, "")
+        _register_faculty_lookup(faculty_user, organization_name)
     if names:
         students = {
             (s.user.get_full_name() or s.user.username).strip().lower(): s
@@ -3613,17 +3669,34 @@ def attendance_data(request, report_id):
                 add_rows_for_class(cls_obj)
                 continue
 
-            add_row_if_missing(
-                {
-                    "registration_no": "",
-                    "full_name": name,
-                    "student_class": "",
-                    "absent": False,
-                    "volunteer": False,
-                    "category": AttendanceRow.Category.EXTERNAL,
-                    "affiliation": "",
-                }
-            )
+            faculty_entry = None
+            lookup_candidates = filter(None, [name, class_name, org_name])
+            for candidate in lookup_candidates:
+                token = _normalise_lookup(candidate)
+                if not token:
+                    continue
+                faculty_entry = faculty_lookup.get(token)
+                if faculty_entry:
+                    break
+
+            if faculty_entry:
+                add_row_if_missing(
+                    {
+                        "registration_no": faculty_entry["registration_no"],
+                        "full_name": faculty_entry["full_name"],
+                        "student_class": faculty_entry["organization"],
+                        "absent": False,
+                        "volunteer": False,
+                        "category": AttendanceRow.Category.FACULTY,
+                        "affiliation": faculty_entry["organization"],
+                    }
+                )
+                continue
+
+            # Skip adding placeholder "guest" rows for unmatched audience entries.
+            # These are often department names (e.g. "Data Science") that should
+            # not appear as attendees until a CSV upload provides concrete data.
+            continue
 
     faculty_users = list(proposal.faculty_incharges.all().select_related("profile"))
     for user in faculty_users:


### PR DESCRIPTION
## Summary
- ignore unmatched target audience strings so department names no longer appear as guest rows
- match faculty target audience values against organization memberships so selected staff and in-charges show up in attendance
- add a regression test covering unmatched department audience names

## Testing
- python manage.py test emt.tests.test_attendance_data_view *(fails: PostgreSQL test database is unreachable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d907742e24832ca201e1285ba5f216