### PR TITLE
Fix autosave for autofilled proposal text sections

### DIFF
--- a/emt/static/emt/js/proposal_dashboard.js
+++ b/emt/static/emt/js/proposal_dashboard.js
@@ -3375,7 +3375,17 @@ function getWhyThisEventForm() {
                     djangoField = $(`[name="${baseName}"]`);
                 }
                 if (djangoField.length) {
-                    djangoField.val($(this).val());
+                    const newVal = $(this).val();
+                    djangoField.each(function() {
+                        const $field = $(this);
+                        const currentVal = $field.val();
+                        if (currentVal !== newVal) {
+                            $field.val(newVal);
+                        }
+                        // Trigger events so autosave listeners pick up the change.
+                        $field.trigger('input');
+                        $field.trigger('change');
+                    });
                 }
             }
             clearFieldError($(this));


### PR DESCRIPTION
## Summary
- trigger input/change events on the hidden Django fields when their modern counterparts change
- ensure autosave listeners run even when sections are populated via autofill so text content is persisted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e6df1e18832c84f1c464ff193749