### PR TITLE
Ensure attendance identifier discovery from admin routes

### DIFF
--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -101,7 +101,11 @@
             </div>
         {% endif %}
 
-        <form method="post" enctype="multipart/form-data" id="report-form" autocomplete="off" action="{% url 'emt:submit_event_report' proposal.id %}" data-preview-url="{% url 'emt:preview_event_report' proposal.id %}">
+        <form method="post" enctype="multipart/form-data" id="report-form" autocomplete="off"
+              action="{% url 'emt:submit_event_report' proposal.id %}"
+              data-preview-url="{% url 'emt:preview_event_report' proposal.id %}"
+              data-proposal-id="{{ proposal.id }}"
+              {% if report %}data-report-id="{{ report.id }}"{% endif %}>
             {% csrf_token %}
             <textarea name="event_summary" hidden>{{ event_summary.content|default_if_none:'' }}</textarea>
             <textarea name="event_outcomes" hidden>{{ event_outcomes.content|default_if_none:'' }}</textarea>


### PR DESCRIPTION
## Summary
- expose the proposal and report identifiers on the report form so client scripts can reliably read them
- add helpers that pull identifiers from the form dataset or admin-prefixed URLs before initializing attendance features
- extend the attendance access test suite with a Node-based check that verifies identifier discovery succeeds on admin routes

## Testing
- python manage.py test emt.tests.test_event_report_view.SubmitEventReportViewTests.test_attendance_identifiers_populate_on_admin_route *(fails: database server unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da4904ea94832c88aed07287639ba3