### PR TITLE
Refine proposal draft workspace interface

### DIFF
--- a/emt/static/emt/css/proposal_drafts.css
+++ b/emt/static/emt/css/proposal_drafts.css
@@ -1,5 +1,5 @@
-.drafts-container {
-    max-width: 1200px;
+.drafts-page {
+    max-width: 1120px;
     margin: 0 auto;
     padding: 2.5rem 2rem 3.5rem;
     display: flex;
@@ -7,364 +7,287 @@
     gap: 2.5rem;
 }
 
-.drafts-hero {
+.drafts-header {
     display: flex;
     flex-wrap: wrap;
-    gap: 2.5rem;
-    align-items: stretch;
     justify-content: space-between;
-    padding: 2.5rem;
-    background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.12), transparent 50%),
-        linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 116, 144, 0.08));
-    border-radius: 28px;
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    box-shadow: 0 25px 45px -30px rgba(15, 23, 42, 0.4);
-}
-
-.drafts-hero-content {
-    flex: 1 1 320px;
-    color: #0f172a;
-}
-
-.hero-tag {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 0.9rem;
-    background: rgba(59, 130, 246, 0.15);
-    color: #1d4ed8;
-    border-radius: 999px;
-    font-weight: 600;
-    font-size: 0.85rem;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-}
-
-.drafts-hero h1 {
-    margin: 1.1rem 0 0.75rem;
-    font-size: clamp(2rem, 2.4vw + 1rem, 2.65rem);
-    font-weight: 700;
-    color: #0f172a;
-}
-
-.drafts-hero p {
-    margin: 0;
-    color: #334155;
-    font-size: 1rem;
-    line-height: 1.75;
-    max-width: 40rem;
-}
-
-.drafts-availability {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-top: 1.5rem;
-    padding: 0.75rem 1.1rem;
-    border-radius: 16px;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-    font-weight: 600;
-    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.14);
-}
-
-.drafts-hero-aside {
-    flex: 1 1 260px;
-    display: flex;
-    flex-direction: column;
-    gap: 1.75rem;
-    justify-content: space-between;
-}
-
-.create-draft-btn {
-    align-self: flex-start;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.65rem;
-    padding: 0.9rem 1.75rem;
-    border-radius: 999px;
-    font-size: 1rem;
-    font-weight: 600;
-    box-shadow: 0 18px 30px -18px rgba(37, 99, 235, 0.6);
-}
-
-.create-draft-btn.disabled,
-.create-draft-btn[aria-disabled="true"] {
-    pointer-events: none;
-    opacity: 0.6;
-    box-shadow: none;
-}
-
-.hero-metrics {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 1rem;
-}
-
-.metric-card {
-    background: rgba(255, 255, 255, 0.65);
-    border-radius: 20px;
-    padding: 1rem 1.25rem;
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    backdrop-filter: blur(6px);
-    box-shadow: 0 16px 32px -28px rgba(15, 23, 42, 0.45);
-}
-
-.metric-label {
-    display: block;
-    color: #64748b;
-    font-size: 0.8rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    margin-bottom: 0.35rem;
-}
-
-.metric-value {
-    font-size: 1.6rem;
-    font-weight: 700;
-    color: #0f172a;
-}
-
-.draft-list {
-    display: grid;
-    gap: 1.5rem;
-}
-
-.draft-card {
+    gap: 2rem;
+    padding: 1.75rem 2rem;
     background: #ffffff;
-    border-radius: 24px;
-    border: 1px solid rgba(148, 163, 184, 0.28);
-    padding: 2rem;
-    box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
+    border: 1px solid #d6dae1;
+    border-radius: 16px;
+    box-shadow: 0 8px 20px -16px rgba(15, 23, 42, 0.35);
+}
+
+.header-content {
+    flex: 1 1 360px;
     display: flex;
     flex-direction: column;
-    gap: 1.75rem;
-    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    gap: 0.75rem;
 }
 
