### PR TITLE
Fix activity autofill on proposal form

### DIFF
--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -273,7 +273,7 @@
             </div>
 
             <div style="display: none;" id="django-forms">
-                <div id="django-basic-info">
+                <div id="django-basic-info" data-activities="{{ activities_json|default:'[]'|escapejs }}">
                     {{ form.organization_type.label_tag }}
                     {{ form.organization_type }}
                     {{ form.organization.label_tag }}


### PR DESCRIPTION
## Summary
- normalize previously stored activity data before rendering the dynamic activity rows
- surface the serialized activities on the hidden Django form container so the client can hydrate reliably

## Testing
- ⚠️ `DATABASE_URL=sqlite:////workspace/IQAC-Suite/db.sqlite3 python manage.py migrate --noinput` *(fails: sqlite backend cannot run raw EXISTS clause in migration)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d30f8f6c832caea63da01edd6312