### PR TITLE
Fix sidebar permission migration index drop

### DIFF
--- a/core/migrations/0047_alter_activitylog_action_alter_activitylog_timestamp_and_more.py
+++ b/core/migrations/0047_alter_activitylog_action_alter_activitylog_timestamp_and_more.py
@@ -287,6 +287,10 @@ class Migration(migrations.Migration):
             sql="DROP INDEX IF EXISTS core_sidebarpermission_role_f55e9f7e;",
             reverse_sql=migrations.RunSQL.noop,
         ),
+        migrations.RunSQL(
+            sql="DROP INDEX IF EXISTS core_sidebarpermission_role_f55e9f7e_like;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.AlterField(
             model_name="sidebarpermission",
             name="role",


### PR DESCRIPTION
## Summary
- drop the LIKE operator index for sidebar permission roles before altering the field to prevent duplicate index creation during migrations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67c584250832c8d37de1e1b283613