### PR TITLE
Prune proposal drafts beyond latest five

### DIFF
--- a/emt/views.py
+++ b/emt/views.py
@@ -831,6 +831,20 @@ def start_proposal(request):
 
 @login_required
 def proposal_drafts(request):
+    base_qs = EventProposal.objects.filter(
+        submitted_by=request.user,
+        status=EventProposal.Status.DRAFT,
+        is_user_deleted=False,
+    ).order_by("-updated_at")
+
+    active_ids = list(base_qs.values_list("id", flat=True))
+
+    if len(active_ids) > MAX_ACTIVE_DRAFTS:
+        EventProposal.objects.filter(id__in=active_ids[MAX_ACTIVE_DRAFTS:]).update(
+            is_user_deleted=True,
+            updated_at=timezone.now(),
+        )
+
     drafts_qs = EventProposal.objects.filter(
         submitted_by=request.user,
         status=EventProposal.Status.DRAFT,


### PR DESCRIPTION
## Summary
- automatically hide older event proposal drafts beyond the most recent five for each user
- add a regression test to ensure only the latest five drafts remain visible and older ones are archived

## Testing
- python manage.py test emt.tests.test_proposal_drafts *(fails: ModuleNotFoundError: No module named 'debug_toolbar')*


------
https://chatgpt.com/codex/tasks/task_e_68e636bc943c832c9952caa822bdd130