### PR TITLE
Refine event proposal navigation grouping

### DIFF
--- a/static/core/css/base.css
+++ b/static/core/css/base.css
@@ -303,12 +303,35 @@ body.command-center-layout{
 }
 .nav-sublink:hover{ background:#fff; color:var(--christ-blue); padding-left:2.25rem; }
 .nav-subgroup{ padding:.35rem 0 .5rem; }
-.nav-sublabel{
-  display:flex; align-items:center; gap:.65rem;
-  padding:.65rem 2rem .35rem;
+.nav-subgroup .nav-sublabel{
+  display:flex; align-items:center; gap:.75rem;
+  width:100%;
+  background:none;
+  border:0;
+  padding:.6rem 1.5rem .45rem 2rem;
   color:#6b7280; font-size:var(--fs-12); font-weight:700;
   text-transform:uppercase; letter-spacing:0.05em;
+  cursor:pointer;
+  text-align:left;
 }
+.nav-subgroup .nav-sublabel:hover,
+.nav-subgroup .nav-sublabel:focus-visible{
+  background:var(--gray-100);
+  outline:none;
+}
+.nav-subgroup .subgroup-expand-icon{
+  margin-left:auto;
+  font-size:.8em;
+  transition:transform .25s;
+}
+.nav-subgroup .nav-subgroup-links{
+  display:none;
+  flex-direction:column;
+  padding-top:.1rem;
+}
+.nav-subgroup.open .nav-subgroup-links{ display:flex; }
+.nav-subgroup.open .nav-sublabel{ background:var(--gray-075); }
+.nav-subgroup.open .subgroup-expand-icon{ transform:rotate(90deg); }
 .nav-subgroup .nav-sublink{ padding-left:2.5rem; }
 .nav-subgroup .nav-sublink i{ width:1.25rem; text-align:center; }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -176,18 +176,23 @@
         </div>
         <div class="nav-submenu {% if 'suite' in request.resolver_match.url_name or '/suite/' in request.path or request.resolver_match.namespace == 'emt' %}open{% endif %}">
           {% if unrestricted_nav or 'submit_proposal' in allowed_nav_items or 'events:submit_proposal' in allowed_nav_items %}
-          <div class="nav-subgroup">
-            <div class="nav-sublabel">
+          {% with request.resolver_match.url_name as current_url %}
+          <div class="nav-subgroup {% if current_url in ('start_proposal', 'submit_proposal', 'submit_proposal_with_pk', 'proposal_drafts') %}open{% endif %}">
+            <button type="button" class="nav-sublabel" aria-expanded="{% if current_url in ('start_proposal', 'submit_proposal', 'submit_proposal_with_pk', 'proposal_drafts') %}true{% else %}false{% endif %}">
               <i class="fas fa-edit"></i>
               <span>Event Proposal</span>
+              <i class="fas fa-chevron-right subgroup-expand-icon"></i>
+            </button>
+            <div class="nav-subgroup-links">
+              <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if current_url == 'start_proposal' or current_url == 'submit_proposal' or current_url == 'submit_proposal_with_pk' %}active{% endif %}">
+                <i class="fas fa-plus-circle"></i> Create New Proposal
+              </a>
+              <a href="{% url 'emt:proposal_drafts' %}" class="nav-sublink {% if current_url == 'proposal_drafts' %}active{% endif %}">
+                <i class="fas fa-file-alt"></i> Drafts
+              </a>
             </div>
-            <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if request.resolver_match.url_name == 'start_proposal' or request.resolver_match.url_name == 'submit_proposal' or request.resolver_match.url_name == 'submit_proposal_with_pk' %}active{% endif %}">
-              <i class="fas fa-plus-circle"></i> Create New Proposal
-            </a>
-            <a href="{% url 'emt:proposal_drafts' %}" class="nav-sublink {% if request.resolver_match.url_name == 'proposal_drafts' %}active{% endif %}">
-              <i class="fas fa-file-alt"></i> Drafts
-            </a>
           </div>
+          {% endwith %}
           {% endif %}
 
           {% if unrestricted_nav or 'pending_reports' in allowed_nav_items or 'events:pending_reports' in allowed_nav_items %}
@@ -443,6 +448,18 @@
             if (submenu) submenu.classList.add('open');
             if (icon) icon.classList.add('rotated');
           }
+        });
+      });
+
+      const navSubgroups = document.querySelectorAll('.nav-subgroup');
+      navSubgroups.forEach(group => {
+        const toggle = group.querySelector('.nav-sublabel');
+        const links = group.querySelector('.nav-subgroup-links');
+        if (!toggle || !links) return;
+
+        toggle.addEventListener('click', function(){
+          const isOpen = group.classList.toggle('open');
+          this.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         });
       });
 


### PR DESCRIPTION
## Summary
- convert the Event Proposal links in the sidebar into a collapsible subgroup
- update sidebar styling so subgroup labels behave like accessible toggle buttons
- add JavaScript to control expanding and collapsing of subgroup links

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: database connection to the configured Railway instance is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ed531620832cb0336ad34145d9c8