### PR TITLE
Fix target audience validation state handling

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3391,15 +3391,45 @@ function getWhyThisEventForm() {
 
         const targetAudienceField = $('#target-audience-modern');
         const hiddenTargetAudienceField = $('#django-basic-info [name="target_audience"]');
-        const targetAudienceValue = targetAudienceField.length ? targetAudienceField.val() : '';
+        const hiddenTargetAudienceValue = hiddenTargetAudienceField.length ? hiddenTargetAudienceField.val() : '';
+        const selectedStudents = targetAudienceField.length ? targetAudienceField.data('selectedStudents') || [] : [];
+        const selectedFaculty = targetAudienceField.length ? targetAudienceField.data('selectedFaculty') || [] : [];
+        const selectedUsers = targetAudienceField.length ? targetAudienceField.data('selectedUsers') || [] : [];
+
+        let targetAudienceValue = targetAudienceField.length ? targetAudienceField.val() : '';
+        let hasVisibleValue = typeof targetAudienceValue === 'string' && targetAudienceValue.trim().length > 0;
+        const hasHiddenValue = typeof hiddenTargetAudienceValue === 'string' && hiddenTargetAudienceValue.trim().length > 0;
+        const hasSelectionData = selectedStudents.length > 0 || selectedFaculty.length > 0 || selectedUsers.length > 0;
+        const shouldRehydrateVisible =
+            targetAudienceField.length && !hasVisibleValue && (hasHiddenValue || hasSelectionData);
+        let rehydratedFromHidden = false;
+
+        if (shouldRehydrateVisible && hasHiddenValue) {
+            targetAudienceField
+                .val(hiddenTargetAudienceValue)
+                .trigger('input')
+                .trigger('change');
+            targetAudienceValue = hiddenTargetAudienceValue;
+            hasVisibleValue = true;
+            rehydratedFromHidden = true;
+        }
+
+        const hasAudience = hasVisibleValue || hasHiddenValue || hasSelectionData;
 
         logAudienceAction('validate-basic-info', {
             visibleValue: targetAudienceValue,
-            hiddenValue: hiddenTargetAudienceField.length ? hiddenTargetAudienceField.val() : undefined
+            hiddenValue: hiddenTargetAudienceValue,
+            selectedStudentCount: selectedStudents.length,
+            selectedFacultyCount: selectedFaculty.length,
+            selectedUserCount: selectedUsers.length,
+            hasVisibleValue,
+            hasHiddenValue,
+            hasSelectionData,
+            hasAudience,
+            rehydratedFromHidden
         });
 
         if (targetAudienceField.length) {
-            const hasAudience = Boolean(targetAudienceValue && targetAudienceValue.trim());
             if (!hasAudience) {
                 showFieldError(targetAudienceField, 'Target Audience is required');
                 isValid = false;


### PR DESCRIPTION
## Summary
- update basic info validation to consider the hidden Django field and stored selection metadata when checking for a target audience
- rehydrate the visible target audience input from the hidden value if selections exist but the field is blank
- enhance validation logging to report the updated audience state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da0437e034832ca0c62aaee8f0e689