### PR TITLE
Persist dynamic sections on proposal form

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -31,6 +31,9 @@ $(document).ready(function() {
     let lastValidationIssues = [];
     let scheduleTableBody = null;
     let scheduleHiddenField = null;
+    let speakersHiddenField = null;
+    let expensesHiddenField = null;
+    let incomeHiddenField = null;
     const autoFillEnabled = new URLSearchParams(window.location.search).has('autofill');
     const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
     const originalFormAction = $('#proposal-form').attr('action') || '';
@@ -38,6 +41,59 @@ $(document).ready(function() {
     const SECTION_AUTOFILL_ORDER = ['basic-info', 'why-this-event', 'schedule', 'speakers', 'expenses', 'income'];
 
     const delay = (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
+
+    const cleanFieldValue = (value) => {
+        if (value === undefined || value === null) return '';
+        return String(value).trim();
+    };
+
+    const parseSerializedArray = (raw) => {
+        if (!raw) return [];
+        try {
+            const text = typeof raw === 'string' ? raw.trim() : String(raw || '').trim();
+            if (!text) return [];
+            const parsed = JSON.parse(text);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (err) {
+            console.warn('Failed to parse serialized section payload', err);
+            return [];
+        }
+    };
+
+    const readSerializedField = (field) => {
+        if (!field) return [];
+        if (Object.prototype.hasOwnProperty.call(field, 'value')) {
+            return parseSerializedArray(field.value);
+        }
+        return parseSerializedArray(field.textContent);
+    };
+
+    const writeSerializedField = (field, items) => {
+        if (!field) return;
+        const payload = (Array.isArray(items) && items.length)
+            ? JSON.stringify(items)
+            : '[]';
+        if (Object.prototype.hasOwnProperty.call(field, 'value')) {
+            if (field.value !== payload) {
+                field.value = payload;
+            }
+        } else if (field.textContent !== payload) {
+            field.textContent = payload;
+        }
+        field.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+
+    const getStoredSectionData = (fieldId, fallback = []) => {
+        const field = document.getElementById(fieldId);
+        const stored = readSerializedField(field);
+        if (stored.length) {
+            return stored;
+        }
+        if (Array.isArray(fallback) && fallback.length) {
+            return fallback;
+        }
+        return [];
+    };
 
     // Demo data used for rapid prototyping. Remove once real data is wired.
     const AUTO_FILL_DATA = {
@@ -2319,6 +2375,29 @@ function getWhyThisEventForm() {
         `;
     }
 
+    function serializeSpeakers() {
+        speakersHiddenField = speakersHiddenField || document.getElementById('speakers-data');
+        if (!speakersHiddenField) return;
+        const items = [];
+        $('#speakers-list .speaker-form-container').each(function() {
+            const form = $(this);
+            const record = {
+                full_name: cleanFieldValue(form.find("input[id^='speaker_full_name_']").val()),
+                designation: cleanFieldValue(form.find("input[id^='speaker_designation_']").val()),
+                affiliation: cleanFieldValue(form.find("input[id^='speaker_affiliation_']").val()),
+                contact_email: cleanFieldValue(form.find("input[id^='speaker_contact_email_']").val()),
+                contact_number: cleanFieldValue(form.find("input[id^='speaker_contact_number_']").val()),
+                linkedin_url: cleanFieldValue(form.find("input[id^='speaker_linkedin_url_']").val()),
+                detailed_profile: cleanFieldValue(form.find("textarea[id^='speaker_detailed_profile_']").val()),
+            };
+            const hasAny = Object.values(record).some(val => val !== '');
+            if (hasAny) {
+                items.push(record);
+            }
+        });
+        writeSerializedField(speakersHiddenField, items);
+    }
+
     function getExpensesForm() {
         return `
             <div class="expenses-section">
@@ -2346,6 +2425,7 @@ function getWhyThisEventForm() {
     function setupSpeakersSection() {
         const container = $('#speakers-list');
         let index = 0;
+        speakersHiddenField = document.getElementById('speakers-data');
 
         function addSpeakerForm() {
             const html = `
@@ -2358,7 +2438,7 @@ function getWhyThisEventForm() {
                                 <span class="sr-only">Remove speaker</span>
                             </button>
                         </div>
-                        
+
                         <div class="speaker-form-content">
                             <div class="speaker-form-grid">
                                 <div class="input-group">
@@ -2398,7 +2478,7 @@ function getWhyThisEventForm() {
                                     <div class="help-text">Upload headshot (JPG, PNG)</div>
                                 </div>
                             </div>
-                            
+
                             <div class="input-group bio-section">
                                 <label for="speaker_detailed_profile_${index}">Brief Profile / Bio *</label>
                                 <textarea id="speaker_detailed_profile_${index}" name="speaker_detailed_profile_${index}" rows="4" required placeholder="Brief description of speaker's expertise, background, and qualifications..."></textarea>
@@ -2409,10 +2489,16 @@ function getWhyThisEventForm() {
                 </div>
             `;
             container.append(html);
+            const newForm = container.children('.speaker-form-container').last();
+            newForm.find('input, textarea').on('input change', () => {
+                serializeSpeakers();
+            });
             index++;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
+            serializeSpeakers();
+            return newForm;
         }
 
         function updateSpeakerHeaders() {
@@ -2449,6 +2535,7 @@ function getWhyThisEventForm() {
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
+            serializeSpeakers();
         }
 
         function showEmptyState() {
@@ -2463,6 +2550,7 @@ function getWhyThisEventForm() {
             } else {
                 container.find('.speakers-empty-state').remove();
             }
+            serializeSpeakers();
         }
 
         $('#add-speaker-btn').on('click', function() {
@@ -2551,18 +2639,19 @@ function getWhyThisEventForm() {
             }
         });
 
-        if (window.EXISTING_SPEAKERS && window.EXISTING_SPEAKERS.length) {
+        const initialSpeakers = getStoredSectionData('speakers-data', window.EXISTING_SPEAKERS || []);
+        if (initialSpeakers.length) {
             container.empty();
-            window.EXISTING_SPEAKERS.forEach(sp => {
+            initialSpeakers.forEach(sp => {
                 addSpeakerForm();
                 const idx = index - 1;
-                $(`#speaker_full_name_${idx}`).val(sp.full_name);
-                $(`#speaker_designation_${idx}`).val(sp.designation);
-                $(`#speaker_affiliation_${idx}`).val(sp.affiliation);
-                $(`#speaker_contact_email_${idx}`).val(sp.contact_email);
-                $(`#speaker_contact_number_${idx}`).val(sp.contact_number);
-                $(`#speaker_linkedin_url_${idx}`).val(sp.linkedin_url);
-                $(`#speaker_detailed_profile_${idx}`).val(sp.detailed_profile);
+                $(`#speaker_full_name_${idx}`).val(cleanFieldValue(sp.full_name));
+                $(`#speaker_designation_${idx}`).val(cleanFieldValue(sp.designation));
+                $(`#speaker_affiliation_${idx}`).val(cleanFieldValue(sp.affiliation));
+                $(`#speaker_contact_email_${idx}`).val(cleanFieldValue(sp.contact_email));
+                $(`#speaker_contact_number_${idx}`).val(cleanFieldValue(sp.contact_number));
+                $(`#speaker_linkedin_url_${idx}`).val(cleanFieldValue(sp.linkedin_url));
+                $(`#speaker_detailed_profile_${idx}`).val(cleanFieldValue(sp.detailed_profile));
             });
             showEmptyState();
         } else {
@@ -2615,6 +2704,24 @@ function getWhyThisEventForm() {
         }
     }
 
+    function serializeExpenses() {
+        expensesHiddenField = expensesHiddenField || document.getElementById('expenses-data');
+        if (!expensesHiddenField) return;
+        const items = [];
+        $('#expense-rows .expense-form-container').each(function() {
+            const form = $(this);
+            const record = {
+                sl_no: cleanFieldValue(form.find("input[id^='expense_sl_no_']").val()),
+                particulars: cleanFieldValue(form.find("input[id^='expense_particulars_']").val()),
+                amount: cleanFieldValue(form.find("input[id^='expense_amount_']").val()),
+            };
+            if (Object.values(record).some(val => val !== '')) {
+                items.push(record);
+            }
+        });
+        writeSerializedField(expensesHiddenField, items);
+    }
+
     function setupExpensesSection() {
         const container = $('#expense-rows');
         let index = 0;
@@ -2653,10 +2760,15 @@ function getWhyThisEventForm() {
                 </div>
             `;
             container.append(html);
+            const newRow = container.children('.expense-form-container').last();
+            newRow.find('input').on('input change', () => {
+                serializeExpenses();
+            });
             index++;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
+            serializeExpenses();
         }
 
         function updateExpenseHeaders() {
@@ -2665,6 +2777,7 @@ function getWhyThisEventForm() {
                 $(this).attr('data-index', i);
                 $(this).find('.remove-expense-btn').attr('data-index', i);
             });
+            serializeExpenses();
         }
 
         function showEmptyState() {
@@ -2679,6 +2792,7 @@ function getWhyThisEventForm() {
             } else {
                 container.find('.expenses-empty-state').remove();
             }
+            serializeExpenses();
         }
 
         $('#add-expense-btn').on('click', function() {
@@ -2693,22 +2807,25 @@ function getWhyThisEventForm() {
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
+            serializeExpenses();
         });
 
-        if (window.EXISTING_EXPENSES && window.EXISTING_EXPENSES.length) {
+        const initialExpenses = getStoredSectionData('expenses-data', window.EXISTING_EXPENSES || []);
+        if (initialExpenses.length) {
             container.empty();
-            window.EXISTING_EXPENSES.forEach(ex => {
+            initialExpenses.forEach(ex => {
                 addExpenseRow();
                 const idx = index - 1;
-                $(`#expense_sl_no_${idx}`).val(ex.sl_no);
-                $(`#expense_particulars_${idx}`).val(ex.particulars);
-                $(`#expense_amount_${idx}`).val(ex.amount);
+                $(`#expense_sl_no_${idx}`).val(cleanFieldValue(ex.sl_no));
+                $(`#expense_particulars_${idx}`).val(cleanFieldValue(ex.particulars));
+                $(`#expense_amount_${idx}`).val(cleanFieldValue(ex.amount));
             });
             showEmptyState();
         } else {
             showEmptyState();
         }
 
+        expensesHiddenField = document.getElementById('expenses-data');
         const addExpenseBtnEl = document.getElementById('add-expense-btn');
         if (addExpenseBtnEl) {
             addExpenseBtnEl.dataset.listenerAttached = 'true';
@@ -2742,6 +2859,26 @@ function getWhyThisEventForm() {
                 </div>
             </div>
         `;
+    }
+
+    function serializeIncome() {
+        incomeHiddenField = incomeHiddenField || document.getElementById('income-data');
+        if (!incomeHiddenField) return;
+        const items = [];
+        $('#income-rows .income-form-container').each(function() {
+            const form = $(this);
+            const record = {
+                sl_no: cleanFieldValue(form.find("input[id^='income_sl_no_']").val()),
+                particulars: cleanFieldValue(form.find("input[id^='income_particulars_']").val()),
+                participants: cleanFieldValue(form.find("input[id^='income_participants_']").val()),
+                rate: cleanFieldValue(form.find("input[id^='income_rate_']").val()),
+                amount: cleanFieldValue(form.find("input[id^='income_amount_']").val()),
+            };
+            if (Object.values(record).some(val => val !== '')) {
+                items.push(record);
+            }
+        });
+        writeSerializedField(incomeHiddenField, items);
     }
 
     function setupIncomeSection() {
@@ -2792,28 +2929,34 @@ function getWhyThisEventForm() {
                 </div>
             `;
             container.append(html);
-            
+
             // Auto-calculate amount when participants and rate change
             const participantsInput = $(`#income_participants_${index}`);
             const rateInput = $(`#income_rate_${index}`);
             const amountInput = $(`#income_amount_${index}`);
-            
+
             function calculateAmount() {
                 const participants = parseFloat(participantsInput.val()) || 0;
                 const rate = parseFloat(rateInput.val()) || 0;
                 const calculatedAmount = participants * rate;
                 if (calculatedAmount > 0) {
                     amountInput.val(calculatedAmount.toFixed(2));
+                    serializeIncome();
                 }
             }
-            
+
             participantsInput.on('input change', calculateAmount);
             rateInput.on('input change', calculateAmount);
-            
+            $(`#income_sl_no_${index}, #income_particulars_${index}, #income_amount_${index}`).on('input change', () => {
+                serializeIncome();
+            });
+            amountInput.on('input change', () => serializeIncome());
+
             index++;
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
+            serializeIncome();
         }
 
         function updateIncomeHeaders() {
@@ -2822,6 +2965,7 @@ function getWhyThisEventForm() {
                 $(this).attr('data-index', i);
                 $(this).find('.remove-income-btn').attr('data-index', i);
             });
+            serializeIncome();
         }
 
         function showEmptyState() {
@@ -2835,6 +2979,7 @@ function getWhyThisEventForm() {
             } else {
                 container.find('.income-empty-state').remove();
             }
+            serializeIncome();
         }
 
         $('#add-income-btn').on('click', function() {
@@ -2849,25 +2994,28 @@ function getWhyThisEventForm() {
             if (window.AutosaveManager && window.AutosaveManager.reinitialize) {
                 window.AutosaveManager.reinitialize();
             }
+            serializeIncome();
         });
 
         // Load existing income data if available
-        if (window.EXISTING_INCOME && window.EXISTING_INCOME.length) {
+        const initialIncome = getStoredSectionData('income-data', window.EXISTING_INCOME || []);
+        if (initialIncome.length) {
             container.empty();
-            window.EXISTING_INCOME.forEach(inc => {
+            initialIncome.forEach(inc => {
                 addIncomeRow();
                 const idx = index - 1;
-                $(`#income_sl_no_${idx}`).val(inc.sl_no);
-                $(`#income_particulars_${idx}`).val(inc.particulars);
-                $(`#income_participants_${idx}`).val(inc.participants);
-                $(`#income_rate_${idx}`).val(inc.rate);
-                $(`#income_amount_${idx}`).val(inc.amount);
+                $(`#income_sl_no_${idx}`).val(cleanFieldValue(inc.sl_no));
+                $(`#income_particulars_${idx}`).val(cleanFieldValue(inc.particulars));
+                $(`#income_participants_${idx}`).val(cleanFieldValue(inc.participants));
+                $(`#income_rate_${idx}`).val(cleanFieldValue(inc.rate));
+                $(`#income_amount_${idx}`).val(cleanFieldValue(inc.amount));
             });
             showEmptyState();
         } else {
             showEmptyState();
         }
 
+        incomeHiddenField = document.getElementById('income-data');
         const addIncomeBtnEl = document.getElementById('add-income-btn');
         if (addIncomeBtnEl) {
             addIncomeBtnEl.dataset.listenerAttached = 'true';
@@ -3002,6 +3150,15 @@ function getWhyThisEventForm() {
 
         if (currentExpandedCard === 'schedule') {
             serializeSchedule();
+        }
+        if (currentExpandedCard === 'speakers') {
+            serializeSpeakers();
+        }
+        if (currentExpandedCard === 'expenses') {
+            serializeExpenses();
+        }
+        if (currentExpandedCard === 'income') {
+            serializeIncome();
         }
 
         // Always validate before saving

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -112,6 +112,9 @@
             <textarea id="id_objectives" name="objectives" class="proposal-input" hidden>{{ objectives.content|default_if_none:'' }}</textarea>
             <textarea id="id_learning_outcomes" name="outcomes" class="proposal-input" hidden>{{ outcomes.content|default_if_none:'' }}</textarea>
             <textarea name="flow" class="proposal-input" hidden>{{ flow.content|default_if_none:'' }}</textarea>
+            <textarea id="speakers-data" name="speakers_serialized" class="proposal-input" hidden>{{ speakers_json|safe }}</textarea>
+            <textarea id="expenses-data" name="expenses_serialized" class="proposal-input" hidden>{{ expenses_json|safe }}</textarea>
+            <textarea id="income-data" name="income_serialized" class="proposal-input" hidden>{{ income_json|default:'[]'|safe }}</textarea>
 
             <div class="form-panel" id="form-panel">
                 <div class="form-panel-content" id="form-panel-content">

--- a/emt/views.py
+++ b/emt/views.py
@@ -645,7 +645,105 @@ def _save_activities(proposal, data, form=None):
     return True
 
 
-def _save_speakers(proposal, data, files):
+def _coerce_str(value):
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _deserialize_section_payload(data, key):
+    raw = data.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, (list, tuple)):
+        parsed = list(raw)
+    else:
+        text = str(raw).strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (TypeError, json.JSONDecodeError):
+            logger.debug("Invalid JSON for %s: %s", key, raw)
+            return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def _deserialize_speaker_entries(data):
+    entries = _deserialize_section_payload(data, "speakers_serialized")
+    if entries is None:
+        return None
+    cleaned = []
+    for entry in entries:
+        cleaned.append(
+            {
+                "full_name": _coerce_str(entry.get("full_name")),
+                "designation": _coerce_str(entry.get("designation")),
+                "affiliation": _coerce_str(entry.get("affiliation")),
+                "contact_email": _coerce_str(entry.get("contact_email")),
+                "contact_number": _coerce_str(entry.get("contact_number")),
+                "linkedin_url": _coerce_str(entry.get("linkedin_url")),
+                "detailed_profile": _coerce_str(entry.get("detailed_profile")),
+            }
+        )
+    return cleaned
+
+
+def _deserialize_expense_entries(data):
+    entries = _deserialize_section_payload(data, "expenses_serialized")
+    if entries is None:
+        return None
+    cleaned = []
+    for entry in entries:
+        cleaned.append(
+            {
+                "sl_no": _coerce_str(entry.get("sl_no")),
+                "particulars": _coerce_str(entry.get("particulars")),
+                "amount": _coerce_str(entry.get("amount")),
+            }
+        )
+    return cleaned
+
+
+def _deserialize_income_entries(data):
+    entries = _deserialize_section_payload(data, "income_serialized")
+    if entries is None:
+        return None
+    cleaned = []
+    for entry in entries:
+        cleaned.append(
+            {
+                "sl_no": _coerce_str(entry.get("sl_no")),
+                "particulars": _coerce_str(entry.get("particulars")),
+                "participants": _coerce_str(entry.get("participants")),
+                "rate": _coerce_str(entry.get("rate")),
+                "amount": _coerce_str(entry.get("amount")),
+            }
+        )
+    return cleaned
+
+
+def _save_speakers(proposal, data, files, entries=None):
+    if entries is not None:
+        proposal.speakers.all().delete()
+        for index, entry in enumerate(entries):
+            full_name = entry.get("full_name", "")
+            if full_name:
+                SpeakerProfile.objects.create(
+                    proposal=proposal,
+                    full_name=full_name,
+                    designation=entry.get("designation", ""),
+                    affiliation=entry.get("affiliation", ""),
+                    contact_email=entry.get("contact_email", ""),
+                    contact_number=entry.get("contact_number", ""),
+                    linkedin_url=entry.get("linkedin_url", ""),
+                    photo=files.get(f"speaker_photo_{index}"),
+                    detailed_profile=entry.get("detailed_profile", ""),
+                )
+        return
+
     pattern = re.compile(
         r"^speaker_(?:full_name|designation|affiliation|contact_email|"
         r"contact_number|linkedin_url|photo|detailed_profile)_(\d+)$"
@@ -747,7 +845,22 @@ def _sync_proposal_from_report(proposal, report, payload: dict):
         proposal.save()
 
 
-def _save_expenses(proposal, data):
+def _save_expenses(proposal, data, entries=None):
+    if entries is not None:
+        proposal.expense_details.all().delete()
+        for entry in entries:
+            particulars = entry.get("particulars", "")
+            amount = entry.get("amount", "")
+            if particulars and amount:
+                sl_no = entry.get("sl_no") or 0
+                ExpenseDetail.objects.create(
+                    proposal=proposal,
+                    sl_no=sl_no or 0,
+                    particulars=particulars,
+                    amount=amount,
+                )
+        return
+
     pattern = re.compile(r"^expense_(?:sl_no|particulars|amount)_(\d+)$")
     indices = sorted(
         {int(m.group(1)) for key in data.keys() if (m := pattern.match(key))}
@@ -768,7 +881,24 @@ def _save_expenses(proposal, data):
             )
 
 
-def _save_income(proposal, data):
+def _save_income(proposal, data, entries=None):
+    if entries is not None:
+        proposal.income_details.all().delete()
+        for entry in entries:
+            particulars = entry.get("particulars", "")
+            amount = entry.get("amount", "")
+            if particulars and amount:
+                sl_no = entry.get("sl_no") or 0
+                IncomeDetail.objects.create(
+                    proposal=proposal,
+                    sl_no=sl_no or 0,
+                    particulars=particulars,
+                    participants=entry.get("participants") or 0,
+                    rate=entry.get("rate") or 0,
+                    amount=amount,
+                )
+        return
+
     pattern = re.compile(
         r"^income_(?:sl_no|particulars|participants|rate|amount)_(\d+)$"
     )
@@ -821,6 +951,9 @@ def submit_proposal(request, pk=None):
         logger.debug(
             "Faculty IDs from POST: %s", post_data.getlist("faculty_incharges")
         )
+        speaker_entries = _deserialize_speaker_entries(post_data)
+        expense_entries = _deserialize_expense_entries(post_data)
+        income_entries = _deserialize_income_entries(post_data)
         form = EventProposalForm(
             post_data,
             instance=proposal,
@@ -949,11 +1082,17 @@ def submit_proposal(request, pk=None):
             ctx["form"] = form
             ctx["proposal"] = proposal
             return render(request, "emt/submit_proposal.html", ctx)
-        if any(key.startswith("speaker_") for key in request.POST.keys()):
+        if speaker_entries is not None:
+            _save_speakers(proposal, request.POST, request.FILES, entries=speaker_entries)
+        elif any(key.startswith("speaker_") for key in request.POST.keys()):
             _save_speakers(proposal, request.POST, request.FILES)
-        if any(key.startswith("expense_") for key in request.POST.keys()):
+        if expense_entries is not None:
+            _save_expenses(proposal, request.POST, entries=expense_entries)
+        elif any(key.startswith("expense_") for key in request.POST.keys()):
             _save_expenses(proposal, request.POST)
-        if any(key.startswith("income_") for key in request.POST.keys()):
+        if income_entries is not None:
+            _save_income(proposal, request.POST, entries=income_entries)
+        elif any(key.startswith("income_") for key in request.POST.keys()):
             _save_income(proposal, request.POST)
         logger.debug(
             "Proposal %s saved with faculty %s",
@@ -1089,6 +1228,10 @@ def autosave_proposal(request):
 
     logger.debug("autosave_proposal payload: %s", data)
 
+    speaker_entries = _deserialize_speaker_entries(data)
+    expense_entries = _deserialize_expense_entries(data)
+    income_entries = _deserialize_income_entries(data)
+
     # Replace department logic with generic organization
     org_type_val = data.get("organization_type")
     org_name_val = data.get("organization")
@@ -1209,7 +1352,6 @@ def autosave_proposal(request):
 
     # Validate speakers
     sp_errors = {}
-    sp_idx = 0
     sp_fields = [
         "full_name",
         "designation",
@@ -1219,88 +1361,144 @@ def autosave_proposal(request):
     ]
     email_validator = EmailValidator()
     url_validator = URLValidator()
-    while any(
-        f"speaker_{field}_{sp_idx}" in data
-        for field in sp_fields + ["contact_number", "linkedin_url", "photo"]
-    ):
-        missing = {}
-        has_any = False
-        for field in sp_fields:
-            value = data.get(f"speaker_{field}_{sp_idx}")
-            if value:
-                has_any = True
-                if field == "full_name" and not NAME_RE.fullmatch(value):
-                    missing[field] = "Enter a valid name (letters, spaces, .'- only)."
-                elif field == "contact_email":
-                    try:
-                        email_validator(value)
-                    except ValidationError:
-                        missing[field] = "Enter a valid email address."
-            else:
-                missing[field] = "This field is required."
+    if speaker_entries is not None:
+        for idx, entry in enumerate(speaker_entries):
+            missing = {}
+            has_any = any(entry.get(field) for field in sp_fields + ["contact_number", "linkedin_url"])
+            for field in sp_fields:
+                value = entry.get(field)
+                if value:
+                    if field == "full_name" and not NAME_RE.fullmatch(value):
+                        missing[field] = "Enter a valid name (letters, spaces, .'- only)."
+                    elif field == "contact_email":
+                        try:
+                            email_validator(value)
+                        except ValidationError:
+                            missing[field] = "Enter a valid email address."
+                else:
+                    missing[field] = "This field is required."
 
-        linkedin = data.get(f"speaker_linkedin_url_{sp_idx}")
-        if linkedin:
-            try:
-                url_validator(linkedin)
-            except ValidationError:
-                missing["linkedin_url"] = "Enter a valid URL."
+            linkedin = entry.get("linkedin_url")
+            if linkedin:
+                try:
+                    url_validator(linkedin)
+                except ValidationError:
+                    missing["linkedin_url"] = "Enter a valid URL."
 
-        if has_any and missing:
-            sp_errors[sp_idx] = missing
-        sp_idx += 1
+            if has_any and missing:
+                sp_errors[idx] = missing
+    else:
+        sp_idx = 0
+        while any(
+            f"speaker_{field}_{sp_idx}" in data
+            for field in sp_fields + ["contact_number", "linkedin_url", "photo"]
+        ):
+            missing = {}
+            has_any = False
+            for field in sp_fields:
+                value = data.get(f"speaker_{field}_{sp_idx}")
+                if value:
+                    has_any = True
+                    if field == "full_name" and not NAME_RE.fullmatch(value):
+                        missing[field] = "Enter a valid name (letters, spaces, .'- only)."
+                    elif field == "contact_email":
+                        try:
+                            email_validator(value)
+                        except ValidationError:
+                            missing[field] = "Enter a valid email address."
+                else:
+                    missing[field] = "This field is required."
+
+            linkedin = data.get(f"speaker_linkedin_url_{sp_idx}")
+            if linkedin:
+                try:
+                    url_validator(linkedin)
+                except ValidationError:
+                    missing["linkedin_url"] = "Enter a valid URL."
+
+            if has_any and missing:
+                sp_errors[sp_idx] = missing
+            sp_idx += 1
     if sp_errors:
         errors["speakers"] = sp_errors
 
     # Validate expenses
     ex_errors = {}
-    ex_idx = 0
-    while any(
-        f"expense_{field}_{ex_idx}" in data
-        for field in ["sl_no", "particulars", "amount"]
-    ):
-        particulars = data.get(f"expense_particulars_{ex_idx}")
-        amount = data.get(f"expense_amount_{ex_idx}")
-        missing = {}
-        if particulars or amount:
-            if not particulars:
-                missing["particulars"] = "This field is required."
-            if not amount:
-                missing["amount"] = "This field is required."
-        if missing:
-            ex_errors[ex_idx] = missing
-        ex_idx += 1
+    if expense_entries is not None:
+        for idx, entry in enumerate(expense_entries):
+            particulars = entry.get("particulars")
+            amount = entry.get("amount")
+            missing = {}
+            if particulars or amount:
+                if not particulars:
+                    missing["particulars"] = "This field is required."
+                if not amount:
+                    missing["amount"] = "This field is required."
+            if missing:
+                ex_errors[idx] = missing
+    else:
+        ex_idx = 0
+        while any(
+            f"expense_{field}_{ex_idx}" in data
+            for field in ["sl_no", "particulars", "amount"]
+        ):
+            particulars = data.get(f"expense_particulars_{ex_idx}")
+            amount = data.get(f"expense_amount_{ex_idx}")
+            missing = {}
+            if particulars or amount:
+                if not particulars:
+                    missing["particulars"] = "This field is required."
+                if not amount:
+                    missing["amount"] = "This field is required."
+            if missing:
+                ex_errors[ex_idx] = missing
+            ex_idx += 1
     if ex_errors:
         errors["expenses"] = ex_errors
 
     # Validate income
     in_errors = {}
-    in_idx = 0
-    while any(
-        f"income_{field}_{in_idx}" in data
-        for field in ["particulars", "participants", "rate", "amount"]
-    ):
-        particulars = data.get(f"income_particulars_{in_idx}")
-        participants = data.get(f"income_participants_{in_idx}")
-        rate = data.get(f"income_rate_{in_idx}")
-        amount = data.get(f"income_amount_{in_idx}")
-        missing = {}
-        # Only require particulars and amount; participants and rate are optional
-        if any([particulars, participants, rate, amount]):
-            if not particulars:
-                missing["particulars"] = "This field is required."
-            if not amount:
-                missing["amount"] = "This field is required."
-        if missing:
-            in_errors[in_idx] = missing
-        in_idx += 1
+    if income_entries is not None:
+        for idx, entry in enumerate(income_entries):
+            particulars = entry.get("particulars")
+            participants = entry.get("participants")
+            rate = entry.get("rate")
+            amount = entry.get("amount")
+            missing = {}
+            if any([particulars, participants, rate, amount]):
+                if not particulars:
+                    missing["particulars"] = "This field is required."
+                if not amount:
+                    missing["amount"] = "This field is required."
+            if missing:
+                in_errors[idx] = missing
+    else:
+        in_idx = 0
+        while any(
+            f"income_{field}_{in_idx}" in data
+            for field in ["particulars", "participants", "rate", "amount"]
+        ):
+            particulars = data.get(f"income_particulars_{in_idx}")
+            participants = data.get(f"income_participants_{in_idx}")
+            rate = data.get(f"income_rate_{in_idx}")
+            amount = data.get(f"income_amount_{in_idx}")
+            missing = {}
+            # Only require particulars and amount; participants and rate are optional
+            if any([particulars, participants, rate, amount]):
+                if not particulars:
+                    missing["particulars"] = "This field is required."
+                if not amount:
+                    missing["amount"] = "This field is required."
+            if missing:
+                in_errors[in_idx] = missing
+            in_idx += 1
     if in_errors:
         errors["income"] = in_errors
 
     _save_activities(proposal, data)
-    _save_speakers(proposal, data, request.FILES)
-    _save_expenses(proposal, data)
-    _save_income(proposal, data)
+    _save_speakers(proposal, data, request.FILES, entries=speaker_entries)
+    _save_expenses(proposal, data, entries=expense_entries)
+    _save_income(proposal, data, entries=income_entries)
 
     if errors:
         logger.debug("autosave_proposal dynamic errors: %s", errors)


### PR DESCRIPTION
## Summary
- add hidden serialized textareas for speakers, expenses, and income on the proposal form so values persist across sections
- serialize dynamic section entries in the proposal dashboard JavaScript, keeping hidden fields in sync and restoring saved values
- update autosave and submission logic to parse the serialized payloads, validate them, and write speaker/expense/income records

## Testing
- python manage.py test *(fails: cannot reach the configured PostgreSQL test database in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c4ffe5a0832c856a2fff4580ec71