### PR TITLE
Fix template syntax error in proposal navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -181,7 +181,7 @@
               <i class="fas fa-edit"></i>
               <span>Event Proposal</span>
             </div>
-            <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if request.resolver_match.url_name in ('start_proposal', 'submit_proposal', 'submit_proposal_with_pk') %}active{% endif %}">
+            <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if request.resolver_match.url_name in ['start_proposal', 'submit_proposal', 'submit_proposal_with_pk'] %}active{% endif %}">
               <i class="fas fa-plus-circle"></i> Create New Proposal
             </a>
             <a href="{% url 'emt:proposal_drafts' %}" class="nav-sublink {% if request.resolver_match.url_name == 'proposal_drafts' %}active{% endif %}">


### PR DESCRIPTION
## Summary
- replace the tuple literal in the proposal navigation link with a list literal so Django can parse the `in` check

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5e8fdef44832cb2d44a205515547b