### PR TITLE
Fix autosave clearing for proposal drafts

### DIFF
--- a/emt/static/emt/js/autosave_draft.js
+++ b/emt/static/emt/js/autosave_draft.js
@@ -141,17 +141,27 @@ window.AutosaveManager = (function() {
                     const values = inputs.filter(i => i.checked).map(i => i.value);
                     if (values.length) {
                         data[name] = values;
+                    } else if (saved[name] !== undefined) {
+                        data[name] = [];
                     }
                 } else if (field.checked) {
                     data[name] = true;
+                } else if (saved[name] !== undefined) {
+                    data[name] = false;
                 }
             } else if (field.type === 'radio') {
                 const checked = inputs.find(i => i.checked);
-                if (checked) data[name] = checked.value;
+                if (checked) {
+                    data[name] = checked.value;
+                } else if (saved[name] !== undefined) {
+                    data[name] = '';
+                }
             } else if (field.multiple) {
                 const selected = Array.from(field.selectedOptions).map(o => o.value).filter(v => v !== '');
                 if (selected.length) {
                     data[name] = selected;
+                } else if (saved[name] !== undefined) {
+                    data[name] = [];
                 }
             } else {
                 // When multiple inputs share the same name (e.g. hidden Django field
@@ -163,6 +173,8 @@ window.AutosaveManager = (function() {
                 const value = preferred.value;
                 if (String(value).trim() !== '') {
                     data[name] = value;
+                } else if (saved[name] !== undefined) {
+                    data[name] = '';
                 }
             }
         });

--- a/tests/autosave-clears-empty-fields.spec.ts
+++ b/tests/autosave-clears-empty-fields.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+test('autosave sends explicit blanks when fields are cleared', async ({ page }) => {
+  const autosavePath = path.join(__dirname, '..', 'emt', 'static', 'emt', 'js', 'autosave_draft.js');
+
+  await page.setContent('<form><input name="title" value="Original" /></form>');
+  await page.addScriptTag({ path: autosavePath });
+
+  await page.evaluate(() => {
+    (window as any).AUTOSAVE_URL = '/suite/autosave-proposal/';
+    (window as any).AUTOSAVE_CSRF = 'TOKEN';
+    (window as any).__payloads = [];
+    let counter = 0;
+    window.fetch = ((_fetch) => (input: any, init?: any) => {
+      const body = init?.body;
+      if (typeof body === 'string') {
+        try {
+          (window as any).__payloads.push(JSON.parse(body));
+        } catch {
+          // ignore JSON parse failures in tests
+        }
+      }
+      counter += 1;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ proposal_id: 100 + counter, success: true }),
+      });
+    })(window.fetch);
+  });
+
+  await page.evaluate(async () => {
+    await (window as any).AutosaveManager.manualSave();
+  });
+
+  await page.fill('input[name="title"]', '');
+
+  await page.evaluate(async () => {
+    await (window as any).AutosaveManager.manualSave();
+  });
+
+  const payloads = await page.evaluate(() => (window as any).__payloads);
+  expect(payloads.length).toBeGreaterThanOrEqual(2);
+  const lastPayload = payloads[payloads.length - 1];
+  expect(lastPayload).toHaveProperty('title', '');
+});


### PR DESCRIPTION
## Summary
- ensure the proposal autosave client sends explicit blank values when a field is cleared so the server no longer restores stale data
- add a Playwright regression test covering the cleared-field autosave payload

## Testing
- pytest emt/tests/test_autosave_draft_persistence.py *(fails: settings not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909e5758df4832c8b29eb95f0fcc955