### PR TITLE
Fix proposal nav link template condition

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -181,7 +181,7 @@
               <i class="fas fa-edit"></i>
               <span>Event Proposal</span>
             </div>
-            <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if request.resolver_match.url_name in ['start_proposal', 'submit_proposal', 'submit_proposal_with_pk'] %}active{% endif %}">
+            <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if request.resolver_match.url_name == 'start_proposal' or request.resolver_match.url_name == 'submit_proposal' or request.resolver_match.url_name == 'submit_proposal_with_pk' %}active{% endif %}">
               <i class="fas fa-plus-circle"></i> Create New Proposal
             </a>
             <a href="{% url 'emt:proposal_drafts' %}" class="nav-sublink {% if request.resolver_match.url_name == 'proposal_drafts' %}active{% endif %}">


### PR DESCRIPTION
## Summary
- replace the invalid list literal in the Event Proposal navigation link condition
- ensure the proposal navigation link still highlights for all proposal-related views

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68e5eb52da3c832c8a0eb819f3bc46e9