### PR TITLE
Update draft removal confirmation message

### DIFF
--- a/emt/templates/emt/proposal_drafts.html
+++ b/emt/templates/emt/proposal_drafts.html
@@ -80,7 +80,7 @@
                     </a>
                     <form method="post" action="{% url 'emt:delete_proposal_draft' draft.id %}" class="draft-delete-form">
                         {% csrf_token %}
-                        <button type="submit" class="btn btn-danger" onclick="return confirm('Remove this draft from your list? Admins will still be able to view it.');">
+                        <button type="submit" class="btn btn-danger" onclick="return confirm('Remove this draft from your list?');">
                             <i class="fas fa-trash"></i>
                             <span>Remove</span>
                         </button>


### PR DESCRIPTION
## Summary
- remove the reference to administrators viewing drafts from the deletion confirmation dialog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f6f88c64832cafe55fcfc877f1e8