### PR TITLE
Shorten target audience display summary

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -1138,13 +1138,16 @@ $(document).ready(function() {
 
         const { summary, truncated, hiddenCount, displayedCount } = buildSummary(names);
 
+        const visibleValue = summary || displayValue;
+
         audienceField
-            .val(displayValue)
+            .val(visibleValue)
             .data('selectedStudents', [...selectedStudents])
             .data('selectedFaculty', [...selectedFaculty])
             .data('selectedUsers', [...userSelected])
             .data('fullAudience', displayValue)
             .attr('data-full-audience', displayValue)
+            .attr('title', displayValue)
             .trigger('change')
             .trigger('input');
 
@@ -1183,6 +1186,7 @@ $(document).ready(function() {
         logAudienceAction('selection-applied', {
             names,
             summary,
+            visibleValue,
             classIds,
             studentCount: selectedStudents.length,
             facultyCount: selectedFaculty.length,


### PR DESCRIPTION
## Summary
- show the shortened target audience summary in the proposal form field and keep the full list in the tooltip
- log the rendered summary alongside the full audience list for diagnostics

## Testing
- npx playwright test tests/save-section-target-audience.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e35e81d640832c90f14c97662c0de9