### PR TITLE
fix: merge emt migrations 0031 and 0033

### DIFF
--- a/emt/migrations/0034_merge_codex.py
+++ b/emt/migrations/0034_merge_codex.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("emt", "0031_safe_add_review_fields"),
+        ("emt", "0033_eventreport_generated_payload"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Summary
- add a no-op merge migration in emt to unify heads 0031_safe_add_review_fields and 0033_eventreport_generated_payload

## Testing
- python manage.py migrate --noinput *(fails: database server unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4898ba834832cba818f8560e53930