### PR TITLE
Add live proposal sync endpoint and client polling

### DIFF
--- a/emt/static/emt/js/proposal_live_sync.js
+++ b/emt/static/emt/js/proposal_live_sync.js
@@ -1,0 +1,252 @@
+(function(window, document) {
+    const proposalId = window.PROPOSAL_ID;
+    const liveStateUrl = window.PROPOSAL_LIVE_STATE_URL;
+    if (!proposalId || !liveStateUrl) {
+        return;
+    }
+
+    const POLL_INTERVAL = 4000;
+    let lastTimestamp = window.PROPOSAL_LAST_UPDATED || null;
+    let isPolling = false;
+    let timerId = null;
+
+    const ACTIVE_TAGS = new Set(["INPUT", "TEXTAREA"]);
+
+    function modernSelector(name) {
+        return `#${name.replace(/_/g, '-')}-modern`;
+    }
+
+    function arraysEqual(a, b) {
+        if (a.length !== b.length) return false;
+        const sortedA = a.slice().sort();
+        const sortedB = b.slice().sort();
+        for (let i = 0; i < sortedA.length; i += 1) {
+            if (sortedA[i] !== sortedB[i]) return false;
+        }
+        return true;
+    }
+
+    function normalizeToArray(value) {
+        if (value === null || value === undefined) return [];
+        if (Array.isArray(value)) {
+            return value.map(v => (v === null || v === undefined) ? '' : String(v));
+        }
+        const str = String(value);
+        return str ? [str] : [];
+    }
+
+    function setElementValue(el, value, options = {}) {
+        if (!el) return false;
+        const { skipActiveCheck = false } = options;
+        if (!skipActiveCheck && document.activeElement === el && ACTIVE_TAGS.has(el.tagName)) {
+            return false;
+        }
+
+        if (el.tomselect) {
+            const desired = normalizeToArray(value);
+            let current = el.tomselect.getValue();
+            if (!Array.isArray(current)) {
+                current = current ? [String(current)] : [];
+            } else {
+                current = current.map(String);
+            }
+            if (arraysEqual(current, desired)) {
+                return false;
+            }
+            desired.forEach(val => {
+                if (!el.tomselect.options[val]) {
+                    el.tomselect.addOption({ id: val, value: val, text: val });
+                }
+            });
+            if (el.tomselect.settings.maxItems === 1) {
+                el.tomselect.setValue(desired[0] || '', true);
+            } else {
+                el.tomselect.setValue(desired, true);
+            }
+            return true;
+        }
+
+        if (el.type === 'checkbox') {
+            const boolValue = Boolean(value);
+            if (el.checked === boolValue) {
+                return false;
+            }
+            el.checked = boolValue;
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+            return true;
+        }
+
+        if (el.multiple) {
+            const desired = normalizeToArray(value);
+            const current = Array.from(el.selectedOptions || []).map(opt => opt.value);
+            if (arraysEqual(current, desired)) {
+                return false;
+            }
+            Array.from(el.options || []).forEach(opt => {
+                opt.selected = desired.includes(opt.value);
+            });
+            el.dispatchEvent(new Event('change', { bubbles: true }));
+            return true;
+        }
+
+        const strValue = value === null || value === undefined ? '' : String(value);
+        if ((el.value ?? '') === strValue) {
+            return false;
+        }
+        el.value = strValue;
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        return true;
+    }
+
+    function updateField(name, value) {
+        const modern = document.querySelector(modernSelector(name));
+        if (modern) {
+            setElementValue(modern, value);
+        }
+        const hiddenSelector = `#django-forms [name="${name}"]`;
+        document.querySelectorAll(hiddenSelector).forEach(field => {
+            setElementValue(field, value, { skipActiveCheck: true });
+        });
+        const basicSelector = `#django-basic-info [name="${name}"]`;
+        document.querySelectorAll(basicSelector).forEach(field => {
+            setElementValue(field, value, { skipActiveCheck: true });
+        });
+    }
+
+    function updateRichField(field, text) {
+        const normalized = text === null || text === undefined ? '' : String(text);
+        const fieldId = `id_${field}`;
+
+        if (window.CKEDITOR && CKEDITOR.instances[fieldId]) {
+            if (CKEDITOR.instances[fieldId].getData() !== normalized) {
+                CKEDITOR.instances[fieldId].setData(normalized);
+            }
+            return;
+        }
+        if (window.ClassicEditor && window._editors && window._editors[field]) {
+            const editor = window._editors[field];
+            if (editor.getData && editor.getData() !== normalized) {
+                editor.setData(normalized);
+            }
+            return;
+        }
+        if (window.tinymce && tinymce.get(fieldId)) {
+            if (tinymce.get(fieldId).getContent({ format: 'raw' }) !== normalized) {
+                tinymce.get(fieldId).setContent(normalized);
+            }
+            return;
+        }
+        if (window.Quill && window._quills && window._quills[field]) {
+            const quill = window._quills[field];
+            const current = quill.getText().trim();
+            if (current !== normalized.trim()) {
+                quill.setText('');
+                quill.clipboard.dangerouslyPasteHTML(0, normalized);
+            }
+            return;
+        }
+
+        const el = document.getElementById(fieldId);
+        if (el) {
+            setElementValue(el, normalized, { skipActiveCheck: true });
+        }
+    }
+
+    function updateTextSection(name, value) {
+        const normalized = value === null || value === undefined ? '' : String(value);
+        const modern = document.querySelector(modernSelector(name));
+        if (modern) {
+            setElementValue(modern, normalized);
+        }
+        updateRichField(name, normalized);
+        if (name === 'flow') {
+            const flowTextarea = document.querySelector('textarea[name="flow"]');
+            if (flowTextarea) {
+                setElementValue(flowTextarea, normalized, { skipActiveCheck: true });
+            }
+        }
+    }
+
+    function applyPayload(payload) {
+        if (!payload || typeof payload !== 'object') {
+            return;
+        }
+        if (payload.fields && typeof payload.fields === 'object') {
+            Object.entries(payload.fields).forEach(([name, value]) => {
+                updateField(name, value);
+            });
+        }
+        if (payload.text_sections && typeof payload.text_sections === 'object') {
+            Object.entries(payload.text_sections).forEach(([name, value]) => {
+                updateTextSection(name, value);
+            });
+        }
+    }
+
+    async function poll() {
+        if (isPolling || document.hidden) {
+            return;
+        }
+        isPolling = true;
+        try {
+            const params = new URLSearchParams();
+            if (lastTimestamp) {
+                params.set('since', lastTimestamp);
+            }
+            const url = params.toString()
+                ? `${liveStateUrl}?${params.toString()}`
+                : liveStateUrl;
+            const response = await fetch(url, {
+                credentials: 'same-origin',
+                headers: { Accept: 'application/json' },
+            });
+            if (!response.ok) {
+                throw new Error(`Live sync request failed (${response.status})`);
+            }
+            const data = await response.json();
+            if (data && typeof data === 'object') {
+                if (data.updated_at) {
+                    lastTimestamp = data.updated_at;
+                }
+                if (data.changed && data.payload) {
+                    applyPayload(data.payload);
+                }
+            }
+        } catch (err) {
+            console.warn('Proposal live sync failed:', err);
+        } finally {
+            isPolling = false;
+        }
+    }
+
+    function startPolling() {
+        if (timerId) {
+            clearInterval(timerId);
+        }
+        timerId = setInterval(poll, POLL_INTERVAL);
+        poll();
+    }
+
+    function stopPolling() {
+        if (!timerId) return;
+        clearInterval(timerId);
+        timerId = null;
+    }
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            stopPolling();
+        } else {
+            startPolling();
+        }
+    });
+
+    document.addEventListener('autosave:success', () => {
+        if (!timerId) {
+            startPolling();
+        }
+    });
+
+    startPolling();
+})(window, document);