-.draft-card:hover {
-    transform: translateY(-4px);
-    border-color: rgba(59, 130, 246, 0.35);
-    box-shadow: 0 35px 70px -45px rgba(37, 99, 235, 0.4);
+.header-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.2rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #3c4758;
+    background: #eef1f7;
+    border-radius: 999px;
 }
 
-.draft-card-header {
+.drafts-header h1 {
+    margin: 0;
+    font-size: clamp(1.9rem, 1.5vw + 1.2rem, 2.4rem);
+    color: #1a2433;
+}
+
+.header-description {
+    margin: 0;
+    color: #475062;
+    line-height: 1.6;
+    max-width: 46ch;
+}
+
+.header-availability {
+    margin-top: 0.5rem;
+    padding: 0.55rem 0.8rem;
+    border-left: 3px solid #2563eb;
+    background: #f3f4f6;
+    color: #1f2a37;
+    font-weight: 600;
+}
+
+.header-actions {
     display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: space-between;
     align-items: flex-start;
 }
 
-.draft-card-title h2 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #0f172a;
-}
-
-.draft-card-subtitle {
-    margin: 0.35rem 0 0;
-    color: #64748b;
-    font-size: 0.95rem;
-}
-
-.draft-status {
+.new-draft-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.45rem 1rem;
-    border-radius: 999px;
-    font-size: 0.85rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.2);
+    gap: 0.6rem;
+    padding: 0.85rem 1.6rem;
+    border-radius: 10px;
+    font-weight: 600;
+    text-transform: none;
+    box-shadow: none;
 }
 
