### PR TITLE
Handle missing Django debug toolbar gracefully

### DIFF
--- a/iqac_project/settings.py
+++ b/iqac_project/settings.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 from pathlib import Path
 
@@ -101,9 +102,6 @@ INSTALLED_APPS = [
     "django.contrib.sites",  # ← required by allauth
     "django_extensions",
 
-    # Third-party apps
-    "debug_toolbar",  # TOOLBAR: Added for Django Debug Toolbar
-
     # Allauth for Google login
     "allauth",
     "allauth.account",
@@ -116,13 +114,22 @@ INSTALLED_APPS = [
     "transcript",
 ]
 
+# Allow toggling the debug toolbar without editing settings
+ENABLE_DEBUG_TOOLBAR = (
+    _env("ENABLE_DEBUG_TOOLBAR", default="true").lower() == "true"
+)
+DEBUG_TOOLBAR_AVAILABLE = importlib.util.find_spec("debug_toolbar") is not None
+USE_DEBUG_TOOLBAR = DEBUG and ENABLE_DEBUG_TOOLBAR and DEBUG_TOOLBAR_AVAILABLE
+
+if USE_DEBUG_TOOLBAR:
+    INSTALLED_APPS.append("debug_toolbar")
+
 ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 # ──────────────────────────────────────────────────────────────────────────────
 # MIDDLEWARE
 # ──────────────────────────────────────────────────────────────────────────────
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",  # TOOLBAR: Added for Django Debug Toolbar
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -135,6 +142,10 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+if USE_DEBUG_TOOLBAR:
+    # Ensure the toolbar middleware runs early, right after security
+    MIDDLEWARE.insert(1, "debug_toolbar.middleware.DebugToolbarMiddleware")
 
 # Allow embedding pages within iframes on the same origin (needed for Review Center)
 # Default is 'DENY' which blocks our internal preview iframe.

--- a/iqac_project/urls.py
+++ b/iqac_project/urls.py
@@ -17,11 +17,13 @@ urlpatterns = [
 
 # This block enables the Debug Toolbar and media file serving in development.
 if settings.DEBUG:
-    # TOOLBAR: Add Django Debug Toolbar URLs
-    import debug_toolbar
-    urlpatterns = [
-        path('__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
+    if getattr(settings, "USE_DEBUG_TOOLBAR", False):
+        from importlib import import_module
+
+        debug_toolbar = import_module("debug_toolbar")
+        urlpatterns = [
+            path("__debug__/", include(debug_toolbar.urls)),
+        ] + urlpatterns
 
     # This line enables media file serving (for student photos) in development.
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- guard the debug toolbar app and middleware behind an availability check so missing packages do not break startup
- update URL configuration to import the debug toolbar only when enabled and installed

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e63b1d9c18832c973ae51fa4cb2b04