### PR TITLE
Normalize autofill inputs for proposal finances and speakers

### DIFF
--- a/emt/normalizers.py
+++ b/emt/normalizers.py
@@ -1,0 +1,79 @@
+"""Utilities for normalizing loosely formatted numeric input."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Optional, Union
+
+NumberLike = Union[str, int, float, Decimal]
+
+_DECIMAL_ALLOWED = re.compile(r"[^0-9.,+-]")
+_INT_ALLOWED = re.compile(r"[^0-9+-]")
+
+
+def _strip_extraneous_chars(value: str, *, allow_negative: bool) -> str:
+    """Remove everything except digits, separators, and sign."""
+    if not value:
+        return ""
+    text = value.strip().replace(" ", "")
+    text = _DECIMAL_ALLOWED.sub("", text)
+    if not allow_negative:
+        text = text.replace("-", "")
+    else:
+        if text.count("-") > 1:
+            text = text.replace("-", "")
+        elif "-" in text and not text.startswith("-"):
+            text = "-" + text.replace("-", "")
+    return text
+
+
+def normalize_decimal(value: Optional[NumberLike], *, allow_negative: bool = False) -> Optional[Decimal]:
+    """Coerce loosely formatted numeric input into a Decimal."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, Decimal):
+        result = value
+    else:
+        text = _strip_extraneous_chars(str(value), allow_negative=allow_negative)
+        if not text:
+            return None
+        text = text.replace(",", "")
+        if text.count(".") > 1:
+            head, tail = text.rsplit(".", 1)
+            head = head.replace(".", "")
+            text = f"{head}.{tail}"
+        try:
+            result = Decimal(text)
+        except InvalidOperation as exc:
+            raise ValueError(f"Unable to parse decimal value from '{value}'") from exc
+    if not allow_negative and result < 0:
+        raise ValueError("Negative values are not allowed")
+    return result
+
+
+def normalize_int(value: Optional[NumberLike], *, allow_negative: bool = False) -> Optional[int]:
+    """Coerce loosely formatted numeric input into an integer."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, int):
+        result = value
+    else:
+        text = str(value).strip().replace(" ", "")
+        text = _INT_ALLOWED.sub("", text)
+        if not allow_negative:
+            text = text.replace("-", "")
+        else:
+            if text.count("-") > 1:
+                text = text.replace("-", "")
+            elif "-" in text and not text.startswith("-"):
+                text = "-" + text.replace("-", "")
+        if not text:
+            return None
+        try:
+            result = int(float(text))
+        except ValueError as exc:
+            raise ValueError(f"Unable to parse integer value from '{value}'") from exc
+    if not allow_negative and result < 0:
+        raise ValueError("Negative values are not allowed")
+    return result

--- a/emt/static/emt/css/styles.css
+++ b/emt/static/emt/css/styles.css
@@ -68,6 +68,26 @@
     color: var(--text-muted);
     margin: .25rem 0 0;
   }
+
+  .form-errors {
+    background: #fef2f2;
+    border: 1px solid var(--error-color);
+    color: var(--error-color);
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .form-errors ul {
+    margin: 0;
+    padding-left: 1.2rem;
+  }
+
+  .field-errors div {
+    color: var(--error-color);
+    font-size: 0.85rem;
+    margin: 0.35rem 0 0.2rem;
+  }
   
   .nav-items { list-style: none; margin: 0; padding: 0; }
   .nav-item { margin: 0; }

--- a/emt/templates/emt/expense_details.html
+++ b/emt/templates/emt/expense_details.html
@@ -22,15 +22,48 @@
     <form method="post">
       {% csrf_token %}
       {{ formset.management_form }}
+      {% if formset.non_form_errors %}
+        <div class="form-errors">
+          <ul>
+            {% for error in formset.non_form_errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
 
       <div class="section">
         <h3>Expense List</h3>
         {% for form in formset %}
           <div class="section expense-form">
             <h4>Expense {{ forloop.counter }}</h4>
+            {% if form.non_field_errors %}
+              <div class="form-errors">
+                <ul>
+                  {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.sl_no.label_tag }} {{ form.sl_no.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.sl_no.errors %}
+              <div class="field-errors">
+                {% for error in form.sl_no.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.particulars.label_tag }} {{ form.particulars.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.particulars.errors %}
+              <div class="field-errors">
+                {% for error in form.particulars.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.amount.label_tag }} {{ form.amount.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.amount.errors %}
+              <div class="field-errors">
+                {% for error in form.amount.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             {% if form.DELETE %}
               <div class="input-group">{{ form.DELETE.as_widget(attrs={'class': 'proposal-input'}) }} Remove this expense</div>
             {% endif %}

--- a/emt/templates/emt/speaker_profile.html
+++ b/emt/templates/emt/speaker_profile.html
@@ -18,19 +18,77 @@
     <form method="post" enctype="multipart/form-data">
       {% csrf_token %}
       {{ formset.management_form }}
+      {% if formset.non_form_errors %}
+        <div class="form-errors">
+          <ul>
+            {% for error in formset.non_form_errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
       <div class="section">
         <h3>Speaker Profiles</h3>
         {% for form in formset %}
           <div class="section speaker-form">
             <h4>Speaker {{ forloop.counter }}</h4>
+            {% if form.non_field_errors %}
+              <div class="form-errors">
+                <ul>
+                  {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.full_name.label_tag }} {{ form.full_name.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.full_name.errors %}
+              <div class="field-errors">
+                {% for error in form.full_name.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.designation.label_tag }} {{ form.designation.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.designation.errors %}
+              <div class="field-errors">
+                {% for error in form.designation.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.affiliation.label_tag }} {{ form.affiliation.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.affiliation.errors %}
+              <div class="field-errors">
+                {% for error in form.affiliation.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.contact_email.label_tag }} {{ form.contact_email.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.contact_email.errors %}
+              <div class="field-errors">
+                {% for error in form.contact_email.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.contact_number.label_tag }} {{ form.contact_number.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.contact_number.errors %}
+              <div class="field-errors">
+                {% for error in form.contact_number.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.linkedin_url.label_tag }} {{ form.linkedin_url.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.linkedin_url.errors %}
+              <div class="field-errors">
+                {% for error in form.linkedin_url.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.photo.label_tag }} {{ form.photo.as_widget(attrs={'class': 'proposal-input'}) }}<img class="linkedin-photo" style="max-width:100px; display:none;"/></div>
+            {% if form.photo.errors %}
+              <div class="field-errors">
+                {% for error in form.photo.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             <div class="input-group">{{ form.detailed_profile.label_tag }} {{ form.detailed_profile.as_widget(attrs={'class': 'proposal-input'}) }}</div>
+            {% if form.detailed_profile.errors %}
+              <div class="field-errors">
+                {% for error in form.detailed_profile.errors %}<div>{{ error }}</div>{% endfor %}
+              </div>
+            {% endif %}
             {% if form.DELETE %}
               <div class="input-group">{{ form.DELETE.as_widget(attrs={'class': 'proposal-input'}) }} Remove this speaker</div>
             {% endif %}


### PR DESCRIPTION
## Summary
- allow speaker name fields to accept broader autofill punctuation and trim whitespace when saving
- sanitize expense and income values through shared normalizers so currency symbols and separators persist correctly
- cover the autofill workflow with a regression test that exercises speaker, expense, and income review output

## Testing
- `python manage.py test emt.tests.test_proposal_review` *(fails: database host unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4dc3ff554832c9a44cb2a5ed6c127