--- a/emt/templates/emt/submit_proposal.html
+++ b/emt/templates/emt/submit_proposal.html
@@ -385,6 +385,8 @@
         window.AUTOSAVE_CSRF = "{{ csrf_token }}";
         window.RESET_DRAFT_URL = "{% url 'emt:reset_proposal_draft' %}";
         window.RESET_DRAFT_REDIRECT_URL = "{% url 'emt:submit_proposal' %}";
+        window.PROPOSAL_LIVE_STATE_URL = {% if proposal %}"{% url 'emt:proposal_live_state' proposal.id %}"{% else %}""{% endif %};
+        window.PROPOSAL_LAST_UPDATED = {% if proposal and proposal.updated_at %}"{{ proposal.updated_at|date:'c' }}"{% else %}""{% endif %};
         window.API_ORGANIZATIONS = "{% url 'emt:api_organizations' %}";
         window.API_FACULTY = "{% url 'emt:api_faculty' %}";
         window.API_CLASSES_BASE = "{% url 'emt:api_classes' 0 %}".split('0/')[0];
@@ -401,4 +403,5 @@
     </script>
     <script src="{% static 'emt/js/autosave_draft.js' %}"></script>
     <script src="{% static 'emt/js/proposal_dashboard.js' %}"></script>
+    <script src="{% static 'emt/js/proposal_live_sync.js' %}"></script>
 {% endblock %}

