### PR TITLE
Revamp proposal drafts page styling

### DIFF
--- a/emt/static/emt/css/proposal_drafts.css
+++ b/emt/static/emt/css/proposal_drafts.css
@@ -1,115 +1,234 @@
 .drafts-container {
-    max-width: 1100px;
+    max-width: 1200px;
     margin: 0 auto;
-    padding: 2.5rem 2rem 3rem;
+    padding: 2.5rem 2rem 3.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
 }
 
-.drafts-header {
+.drafts-hero {
     display: flex;
     flex-wrap: wrap;
-    align-items: flex-start;
+    gap: 2.5rem;
+    align-items: stretch;
     justify-content: space-between;
-    gap: 1.25rem;
-    margin-bottom: 2rem;
+    padding: 2.5rem;
+    background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.12), transparent 50%),
+        linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 116, 144, 0.08));
+    border-radius: 28px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: 0 25px 45px -30px rgba(15, 23, 42, 0.4);
 }
 
-.drafts-heading h1 {
-    font-size: 2rem;
-    font-weight: 700;
-    color: #1f2937;
-    margin-bottom: 0.5rem;
+.drafts-hero-content {
+    flex: 1 1 320px;
+    color: #0f172a;
 }
 
-.drafts-heading p {
-    margin: 0.35rem 0;
-    color: #4b5563;
-    max-width: 38rem;
-    line-height: 1.6;
-}
-
-.drafts-availability {
-    font-weight: 600;
-    color: #1d4ed8;
-}
-
-.create-draft-btn {
+.hero-tag {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.75rem 1.5rem;
+    padding: 0.4rem 0.9rem;
+    background: rgba(59, 130, 246, 0.15);
+    color: #1d4ed8;
     border-radius: 999px;
     font-weight: 600;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.drafts-hero h1 {
+    margin: 1.1rem 0 0.75rem;
+    font-size: clamp(2rem, 2.4vw + 1rem, 2.65rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.drafts-hero p {
+    margin: 0;
+    color: #334155;
+    font-size: 1rem;
+    line-height: 1.75;
+    max-width: 40rem;
+}
+
+.drafts-availability {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+    padding: 0.75rem 1.1rem;
+    border-radius: 16px;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+    font-weight: 600;
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.14);
+}
+
+.drafts-hero-aside {
+    flex: 1 1 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    justify-content: space-between;
+}
+
+.create-draft-btn {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.9rem 1.75rem;
+    border-radius: 999px;
+    font-size: 1rem;
+    font-weight: 600;
+    box-shadow: 0 18px 30px -18px rgba(37, 99, 235, 0.6);
 }
 
 .create-draft-btn.disabled,
 .create-draft-btn[aria-disabled="true"] {
     pointer-events: none;
     opacity: 0.6;
+    box-shadow: none;
+}
+
+.hero-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+}
+
+.metric-card {
+    background: rgba(255, 255, 255, 0.65);
+    border-radius: 20px;
+    padding: 1rem 1.25rem;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 16px 32px -28px rgba(15, 23, 42, 0.45);
+}
+
+.metric-label {
+    display: block;
+    color: #64748b;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.35rem;
+}
+
+.metric-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: #0f172a;
 }
 
 .draft-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
+    display: grid;
+    gap: 1.5rem;
 }
 
 .draft-card {
     background: #ffffff;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    border-radius: 18px;
-    padding: 1.75rem;
-    box-shadow: 0 15px 30px -20px rgba(15, 23, 42, 0.2);
+    border-radius: 24px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    padding: 2rem;
+    box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1.75rem;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.draft-card-title {
+.draft-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(59, 130, 246, 0.35);
+    box-shadow: 0 35px 70px -45px rgba(37, 99, 235, 0.4);
+}
+
+.draft-card-header {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
-    align-items: center;
+    gap: 1rem;
     justify-content: space-between;
+    align-items: flex-start;
 }
 
 .draft-card-title h2 {
     margin: 0;
-    font-size: 1.35rem;
+    font-size: 1.5rem;
     font-weight: 700;
-    color: #111827;
+    color: #0f172a;
+}
+
+.draft-card-subtitle {
+    margin: 0.35rem 0 0;
+    color: #64748b;
+    font-size: 0.95rem;
 }
 
 .draft-status {
-    background: rgba(37, 99, 235, 0.1);
-    color: #1d4ed8;
-    font-size: 0.75rem;
-    font-weight: 700;
-    padding: 0.25rem 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 1rem;
     border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-}
-
-.draft-meta {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 1.25rem;
-    margin: 0;
-}
-
-.draft-meta dt {
-    font-size: 0.75rem;
     letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: #6b7280;
-    margin-bottom: 0.35rem;
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
 }
 
-.draft-meta dd {
-    margin: 0;
-    font-size: 0.95rem;
+.draft-status::before {
+    content: "";
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.draft-card-body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+}
+
+.draft-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1rem 1.2rem;
+    background: rgba(248, 250, 252, 0.9);
+    border-radius: 18px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.detail-label {
+    color: #64748b;
     font-weight: 600;
-    color: #1f2937;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.detail-value {
+    color: #0f172a;
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+
+.draft-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .draft-card-actions {
@@ -121,32 +240,37 @@
 .draft-card-actions .btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
-    border-radius: 999px;
-    padding: 0.65rem 1.4rem;
+    gap: 0.55rem;
+    border-radius: 14px;
+    padding: 0.75rem 1.5rem;
     font-weight: 600;
+    border: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.draft-card-actions .btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 20px -16px rgba(15, 23, 42, 0.6);
 }
 
 .btn-secondary {
-    background: rgba(37, 99, 235, 0.08);
-    border: 1px solid rgba(37, 99, 235, 0.2);
+    background: rgba(59, 130, 246, 0.12);
     color: #1d4ed8;
+    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.18);
 }
 
 .btn-secondary:hover {
-    background: rgba(37, 99, 235, 0.15);
-    border-color: rgba(37, 99, 235, 0.35);
+    background: rgba(59, 130, 246, 0.18);
 }
 
 .btn-danger {
-    background: rgba(220, 38, 38, 0.08);
-    border: 1px solid rgba(220, 38, 38, 0.2);
-    color: #dc2626;
+    background: rgba(248, 113, 113, 0.12);
+    color: #b91c1c;
+    box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.2);
 }
 
 .btn-danger:hover {
-    background: rgba(220, 38, 38, 0.15);
-    border-color: rgba(220, 38, 38, 0.35);
+    background: rgba(248, 113, 113, 0.18);
 }
 
 .draft-delete-form {
@@ -154,57 +278,93 @@
 }
 
 .draft-empty {
-    margin: 4rem auto;
-    max-width: 28rem;
+    margin: 4.5rem auto 3rem;
+    max-width: 32rem;
     text-align: center;
-    background: #ffffff;
-    padding: 3rem 2.5rem;
-    border-radius: 20px;
+    background: linear-gradient(165deg, rgba(255, 255, 255, 0.9), rgba(241, 245, 249, 0.9));
+    padding: 3.5rem 3rem;
+    border-radius: 28px;
     border: 1px solid rgba(148, 163, 184, 0.25);
-    box-shadow: 0 18px 32px -22px rgba(15, 23, 42, 0.25);
-}
-
-.draft-empty h2 {
-    margin-top: 1.5rem;
-    font-size: 1.5rem;
-    color: #1f2937;
-}
-
-.draft-empty p {
-    color: #6b7280;
-    margin: 0.75rem 0 1.75rem;
-    line-height: 1.6;
+    box-shadow: 0 32px 60px -40px rgba(15, 23, 42, 0.45);
 }
 
 .empty-icon {
-    width: 4rem;
-    height: 4rem;
-    border-radius: 999px;
+    width: 4.5rem;
+    height: 4.5rem;
+    border-radius: 20px;
     margin: 0 auto;
-    background: rgba(37, 99, 235, 0.1);
+    background: rgba(59, 130, 246, 0.12);
     color: #1d4ed8;
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 1.9rem;
+}
+
+.draft-empty h2 {
+    margin-top: 1.75rem;
     font-size: 1.75rem;
+    color: #0f172a;
+}
+
+.draft-empty p {
+    color: #475569;
+    margin: 1rem 0 2.25rem;
+    line-height: 1.7;
+}
+
+.draft-empty .btn {
+    border-radius: 999px;
+    padding: 0.85rem 1.75rem;
+    font-weight: 600;
+    box-shadow: 0 18px 32px -24px rgba(37, 99, 235, 0.6);
+}
+
+@media (max-width: 1024px) {
+    .drafts-container {
+        padding: 2.25rem 1.5rem 3rem;
+    }
+
+    .drafts-hero {
+        padding: 2rem;
+    }
 }
 
 @media (max-width: 768px) {
     .drafts-container {
-        padding: 2rem 1.25rem 2.5rem;
+        padding: 2rem 1.25rem 2.75rem;
     }
 
     .draft-card {
-        padding: 1.5rem;
+        padding: 1.75rem;
+    }
+
+    .draft-card-footer {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.25rem;
     }
 
     .draft-card-actions {
-        flex-direction: column;
-        align-items: stretch;
+        width: 100%;
     }
 
     .draft-card-actions .btn {
         justify-content: center;
         width: 100%;
+    }
+}
+
+@media (max-width: 540px) {
+    .drafts-hero {
+        padding: 1.75rem;
+    }
+
+    .draft-card {
+        padding: 1.6rem;
+    }
+
+    .hero-metrics {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 }

--- a/emt/templates/emt/proposal_drafts.html
+++ b/emt/templates/emt/proposal_drafts.html
@@ -9,58 +9,84 @@
 
 {% block content %}
 <div class="drafts-container">
-    <div class="drafts-header">
-        <div class="drafts-heading">
+    <section class="drafts-hero">
+        <div class="drafts-hero-content">
+            <span class="hero-tag"><i class="fas fa-lightbulb"></i> Proposal Workspace</span>
             <h1>Event Proposal Drafts</h1>
-            <p>Save up to {{ draft_limit }} drafts at a time. Continue editing a draft or remove it once it's no longer needed.</p>
+            <p>Keep your ideas organized and ready for submission. Save drafts, refine the details, and submit when everything is polished.</p>
             <p class="drafts-availability">
-                {% if remaining_slots %}
-                    {{ remaining_slots }} draft{{ remaining_slots|pluralize }} available before reaching the limit.
-                {% else %}
-                    You have reached the maximum number of active drafts.
-                {% endif %}
+                <i class="fas fa-layer-group"></i>
+                <span>
+                    {% if remaining_slots %}
+                        {{ remaining_slots }} draft{{ remaining_slots|pluralize }} available before reaching the limit.
+                    {% else %}
+                        You have reached the maximum number of active drafts.
+                    {% endif %}
+                </span>
             </p>
         </div>
-        <a href="{% url 'emt:start_proposal' %}" class="btn btn-primary create-draft-btn {% if remaining_slots == 0 %}disabled{% endif %}" {% if remaining_slots == 0 %}aria-disabled="true"{% endif %}>
-            <i class="fas fa-plus"></i> Create New Proposal
-        </a>
-    </div>
+        <div class="drafts-hero-aside">
+            <a href="{% url 'emt:start_proposal' %}" class="btn btn-primary create-draft-btn {% if remaining_slots == 0 %}disabled{% endif %}" {% if remaining_slots == 0 %}aria-disabled="true"{% endif %}>
+                <i class="fas fa-plus"></i>
+                <span>Create New Proposal</span>
+            </a>
+            <div class="hero-metrics">
+                <div class="metric-card">
+                    <span class="metric-label">Active drafts</span>
+                    <span class="metric-value">{{ drafts|length }}</span>
+                </div>
+                <div class="metric-card">
+                    <span class="metric-label">Draft limit</span>
+                    <span class="metric-value">{{ draft_limit }}</span>
+                </div>
+                <div class="metric-card">
+                    <span class="metric-label">Available slots</span>
+                    <span class="metric-value">{{ remaining_slots|default:0 }}</span>
+                </div>
+            </div>
+        </div>
+    </section>
 
     {% if drafts %}
     <div class="draft-list">
         {% for draft in drafts %}
         <article class="draft-card">
-            <div class="draft-card-main">
+            <header class="draft-card-header">
                 <div class="draft-card-title">
                     <h2>{{ draft.event_title|default:"Untitled Event" }}</h2>
-                    <span class="draft-status">{{ draft.get_status_display }}</span>
+                    <p class="draft-card-subtitle">Updated {{ draft.updated_at|date:"M d, Y" }} at {{ draft.updated_at|date:"h:i A" }}</p>
                 </div>
-                <dl class="draft-meta">
-                    <div>
-                        <dt>Organization</dt>
-                        <dd>{{ draft.organization.name|default:"Not selected" }}</dd>
-                    </div>
-                    <div>
-                        <dt>Academic Year</dt>
-                        <dd>{{ draft.academic_year|default:"Not set" }}</dd>
-                    </div>
-                    <div>
-                        <dt>Last Updated</dt>
-                        <dd>{{ draft.updated_at|date:"M d, Y h:i A" }}</dd>
-                    </div>
-                </dl>
+                <span class="draft-status">{{ draft.get_status_display }}</span>
+            </header>
+            <div class="draft-card-body">
+                <div class="draft-detail">
+                    <span class="detail-label"><i class="fas fa-building"></i> Organization</span>
+                    <span class="detail-value">{{ draft.organization.name|default:"Not selected" }}</span>
+                </div>
+                <div class="draft-detail">
+                    <span class="detail-label"><i class="fas fa-calendar-alt"></i> Academic Year</span>
+                    <span class="detail-value">{{ draft.academic_year|default:"Not set" }}</span>
+                </div>
+                <div class="draft-detail">
+                    <span class="detail-label"><i class="fas fa-hashtag"></i> Draft ID</span>
+                    <span class="detail-value">#{{ draft.id }}</span>
+                </div>
             </div>
-            <div class="draft-card-actions">
-                <a href="{% url 'emt:submit_proposal_with_pk' draft.id %}" class="btn btn-secondary">
-                    <i class="fas fa-pen"></i> Continue Editing
-                </a>
-                <form method="post" action="{% url 'emt:delete_proposal_draft' draft.id %}" class="draft-delete-form">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-danger" onclick="return confirm('Remove this draft from your list? Admins will still be able to view it.');">
-                        <i class="fas fa-trash"></i> Remove
-                    </button>
-                </form>
-            </div>
+            <footer class="draft-card-footer">
+                <div class="draft-card-actions">
+                    <a href="{% url 'emt:submit_proposal_with_pk' draft.id %}" class="btn btn-secondary">
+                        <i class="fas fa-pen"></i>
+                        <span>Continue Editing</span>
+                    </a>
+                    <form method="post" action="{% url 'emt:delete_proposal_draft' draft.id %}" class="draft-delete-form">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-danger" onclick="return confirm('Remove this draft from your list? Admins will still be able to view it.');">
+                            <i class="fas fa-trash"></i>
+                            <span>Remove</span>
+                        </button>
+                    </form>
+                </div>
+            </footer>
         </article>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- redesign the proposal drafts hero section with contextual metrics and refreshed copy
- restructure draft cards to highlight status, metadata, and actions with a modern layout
- update empty state and responsive styles for a cohesive visual experience

## Testing
- `python manage.py runserver 0.0.0.0:8000` *(fails: database host yamanote.proxy.rlwy.net unreachable from container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f27003c0832cbe4e055bec0e37db