-.draft-status::before {
-    content: "";
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    background: currentColor;
+.new-draft-btn.disabled,
+.new-draft-btn[aria-disabled="true"] {
+    pointer-events: none;
+    opacity: 0.55;
 }
 
-.draft-card-body {
+.drafts-overview {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
 }
 
-.draft-detail {
+.overview-item {
+    background: #f8f9fb;
+    border: 1px solid #d9dde5;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
-    padding: 1rem 1.2rem;
-    background: rgba(248, 250, 252, 0.9);
-    border-radius: 18px;
-    border: 1px solid rgba(226, 232, 240, 0.9);
+    gap: 0.35rem;
 }
 
-.detail-label {
-    color: #64748b;
-    font-weight: 600;
-    font-size: 0.85rem;
-    letter-spacing: 0.05em;
+.overview-item .label {
+    font-size: 0.8rem;
     text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #5b6576;
+    font-weight: 600;
+}
+
+.overview-item .value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: #1a2433;
+}
+
+.drafts-table-wrapper {
+    background: #ffffff;
+    border: 1px solid #d6dae1;
+    border-radius: 16px;
+    box-shadow: 0 12px 25px -22px rgba(15, 23, 42, 0.35);
+    overflow-x: auto;
+}
+
+.drafts-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+}
+
+.drafts-table thead {
+    background: #f3f4f6;
+    color: #3c4758;
+}
+
+.drafts-table th,
+.drafts-table td {
+    padding: 1rem 1.25rem;
+    text-align: left;
+    border-bottom: 1px solid #e2e6ef;
+    vertical-align: top;
+}
+
+.drafts-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.drafts-table tbody tr:hover {
+    background: #f9fafb;
+}
+
+.draft-title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: #1a2433;
+}
+
+.draft-title .title {
+    font-weight: 600;
+    font-size: 1.05rem;
+}
+
+.draft-title .meta {
+    font-size: 0.85rem;
+    color: #5b6576;
+}
+
+.truncate {
+    max-width: 16rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.status-badge {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-}
-
-.detail-value {
-    color: #0f172a;
-    font-size: 1.05rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 8px;
+    font-size: 0.85rem;
     font-weight: 600;
+    background: #e8f1ff;
+    color: #1e40af;
+    border: 1px solid #bfd4ff;
 }
 
-.draft-card-footer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.draft-card-actions {
+.actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
 }
 
-.draft-card-actions .btn {
+.actions-col {
+    width: 160px;
+}
+
+.table-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
-    border-radius: 14px;
-    padding: 0.75rem 1.5rem;
-    font-weight: 600;
-    border: none;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.draft-card-actions .btn:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 20px -16px rgba(15, 23, 42, 0.6);
-}
-
-.btn-secondary {
-    background: rgba(59, 130, 246, 0.12);
+    gap: 0.45rem;
+    padding: 0.35rem 0.4rem;
     color: #1d4ed8;
-    box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.18);
+    font-weight: 600;
+    text-decoration: none;
 }
 
-.btn-secondary:hover {
-    background: rgba(59, 130, 246, 0.18);
+.table-link:hover {
+    text-decoration: underline;
 }
 
-.btn-danger {
-    background: rgba(248, 113, 113, 0.12);
+.table-link-danger {
     color: #b91c1c;
-    box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.2);
 }
 
-.btn-danger:hover {
-    background: rgba(248, 113, 113, 0.18);
+.inline-form {
+    display: inline;
 }
 
-.draft-delete-form {
-    margin: 0;
+.inline-form button {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
 }
 
 .draft-empty {
-    margin: 4.5rem auto 3rem;
-    max-width: 32rem;
+    margin: 4rem auto 3rem;
+    max-width: 420px;
+    padding: 3rem 2.75rem;
     text-align: center;
-    background: linear-gradient(165deg, rgba(255, 255, 255, 0.9), rgba(241, 245, 249, 0.9));
-    padding: 3.5rem 3rem;
-    border-radius: 28px;
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    box-shadow: 0 32px 60px -40px rgba(15, 23, 42, 0.45);
+    background: #ffffff;
+    border: 1px solid #d9dde5;
+    border-radius: 16px;
+    box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.28);
 }
 
 .empty-icon {
-    width: 4.5rem;
-    height: 4.5rem;
-    border-radius: 20px;
+    width: 4rem;
+    height: 4rem;
     margin: 0 auto;
-    background: rgba(59, 130, 246, 0.12);
-    color: #1d4ed8;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.9rem;
+    border-radius: 14px;
+    background: #e8f1ff;
+    color: #1e40af;
+    display: grid;
+    place-items: center;
+    font-size: 1.6rem;
 }
 
 .draft-empty h2 {
-    margin-top: 1.75rem;
-    font-size: 1.75rem;
-    color: #0f172a;
+    margin-top: 1.5rem;
+    font-size: 1.6rem;
+    color: #1a2433;
 }
 
 .draft-empty p {
-    color: #475569;
-    margin: 1rem 0 2.25rem;
-    line-height: 1.7;
+    margin: 1rem 0 2rem;
+    color: #475062;
 }
 
 .draft-empty .btn {
-    border-radius: 999px;
-    padding: 0.85rem 1.75rem;
-    font-weight: 600;
-    box-shadow: 0 18px 32px -24px rgba(37, 99, 235, 0.6);
-}
-
-@media (max-width: 1024px) {
-    .drafts-container {
-        padding: 2.25rem 1.5rem 3rem;
-    }
-
-    .drafts-hero {
-        padding: 2rem;
-    }
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 10px;
+    padding: 0.75rem 1.6rem;
 }
 
 @media (max-width: 768px) {
-    .drafts-container {
-        padding: 2rem 1.25rem 2.75rem;
+    .drafts-page {
+        padding: 2rem 1.25rem 3rem;
     }
 
-    .draft-card {
-        padding: 1.75rem;
+    .drafts-header {
+        padding: 1.5rem;
     }
 
-    .draft-card-footer {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 1.25rem;
-    }
-
-    .draft-card-actions {
-        width: 100%;
-    }
-
-    .draft-card-actions .btn {
-        justify-content: center;
-        width: 100%;
+    .drafts-table {
+        min-width: 640px;
     }
 }
 
 @media (max-width: 540px) {
-    .drafts-hero {
-        padding: 1.75rem;
+    .header-actions {
+        width: 100%;
     }
 
-    .draft-card {
-        padding: 1.6rem;
-    }
-
-    .hero-metrics {
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    .new-draft-btn {
+        width: 100%;
+        justify-content: center;
     }
 }

--- a/emt/templates/emt/proposal_drafts.html
+++ b/emt/templates/emt/proposal_drafts.html
@@ -8,97 +8,101 @@
 {% endblock %}
 
 {% block content %}
-<div class="drafts-container">
-    <section class="drafts-hero">
-        <div class="drafts-hero-content">
-            <span class="hero-tag"><i class="fas fa-lightbulb"></i> Proposal Workspace</span>
+<div class="drafts-page">
+    <header class="drafts-header">
+        <div class="header-content">
+            <p class="header-tag">Proposal workspace</p>
             <h1>Event Proposal Drafts</h1>
-            <p>Keep your ideas organized and ready for submission. Save drafts, refine the details, and submit when everything is polished.</p>
-            <p class="drafts-availability">
-                <i class="fas fa-layer-group"></i>
-                <span>
-                    {% if remaining_slots %}
-                        {{ remaining_slots }} draft{{ remaining_slots|pluralize }} available before reaching the limit.
-                    {% else %}
-                        You have reached the maximum number of active drafts.
-                    {% endif %}
-                </span>
+            <p class="header-description">
+                Keep proposals in progress organized. Save your work, adjust the details, and submit once everything is ready.
             </p>
-        </div>
-        <div class="drafts-hero-aside">
-            <a href="{% url 'emt:start_proposal' %}" class="btn btn-primary create-draft-btn {% if remaining_slots == 0 %}disabled{% endif %}" {% if remaining_slots == 0 %}aria-disabled="true"{% endif %}>
-                <i class="fas fa-plus"></i>
-                <span>Create New Proposal</span>
-            </a>
-            <div class="hero-metrics">
-                <div class="metric-card">
-                    <span class="metric-label">Active drafts</span>
-                    <span class="metric-value">{{ drafts|length }}</span>
-                </div>
-                <div class="metric-card">
-                    <span class="metric-label">Draft limit</span>
-                    <span class="metric-value">{{ draft_limit }}</span>
-                </div>
-                <div class="metric-card">
-                    <span class="metric-label">Available slots</span>
-                    <span class="metric-value">{{ remaining_slots|default:0 }}</span>
-                </div>
+            <div class="header-availability">
+                {% if remaining_slots %}
+                    <span>{{ remaining_slots }} draft{{ remaining_slots|pluralize }} available before reaching the limit.</span>
+                {% else %}
+                    <span>You have reached the maximum number of active drafts.</span>
+                {% endif %}
             </div>
+        </div>
+        <div class="header-actions">
+            <a href="{% url 'emt:start_proposal' %}" class="btn btn-primary new-draft-btn {% if remaining_slots == 0 %}disabled{% endif %}" {% if remaining_slots == 0 %}aria-disabled="true"{% endif %}>
+                <i class="fas fa-plus"></i>
+                <span>Create new proposal</span>
+            </a>
+        </div>
+    </header>
+
+    <section class="drafts-overview" aria-label="Draft summary">
+        <div class="overview-item">
+            <span class="label">Active drafts</span>
+            <span class="value">{{ drafts|length }}</span>
+        </div>
+        <div class="overview-item">
+            <span class="label">Draft limit</span>
+            <span class="value">{{ draft_limit }}</span>
+        </div>
+        <div class="overview-item">
+            <span class="label">Available slots</span>
+            <span class="value">{{ remaining_slots|default:0 }}</span>
         </div>
     </section>
 
     {% if drafts %}
-    <div class="draft-list">
-        {% for draft in drafts %}
-        <article class="draft-card">
-            <header class="draft-card-header">
-                <div class="draft-card-title">
-                    <h2>{{ draft.event_title|default:"Untitled Event" }}</h2>
-                    <p class="draft-card-subtitle">Updated {{ draft.updated_at|date:"M d, Y" }} at {{ draft.updated_at|date:"h:i A" }}</p>
-                </div>
-                <span class="draft-status">{{ draft.get_status_display }}</span>
-            </header>
-            <div class="draft-card-body">
-                <div class="draft-detail">
-                    <span class="detail-label"><i class="fas fa-building"></i> Organization</span>
-                    <span class="detail-value">{{ draft.organization.name|default:"Not selected" }}</span>
-                </div>
-                <div class="draft-detail">
-                    <span class="detail-label"><i class="fas fa-calendar-alt"></i> Academic Year</span>
-                    <span class="detail-value">{{ draft.academic_year|default:"Not set" }}</span>
-                </div>
-                <div class="draft-detail">
-                    <span class="detail-label"><i class="fas fa-hashtag"></i> Draft ID</span>
-                    <span class="detail-value">#{{ draft.id }}</span>
-                </div>
-            </div>
-            <footer class="draft-card-footer">
-                <div class="draft-card-actions">
-                    <a href="{% url 'emt:submit_proposal_with_pk' draft.id %}" class="btn btn-secondary">
-                        <i class="fas fa-pen"></i>
-                        <span>Continue Editing</span>
-                    </a>
-                    <form method="post" action="{% url 'emt:delete_proposal_draft' draft.id %}" class="draft-delete-form">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-danger" onclick="return confirm('Remove this draft from your list? Admins will still be able to view it.');">
-                            <i class="fas fa-trash"></i>
-                            <span>Remove</span>
-                        </button>
-                    </form>
-                </div>
-            </footer>
-        </article>
-        {% endfor %}
+    <div class="drafts-table-wrapper">
+        <table class="drafts-table">
+            <thead>
+                <tr>
+                    <th scope="col">Proposal</th>
+                    <th scope="col">Organisation</th>
+                    <th scope="col">Academic year</th>
+                    <th scope="col">Draft ID</th>
+                    <th scope="col">Status</th>
+                    <th scope="col" class="actions-col">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for draft in drafts %}
+                <tr>
+                    <td>
+                        <div class="draft-title">
+                            <span class="title">{{ draft.event_title|default:"Untitled Event" }}</span>
+                            <span class="meta">Updated {{ draft.updated_at|date:"M d, Y" }} at {{ draft.updated_at|date:"h:i A" }}</span>
+                        </div>
+                    </td>
+                    <td class="truncate">{{ draft.organization.name|default:"Not selected" }}</td>
+                    <td>{{ draft.academic_year|default:"Not set" }}</td>
+                    <td>#{{ draft.id }}</td>
+                    <td>
+                        <span class="status-badge">{{ draft.get_status_display }}</span>
+                    </td>
+                    <td class="actions">
+                        <a href="{% url 'emt:submit_proposal_with_pk' draft.id %}" class="table-link">
+                            <i class="fas fa-pen"></i>
+                            <span>Continue editing</span>
+                        </a>
+                        <form method="post" action="{% url 'emt:delete_proposal_draft' draft.id %}" class="inline-form">
+                            {% csrf_token %}
+                            <button type="submit" class="table-link table-link-danger" onclick="return confirm('Remove this draft from your list? Admins will still be able to view it.');">
+                                <i class="fas fa-trash"></i>
+                                <span>Remove</span>
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
     {% else %}
-    <div class="draft-empty">
-        <div class="empty-icon">
+    <div class="draft-empty" role="status">
+        <div class="empty-icon" aria-hidden="true">
             <i class="fas fa-inbox"></i>
         </div>
         <h2>No drafts yet</h2>
         <p>Your saved event proposal drafts will appear here for quick access.</p>
         <a href="{% url 'emt:start_proposal' %}" class="btn btn-primary">
-            <i class="fas fa-plus"></i> Start your first proposal
+            <i class="fas fa-plus"></i>
+            <span>Start your first proposal</span>
         </a>
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- replace the card-driven proposal draft page with a streamlined header and status overview
- present drafts in a utility-style table with accessible action links and updated empty state styling

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: remote PostgreSQL instance unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f40610b0832ca6e6484f9df4b8d0