### PR TITLE
Fix event report event type and venue fields

### DIFF
--- a/emt/static/emt/js/submit_event_report.js
+++ b/emt/static/emt/js/submit_event_report.js
@@ -651,9 +651,23 @@ $(document).on('click', '#ai-sdg-implementation', function(){
   });
   
   // Auto-populate actual location with proposal venue if empty
+  if (window.PROPOSAL_DATA && !window.PROPOSAL_DATA.actual_event_type) {
+      window.PROPOSAL_DATA.actual_event_type = window.REPORT_ACTUAL_EVENT_TYPE || window.PROPOSAL_DATA.event_focus_type || '';
+  }
+
   const actualLocationField = $('#actual-location-modern');
   if (actualLocationField.length && actualLocationField.val().trim() === '' && window.PROPOSAL_DATA && window.PROPOSAL_DATA.venue) {
       actualLocationField.val(window.PROPOSAL_DATA.venue);
+  }
+
+  const eventTypeField = $('#event-type-modern');
+  if (eventTypeField.length) {
+      const proposalEventType = window.PROPOSAL_DATA ? (window.PROPOSAL_DATA.actual_event_type || window.PROPOSAL_DATA.event_focus_type || '') : '';
+      const derivedEventType = window.REPORT_ACTUAL_EVENT_TYPE || proposalEventType;
+      if (!eventTypeField.val() || eventTypeField.val().trim() === '') {
+          eventTypeField.val(derivedEventType);
+      }
+      eventTypeField.prop('readonly', false);
   }
   
   // Debug: Log proposal data
@@ -1169,7 +1183,10 @@ $(document).on('click', '#ai-sdg-implementation', function(){
     // GA inline controls removed; use dedicated editor
 
   function getEventInformationContent() {
-      const eventTypeValue = window.REPORT_ACTUAL_EVENT_TYPE || (window.PROPOSAL_DATA ? window.PROPOSAL_DATA.event_focus_type || '' : '');
+      const eventTypeValue = (sectionState['actual_event_type'] && String(sectionState['actual_event_type']).trim() !== '')
+          ? sectionState['actual_event_type']
+          : window.REPORT_ACTUAL_EVENT_TYPE
+              || (window.PROPOSAL_DATA ? (window.PROPOSAL_DATA.actual_event_type || window.PROPOSAL_DATA.event_focus_type || '') : '');
       return `
           <!-- Organization Information Section -->
           <div class="form-section-header">
@@ -1208,11 +1225,6 @@ $(document).on('click', '#ai-sdg-implementation', function(){
                   <input type="number" id="num-activities-modern" name="num_activities" value="${window.PROPOSAL_DATA ? window.PROPOSAL_DATA.num_activities || 1 : 1}">
                   <div class="help-text">Total activities from proposal (editable)</div>
               </div>
-              <div class="input-group">
-                  <label for="venue-modern">Venue *</label>
-                  <input type="text" id="venue-modern" name="venue_detail" value="${window.PROPOSAL_DATA ? window.PROPOSAL_DATA.venue || '' : ''}">
-                  <div class="help-text">Venue from proposal (editable)</div>
-              </div>
           </div>
 
           <!-- Schedule & Academic Information Section -->
@@ -1242,8 +1254,8 @@ $(document).on('click', '#ai-sdg-implementation', function(){
               </div>
               <div class="input-group">
                   <label for="event-type-modern">Event Type *</label>
-                  <input type="text" id="event-type-modern" name="actual_event_type" value="${eventTypeValue}" readonly>
-                  <div class="help-text">Event type from proposal (not editable)</div>
+                  <input type="text" id="event-type-modern" name="actual_event_type" value="${eventTypeValue}">
+                  <div class="help-text">Event type from proposal (editable)</div>
               </div>
           </div>
 

--- a/emt/templates/emt/submit_event_report.html
+++ b/emt/templates/emt/submit_event_report.html
@@ -146,14 +146,6 @@
                             </div>
                         </div>
 
-                        <div class="form-row">
-                            <div class="input-group">
-                                <label for="venue-modern">Venue *</label>
-                                <input type="text" id="venue-modern" name="venue_detail" class="proposal-input" value="{{ proposal.venue|default:'' }}">
-                                <div class="help-text">Venue from proposal (editable)</div>
-                            </div>
-                        </div>
-
                         <!-- Schedule & Academic Information Section -->
                         <div class="form-section-header">
                             <h3>Schedule & Academic Information</h3>
@@ -181,11 +173,11 @@
                             </div>
                             <div class="input-group">
                                 <label for="event-type-modern">Event Type *</label>
-                                <input type="text" id="event-type-modern" name="actual_event_type" class="proposal-input" value="{{ form.actual_event_type.value|default:proposal.event_focus_type }}" readonly>
+                                <input type="text" id="event-type-modern" name="actual_event_type" class="proposal-input" value="{{ form.actual_event_type.value|default:proposal.event_focus_type }}">
                                 {% if form.actual_event_type.errors %}
                                     <div class="field-error">{{ form.actual_event_type.errors.0 }}</div>
                                 {% endif %}
-                                <div class="help-text">Event type from proposal (not editable)</div>
+                                <div class="help-text">Event type from proposal (editable)</div>
                             </div>
                         </div>
 
@@ -476,6 +468,7 @@
             title: "{{ proposal.event_title|default:''|escapejs }}",
             target_audience: "{{ proposal.target_audience|default:''|escapejs }}",
             event_focus_type: "{{ proposal.event_focus_type|default:''|escapejs }}",
+            actual_event_type: "{{ report.actual_event_type|default:''|escapejs }}",
             student_coordinators: "{{ proposal.student_coordinators|default:''|escapejs }}",
             proposer: "{{ proposal.submitted_by.get_full_name|default:''|escapejs }}",
             faculty_incharges: {{ faculty_names_json|default:'[]'|safe }},


### PR DESCRIPTION
## Summary
- ensure the event report form pre-fills the event type and allows users to edit it
- remove duplicate venue inputs and share the saved event type with the client-side state so dynamic renders stay in sync

## Testing
- python manage.py test emt.tests.test_event_report_view *(fails: database connection to Railway Postgres is unreachable in the CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e134ff79fc832ca4e5e3e1d60f99a5