--- a/emt/tests/test_proposal_live_state.py
+++ b/emt/tests/test_proposal_live_state.py
@@ -1,0 +1,127 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import Organization, OrganizationType, SDGGoal
+from emt.models import (
+    EventActivity,
+    EventExpectedOutcomes,
+    EventNeedAnalysis,
+    EventObjectives,
+    EventProposal,
+    ExpenseDetail,
+    IncomeDetail,
+    SpeakerProfile,
+    TentativeFlow,
+)
+
+
+class ProposalLiveStateTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="sync", password="pass1234")
+        self.client.login(username="sync", password="pass1234")
+        self.org_type = OrganizationType.objects.create(name="Department", is_active=True)
+        self.organization = Organization.objects.create(
+            name="Computer Science",
+            org_type=self.org_type,
+        )
+        self.proposal = EventProposal.objects.create(
+            submitted_by=self.user,
+            organization=self.organization,
+            event_title="Live Sync Showcase",
+            event_start_date=timezone.now().date(),
+            event_end_date=timezone.now().date(),
+            venue="Innovation Hall",
+            academic_year="2024-2025",
+            target_audience="Students",
+            event_focus_type="Seminar",
+            num_activities=1,
+            pos_pso="PO1",
+            student_coordinators="Coordinator A",
+            committees_collaborations="Robotics Club",
+        )
+        EventNeedAnalysis.objects.create(proposal=self.proposal, content="Need content")
+        EventObjectives.objects.create(proposal=self.proposal, content="Objectives content")
+        EventExpectedOutcomes.objects.create(
+            proposal=self.proposal,
+            content="Outcomes content",
+        )
+        TentativeFlow.objects.create(proposal=self.proposal, content="2024-05-01T10:00:00||Kickoff")
+        EventActivity.objects.create(
+            proposal=self.proposal,
+            name="Introduction",
+            date=timezone.now().date(),
+        )
+        SpeakerProfile.objects.create(
+            proposal=self.proposal,
+            full_name="Dr. Jane Speaker",
+            designation="Professor",
+            affiliation="Computer Science",
+            contact_email="speaker@example.com",
+            contact_number="1234567890",
+            detailed_profile="Keynote speaker",
+        )
+        ExpenseDetail.objects.create(
+            proposal=self.proposal,
+            sl_no=1,
+            particulars="Logistics",
+            amount=2500,
+        )
+        IncomeDetail.objects.create(
+            proposal=self.proposal,
+            sl_no=1,
+            particulars="Registration",
+            participants=50,
+            rate=100,
+            amount=5000,
+        )
+        sdg = SDGGoal.objects.create(name="Quality Education")
+        self.proposal.sdg_goals.add(sdg)
+
+        self.url = reverse("emt:proposal_live_state", args=[self.proposal.id])
+
+    def test_live_state_returns_serialized_payload(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data.get("changed"))
+        self.assertIsNotNone(data.get("updated_at"))
+
+        payload = data.get("payload", {})
+        self.assertEqual(payload.get("fields", {}).get("event_title"), "Live Sync Showcase")
+        self.assertEqual(payload.get("fields", {}).get("organization"), str(self.organization.id))
+        self.assertEqual(payload.get("text_sections", {}).get("need_analysis"), "Need content")
+
+        activities = payload.get("activities", [])
+        self.assertEqual(len(activities), 1)
+        self.assertEqual(activities[0].get("name"), "Introduction")
+        self.assertTrue(activities[0].get("date"))
+
+        speakers = payload.get("speakers", [])
+        self.assertEqual(len(speakers), 1)
+        self.assertEqual(speakers[0].get("full_name"), "Dr. Jane Speaker")
+
+        expenses = payload.get("expenses", [])
+        self.assertEqual(len(expenses), 1)
+        self.assertEqual(expenses[0].get("amount"), 2500.0)
+
+        income = payload.get("income", [])
+        self.assertEqual(len(income), 1)
+        self.assertEqual(income[0].get("amount"), 5000.0)
+
+    def test_since_parameter_avoids_duplicate_payload(self):
+        future = (timezone.now() + timedelta(minutes=5)).isoformat()
+        response = self.client.get(self.url, {"since": future})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertFalse(data.get("changed"))
+
+    def test_live_state_enforces_owner(self):
+        other = User.objects.create_user(username="other", password="pass1234")
+        self.client.logout()
+        self.client.login(username="other", password="pass1234")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 404)

--- a/emt/urls.py
+++ b/emt/urls.py
@@ -56,6 +56,11 @@ urlpatterns = [
     path("review/<int:proposal_id>/", views.review_proposal, name="review_proposal"),
     path("autosave-proposal/", views.autosave_proposal, name="autosave_proposal"),
     path(
+        "proposal-live-state/<int:proposal_id>/",
+        views.proposal_live_state,
+        name="proposal_live_state",
+    ),
+    path(
         "reset-proposal-draft/", views.reset_proposal_draft, name="reset_proposal_draft"
     ),
     path(


### PR DESCRIPTION
## Summary
- add a proposal_live_state endpoint to expose the latest draft data for collaborative editing
- inject real-time polling on the submit proposal page so secondary sessions reflect remote edits
- cover the live sync API with unit tests and introduce a dedicated front-end script

## Testing
- `python manage.py test emt.tests.test_proposal_live_state` *(fails: cannot reach external PostgreSQL service in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e5dd62c698832cb2997a5760909be3