### PR TITLE
Fix template syntax error in proposal navigation

### DIFF
--- a/core/templatetags/nav_tags.py
+++ b/core/templatetags/nav_tags.py
@@ -1,0 +1,35 @@
+"""Navigation-related template helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+from django import template
+
+register = template.Library()
+
+
+def _flatten_names(names: Iterable[str]) -> List[str]:
+    tokens: List[str] = []
+    for name in names:
+        if isinstance(name, (list, tuple, set)):
+            tokens.extend(_flatten_names(name))
+        elif name:
+            tokens.extend(
+                token
+                for token in re.split(r"[\s,]+", str(name).strip())
+                if token
+            )
+    return tokens
+
+
+@register.simple_tag
+def url_in(current_url: str | None, *names) -> bool:
+    """Return True if ``current_url`` matches any of the provided names."""
+
+    if not current_url:
+        return False
+
+    candidates = _flatten_names(names)
+    return str(current_url) in candidates

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load static group_filters admin_tags %}
+{% load static group_filters admin_tags nav_tags %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -177,14 +177,16 @@
         <div class="nav-submenu {% if 'suite' in request.resolver_match.url_name or '/suite/' in request.path or request.resolver_match.namespace == 'emt' %}open{% endif %}">
           {% if unrestricted_nav or 'submit_proposal' in allowed_nav_items or 'events:submit_proposal' in allowed_nav_items %}
           {% with request.resolver_match.url_name as current_url %}
-          <div class="nav-subgroup {% if current_url in ('start_proposal', 'submit_proposal', 'submit_proposal_with_pk', 'proposal_drafts') %}open{% endif %}">
-            <button type="button" class="nav-sublabel" aria-expanded="{% if current_url in ('start_proposal', 'submit_proposal', 'submit_proposal_with_pk', 'proposal_drafts') %}true{% else %}false{% endif %}">
+          {% url_in current_url "start_proposal submit_proposal submit_proposal_with_pk proposal_drafts" as proposal_flow_open %}
+          <div class="nav-subgroup {% if proposal_flow_open %}open{% endif %}">
+            <button type="button" class="nav-sublabel" aria-expanded="{% if proposal_flow_open %}true{% else %}false{% endif %}">
               <i class="fas fa-edit"></i>
               <span>Event Proposal</span>
               <i class="fas fa-chevron-right subgroup-expand-icon"></i>
             </button>
             <div class="nav-subgroup-links">
-              <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if current_url == 'start_proposal' or current_url == 'submit_proposal' or current_url == 'submit_proposal_with_pk' %}active{% endif %}">
+              {% url_in current_url "start_proposal submit_proposal submit_proposal_with_pk" as create_proposal_active %}
+              <a href="{% url 'emt:start_proposal' %}" class="nav-sublink {% if create_proposal_active %}active{% endif %}">
                 <i class="fas fa-plus-circle"></i> Create New Proposal
               </a>
               <a href="{% url 'emt:proposal_drafts' %}" class="nav-sublink {% if current_url == 'proposal_drafts' %}active{% endif %}">


### PR DESCRIPTION
## Summary
- add a reusable `url_in` template tag to safely check URL membership in templates
- update the proposal navigation block to use the helper and avoid invalid syntax when rendering drafts

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e5eebb2be8832c9689c7f9c3858b30